### PR TITLE
Consolidate various inlined and vendor js to main

### DIFF
--- a/_cms.ts
+++ b/_cms.ts
@@ -197,6 +197,7 @@ cms.collection({
       type: "url",
       label: "URL",
       description: "The public URL of the page. Leave empty to use the file path",
+      view: "Show Overrides",
     },
     {
       name: "date",

--- a/_config.ts
+++ b/_config.ts
@@ -10,6 +10,7 @@ import tailwindcss from "lume/plugins/tailwindcss.ts";
 // import lightningCss from "lume/plugins/lightningcss.ts";
 import googleFonts from "lume/plugins/google_fonts.ts";
 import attributes from "lume/plugins/attributes.ts";
+import esbuild from "lume/plugins/esbuild.ts";
 import terser from "lume/plugins/terser.ts";
 import prism from "lume/plugins/prism.ts";
 import basePath from "lume/plugins/base_path.ts";
@@ -63,6 +64,7 @@ site.use(picture(/* Options */));
 site.use(transformImages());
 site.use(tailwindcss());
 // site.use(lightningCss());
+site.use(esbuild());
 site.use(terser());
 site.use(prism());
 site.use(basePath());
@@ -126,6 +128,11 @@ site.add("js")
 site.add("favicon.png")
 site.add("uploads")
 site.add("assets")
+// Mastodon comment system
+site.remoteFile(
+  "/js/comments.js",
+  "https://cdn.jsdelivr.net/npm/@oom/mastodon-comments@0.3.2/src/comments.js",
+);
 site.mergeKey("extra_head", "stringArray")
 
 site.ignore("*.DS_Store");
@@ -228,13 +235,5 @@ site.hooks.addMarkdownItPlugin(alert);
 //     return "Invalid date";
 //   }
 // });
-
-
-
-// Mastodon comment system
-// site.add(
-//   "/js/comments.js",
-//   "https://cdn.jsdelivr.net/npm/@oom/mastodon-comments@0.3.2/src/comments.js",
-// );
 
 export default site;

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@bb87e2379e5500547d06d1b8987286c1c3aae2ee/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@47f3f4a4931f33c57e5b234b6cdd4f4a8697a079/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.10.4/"
   },
   "tasks": {

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -12,59 +12,16 @@
     <meta name="theme-color" content="hsl(220, 20%, 10%)" media="(prefers-color-scheme: dark)">
     
     <link rel="stylesheet" href="/styles.css?cb={{ cacheBuster }}"/ type="text/css">
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <link rel="alternate" href="/feed.xml" type="application/atom+xml" title="{{ metas.site }}">
     <link rel="alternate" href="/feed.json" type="application/json" title="{{ metas.site }}">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
     <link rel="canonical" href="{{ url |> url(true) }}">
-    <script src="/js/main.js?cb={{ cacheBuster }}" type="module"></script>
-    <!-- Fathom - beautiful, simple website analytics -->
-    <script src="https://cdn.usefathom.com/script.js" data-site="OIXGEUHR" defer></script>
-    <!-- / Fathom -->
+    {{# Various js, such as Alpine and Fathom and the theme toggle script #}}
+    <script src="/js/main.js?cb={{ cacheBuster }}" type="module" defer></script>
     {{ it.extra_head?.join("\n") }}
     
-    <!-- Theme toggle script -->
-    <script>
-        document.addEventListener('alpine:init', () => {
-            Alpine.data('themeToggle', () => ({
-                darkMode: localStorage.getItem('darkMode') === 'true' || false,
-                init() {
-                    this.$watch('darkMode', value => {
-                        localStorage.setItem('darkMode', value);
-                        document.body.classList.toggle('dark', value);
-                    });
-                    // Ensure the correct class is applied on page load
-                    document.body.classList.toggle('dark', this.darkMode);
-                }
-            }));
-        });
-    </script>
   </head>
   <body class="flex h-full bg-zinc-50 dark:bg-black">
-  {{# <script>
-    !(function () {
-      try {
-        var d = document.documentElement,
-          c = d.classList
-        c.remove('light', 'dark')
-        var e = localStorage.getItem('theme')
-        if ('system' === e || (!e && true)) {
-          var t = '(prefers-color-scheme: dark)',
-            m = window.matchMedia(t)
-          if (m.media !== t || m.matches) {
-            d.style.colorScheme = 'dark'
-            c.add('dark')
-          } else {
-            d.style.colorScheme = 'light'
-            c.add('light')
-          }
-        } else if (e) {
-          c.add(e || '')
-        }
-        if (e === 'light' || e === 'dark') d.style.colorScheme = e
-      } catch (e) {}
-    })()
-  </script> #}}
     <!-- Container start -->
     <div class="flex w-full">
       <div class="fixed inset-0 flex justify-center sm:px-8">
@@ -88,23 +45,7 @@
       </div>
     </div>
     <!-- Container end -->
-    <script>
-      window.addEventListener('scroll', () => {
-          const largeLogo = document.getElementById('large-logo');
-          const smallLogo = document.getElementById('small-logo');
-          const scrollPosition = window.scrollY;
-
-          if (scrollPosition > 10) {
-              largeLogo.classList.add('opacity-0');
-              smallLogo.classList.remove('opacity-0');
-          } else {
-              largeLogo.classList.remove('opacity-0');
-              smallLogo.classList.add('opacity-0');
-          }
-      });
-    </script>
     <script src="{{ script }}"></script>
-
   </body>
   <!-- ===== base.vto LAYOUT END ===== -->
 </html>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,3 +1,58 @@
-import Comments from "./comments.js";
+// Function to load a script from a CDN with additional attributes
+function loadVendorScript(src, attributes, callback) {
+  var script = document.createElement('script');
+  script.src = src;
+  // script.async = true;
+  // Set additional attributes
+  for (var key in attributes) {
+      if (attributes.hasOwnProperty(key)) {
+          script.setAttribute(key, attributes[key]);
+      }
+  }
+  script.onload = callback;
+  document.head.appendChild(script);
+}
+  
+// Swap logo on scroll
+window.addEventListener('scroll', () => {
+  const largeLogo = document.getElementById('large-logo');
+  const smallLogo = document.getElementById('small-logo');
+  const scrollPosition = window.scrollY;
 
+  if (scrollPosition > 10) {
+      largeLogo.classList.add('opacity-0');
+      smallLogo.classList.remove('opacity-0');
+  } else {
+      largeLogo.classList.remove('opacity-0');
+      smallLogo.classList.add('opacity-0');
+  }
+});
+
+// Theme Toggle with Alpine.js
+document.addEventListener('alpine:init', () => {
+  Alpine.data('themeToggle', () => ({
+      darkMode: localStorage.getItem('darkMode') === 'true' || false,
+      init() {
+          this.$watch('darkMode', value => {
+              localStorage.setItem('darkMode', value);
+              document.body.classList.toggle('dark', value);
+          });
+          // Ensure the correct class is applied on page load
+          document.body.classList.toggle('dark', this.darkMode);
+      }
+  }));
+});
+  
+// Load Mastodon Comments from a local file
+import Comments from "./comments.js";
 customElements.define("mastodon-comments", Comments);
+
+// Load Alpine.js with defer
+loadVendorScript('https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js', { 'defer': '' }, function() {
+  console.log('Alpine.js loaded with defer');
+});
+
+// Load Fathom Analytics script with data-site attribute and defer
+loadVendorScript('https://cdn.usefathom.com/script.js', { 'data-site': 'OIXGEUHR', 'defer': '' }, function() {
+  console.log('Fathom Analytics loaded with defer and data-site attribute');
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,7 +3,7 @@
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/container-queries";
 /* @plugin "daisyui@5.0.1"; */
-/* @plugin "flyonui@latest"; */
+/* @plugin "flyonui@2.0.0"; */
 /* @plugin "tailwind-layouts"; */
 @import "css/alerts.css";
 @layer base {


### PR DESCRIPTION
Consolidate various inlined js scripts, and alpine and fathom deferred vendor scripts, into main.js, for better clarity. Loading vendor scripts with a function. Added esbuild for bundling.

Fix mastodon comments loading bug. 

Tested with no errors in console, and functionally it appears logo swap on scroll, dark/light mode switch work as expected.

Upgrade lume to latest v3 and deno to 2.5.5.

Add CMS view to hide URL field since it would not normally be used.

Fixes #50
Fixes #56
Fixes #57
