### PR TITLE
Use add to load remote file

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -129,9 +129,9 @@ site.add("favicon.png")
 site.add("uploads")
 site.add("assets")
 // Mastodon comment system
-site.remoteFile(
-  "/js/comments.js",
+site.add(
   "https://cdn.jsdelivr.net/npm/@oom/mastodon-comments@0.3.2/src/comments.js",
+  "/js/comments.js",
 );
 site.mergeKey("extra_head", "stringArray")
 


### PR DESCRIPTION
When you use add to load a remote file, you put the remote file first, then the local file name.

Fixes #61
