### PR TITLE
Create post-share template and link to post

### DIFF
--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -7,6 +7,7 @@ archive:
   title: Archive
   description: Find below an archive list of posts written on various IT topics, by eSolia professionals
 social:
+  share_title: Share this post on social media
   linkedin-label: Follow on LinkedIn
   linkedin-profile-url: https://www.linkedin.com/company/esolia
   twitter-label: Follow on X Twitter

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -7,11 +7,15 @@ archive:
   title: アーカイブ
   description: 当ページにて、私達イソリアのプロが書いた、様々なITトピックスについてのポストを閲覧できます
 social:
+  share_title: 当ポストをソーシャルでシェアする
   linkedin_label: LinkedInでフォローする
+  linkedin_share: LinkedInでシェアする
   linkedin_profile_url: https://www.linkedin.com/company/esolia
   twitter_label: X Twitterでフォローする
+  twitter_share: X Twitterでシェアする
   twitter_profile_url: https://x.com/esolia_inc
   bluesky_label: Blueskyでフォローする
+  bluesky_share: Blueskyでシェアする
   bluesky_profile_url: https://bsky.app/profile/esolia.com
   github_label: GitHubプロフィール
   github_profile_url: https://github.com/esolia

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -66,6 +66,8 @@ bodyClass: body-post
                     </aside>
                   {{ /if }}
 
+                  {{ include "templates/post-share.vto" }}
+
                   {{# <nav class="page-pagination pagination">
                     <ul>
                       {{- set previousPost = search.previousPage(url, "type=post") }}

--- a/src/_includes/templates/post-share.vto
+++ b/src/_includes/templates/post-share.vto
@@ -1,0 +1,30 @@
+<!-- ===== post-share.vto TEMPLATE START ===== -->
+<div class="mx-auto max-w-sm overflow-hidden rounded-md px-4 py-4 sm:py-2 lg:px-6 bg-zinc-50 dark:bg-zinc-800">
+  <div class="flex flex-wrap justify-center text-md p-1">
+    <p class="text-gray-600">{{ i18n.social.share_title }}</p>
+  </div>
+  <div class="mt-1 flex justify-center gap-x-4 pb-3">
+    <a
+      class="group -m-1 p-1"
+      aria-label="{{ i18n.social.linkedin_share }}"
+      href="https://www.linkedin.com/sharing/share-offsite/?url={{ url }}"
+      target="_blank"
+      ><img class="size-6 fill-sky-800 dark:fill-sky-600" aria-hidden="true" src="{{ "linkedin-logo" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.linkedin_share }}</span>
+    </a>
+    <a
+      class="group -m-1 p-1"
+      aria-label="{{ i18n.social.bluesky_share }}"
+      href="https://bsky.app/intent/compose?text=Check%20out%20this%20post!&url={{ url }}"
+      target="_blank"
+      ><img class="size-6 fill-sky-400 dark:fill-sky-300" aria-hidden="true" src="{{ "butterfly" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.bluesky_share }}</span>
+    </a> 
+    <a
+      class="group -m-1 p-1"
+      aria-label="{{ i18n.social.twitter_share }}"
+      href="https://x.com/intent/post?text=Check%20out%20this%20post!&url={{ url }}"
+      target="_blank"
+      ><img class="size-6 fill-black-600 dark:fill-stone-50" aria-hidden="true" src="{{ "x-logo" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.twitter_share }}</span>
+    </a>
+  </div>
+</div>
+<!-- ===== post-share.vto TEMPLATE END ===== -->


### PR DESCRIPTION
Post-share template is called at the bottom of post, and shows icons for sharing via linkedin, bluesky and x.

These services will pick up the og-tags when you try to share an url via this method. However, currently the site is behind a password, so this needs to be retested when we remove that password.

Fixes #6
