### PR TITLE
Add i18n placeholder for share msgs and escape

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3e3e37c0bb341f2268d262e4199d80dd70da9302/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@bb87e2379e5500547d06d1b8987286c1c3aae2ee/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.10.2/"
   },
   "tasks": {

--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -7,18 +7,20 @@ archive:
   title: Archive
   description: Find below an archive list of posts written on various IT topics, by eSolia professionals
 social:
+  share_placeholder: Check out this new post from eSolia's Pro Blog
   share_title: Share this post on social media
-  linkedin-label: Follow on LinkedIn
-  linkedin-profile-url: https://www.linkedin.com/company/esolia
-  twitter-label: Follow on X Twitter
-  twitter-profile-url: https://x.com/esolia_inc
-  bluesky-label: Follow on Bluesky
-  bluesky-profile-url: https://bsky.app/profile/esolia.com
-  github-label: GitHub profile
-  github-profile-url: https://github.com/esolia
+  linkedin_label: Follow on LinkedIn
+  linkedin_share: Share on LinkedIn
+  linkedin_profile_url: https://www.linkedin.com/company/esolia
+  twitter_label: Follow on X Twitter
+  twitter_profile_url: https://x.com/esolia_inc
+  bluesky_label: Follow on Bluesky
+  bluesky_profile_url: https://bsky.app/profile/esolia.com
+  github_label: GitHub profile
+  github_profile_url: https://github.com/esolia
 logo:
-  symbol-alt: eSolia logo
-  full-alt: eSolia Pro Blog
+  symbol_alt: eSolia logo
+  full_alt: eSolia Pro Blog
 newsletter:
   title: Stay Informed
   description: Get notified when we publish something new, by entering your email address below.

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -8,6 +8,7 @@ archive:
   description: 当ページにて、私達イソリアのプロが書いた、様々なITトピックスについてのポストを閲覧できます
 social:
   share_title: 当ポストをソーシャルでシェアする
+  share_placeholder: イソリア プロ ブログの新しいポストを是非チェック
   linkedin_label: LinkedInでフォローする
   linkedin_share: LinkedInでシェアする
   linkedin_profile_url: https://www.linkedin.com/company/esolia

--- a/src/_includes/templates/post-share.vto
+++ b/src/_includes/templates/post-share.vto
@@ -1,7 +1,7 @@
 <!-- ===== post-share.vto TEMPLATE START ===== -->
-<div class="mx-auto max-w-sm overflow-hidden rounded-md px-4 py-4 sm:py-2 lg:px-6 bg-zinc-50 dark:bg-zinc-800">
+<div class="mx-auto max-w-sm overflow-hidden rounded-full shadow-md px-4 py-4 sm:py-2 lg:px-6 bg-zinc-50 dark:bg-zinc-800">
   <div class="flex flex-wrap justify-center text-md p-1">
-    <p class="text-gray-600">{{ i18n.social.share_title }}</p>
+    <p class="text-gray-600 underline underline-offset-4 decoration-fuchsia-500/60 decoration-wavy">{{ i18n.social.share_title }}</p>
   </div>
   <div class="mt-1 flex justify-center gap-x-4 pb-3">
     <a
@@ -14,14 +14,14 @@
     <a
       class="group -m-1 p-1"
       aria-label="{{ i18n.social.bluesky_share }}"
-      href="https://bsky.app/intent/compose?text=Check%20out%20this%20post!&url={{ url }}"
+      href="https://bsky.app/intent/compose?text={{ i18n.social.share_placeholder |> encodeURI() }}&url={{ url }}"
       target="_blank"
       ><img class="size-6 fill-sky-400 dark:fill-sky-300" aria-hidden="true" src="{{ "butterfly" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.bluesky_share }}</span>
     </a> 
     <a
       class="group -m-1 p-1"
       aria-label="{{ i18n.social.twitter_share }}"
-      href="https://x.com/intent/post?text=Check%20out%20this%20post!&url={{ url }}"
+      href="https://x.com/intent/post?text={{ i18n.social.share_placeholder |> encodeURI() }}&url={{ url }}"
       target="_blank"
       ><img class="size-6 fill-black-600 dark:fill-stone-50" aria-hidden="true" src="{{ "x-logo" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.twitter_share }}</span>
     </a>


### PR DESCRIPTION
Placeholder text should be an i18n string so it's correct for either lang. Add to i18n data files, call into vento template where icons are clicked, and escape using js encodeURI().

Format share icon area so the CTA is prominent and the bg matches the general design.

Update lume v3 to latest dev.

Fixes #45
