### PR TITLE
Add cache busting var and use on css in head

### DIFF
--- a/src/_data.ts
+++ b/src/_data.ts
@@ -1,4 +1,4 @@
-export const todaysDateYYYYMMDD = `${new Date().toISOString().split("T")[0]}`;
+export const todaysDateYYYYMMDD = `${new Date().toISOString().split("T")[0]}`; 
 
 export const currentDateTime = Temporal.Now.zonedDateTimeISO();
 console.log(`Current temporal timezoned datetime: ${currentDateTime.toString()}`);
@@ -90,3 +90,6 @@ const recdZonedDateTime = sampleInstant.toZonedDateTimeISO(sampleTimezone);
     }
   ];
   console.log(new Intl.DateTimeFormat(...formatArgs).format(recdZonedDateTime.toInstant().epochMilliseconds))
+
+  export const cacheBuster = `${Temporal.Now.instant().epochMilliseconds}`;
+  console.log(`Cache buster: ${cacheBuster}`);

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -11,13 +11,13 @@
     <meta name="theme-color" content="hsl(220, 20%, 100%)" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="hsl(220, 20%, 10%)" media="(prefers-color-scheme: dark)">
     
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/styles.css?cb={{ cacheBuster }}"/ type="text/css">
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <link rel="alternate" href="/feed.xml" type="application/atom+xml" title="{{ metas.site }}">
     <link rel="alternate" href="/feed.json" type="application/json" title="{{ metas.site }}">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
     <link rel="canonical" href="{{ url |> url(true) }}">
-    <script src="/js/main.js" type="module"></script>
+    <script src="/js/main.js?cb={{ cacheBuster }}" type="module"></script>
     <!-- Fathom - beautiful, simple website analytics -->
     <script src="https://cdn.usefathom.com/script.js" data-site="OIXGEUHR" defer></script>
     <!-- / Fathom -->


### PR DESCRIPTION
In order to ensure css gets updated by visitors browsers, add an url param based on unix epoch time. Use Temporal.Now.instant() to get the current instant in time, and epochMilliseconds to get the number of milliseconds since the Unix epoch, similar to new Date().getTime(). Reference the const in vento template by simply referring to {{ cacheBuster }}. 

Fixes #36
