### PR TITLE
Pull basic auth credentials from env secrets

### DIFF
--- a/headers-dev
+++ b/headers-dev
@@ -1,2 +1,2 @@
 /*
-  Basic-Auth: tell:aStory!
+  Basic-Auth: ${BASIC_AUTH_USER}:${BASIC_AUTH_PASSWORD}

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,21 +5,21 @@
       curl -fsSL https://deno.land/x/install/install.sh | sh && \
       /opt/buildhome/.deno/bin/deno task build && \
       tree . > _site/esolia_blog_tree.txt && \
-      cp headers-dev _site/_headers
+      envsubst < headers-dev > _site/_headers
     """
   [context.deploy-preview]
     command = """
       curl -fsSL https://deno.land/x/install/install.sh | sh && \
       /opt/buildhome/.deno/bin/deno task build && \
       tree . > _site/esolia_blog_tree.txt && \
-      cp headers-dev _site/_headers 
+      envsubst < headers-dev > _site/_headers 
     """
   [context.branch-deploy]
     command = """
       curl -fsSL https://deno.land/x/install/install.sh | sh && \
       /opt/buildhome/.deno/bin/deno task build && \
       tree . > _site/esolia_blog_tree.txt
-      cp headers-dev _site/_headers
+      envsubst < headers-dev > _site/_headers
     """ 
 
 [[headers]]
@@ -28,7 +28,7 @@
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
-    X-Powered-By = "Lume mixed with Blood Sweat and Tears"
+    X-Powered-By = "Lume and Deno mixed with Blood Sweat and Tears"
     X-Custom-Header = "Rawr eSolia Tokyo"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,6 +4,7 @@
 @plugin "@tailwindcss/container-queries";
 /* @plugin "daisyui@5.0.1"; */
 /* @plugin "flyonui@latest"; */
+/* @plugin "tailwind-layouts"; */
 @import "css/alerts.css";
 @layer base {
   a {


### PR DESCRIPTION
Copying basic auth credentials from plaintext file is not a good approach, so change to use env variables, and use "envsubst" to swap them into var placeholders before copying to _headers.

Fixes #33