### PR TITLE
Deploy a11y for base navs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@47f3f4a4931f33c57e5b234b6cdd4f4a8697a079/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@133bf8a8eeaa1c0ad6f3ab82b0b970666732c0c3/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.10.4/"
   },
   "tasks": {

--- a/src/_data.yml
+++ b/src/_data.yml
@@ -7,32 +7,46 @@ topnav:
       href: /archive
       target: _self
       icon: archive
+      aria_label: サイト内リンク
+      title: アーカイブページへのリンク
     - text: イソリア
       href: https://esolia.co.jp
       target: _blank
       icon: building-office
+      aria_label: 外部リンク
+      title: イソリア社ウェブサイトへのリンク
 footernav:
   links: 
     - text: アーカイブ
       href: /archive
       target: _self
       icon: archive
+      aria_label: サイト内リンク
+      title: アーカイブページへのリンク
     - text: サイトマップ
       href: /sitemap.xml
       target: _self
       icon: sitemap
+      aria_label: サイト内リンク
+      title: サイトマップへのリンク
     - text: プライバシーポリシー
       href: #
       target: _self
       icon: privacy
+      aria_label: サイト内リンク
+      title: プライバシーポリシーへのリンク
     - text: 当サイトのGitHubリポジトリ
       href: https://github.com/eSolia/blog.esolia.pro
       target: _blank
       icon: github-logo
+      aria_label: 外部リンク
+      title: 当サイトのGitHubリポジトリへのリンク
     - text: イソリア
       href: https://esolia.co.jp
       target: _blank
       icon: building-office
+      aria_label: 外部リンク
+      title: イソリア社ウェブサイトへのリンク
 # Metas plugin https://lume.land/plugins/metas/#description
 metas:
   type: website
@@ -61,32 +75,46 @@ en:
         href: /en/archive
         target: _self
         icon: archive
+        aria_label: Site internal link
+        title: Link to the Archive page
       - text: eSolia Inc.
         href: https://esolia.com
         target: _blank
         icon: building-office
+        aria_label: External link
+        title: Link to eSolia Inc. website
   footernav:
     links: 
       - text: Archive
         href: /archive
         target: _self
         icon: archive
+        aria_label: Site internal link
+        title: Link to the Archive page
       - text: Sitemap
         href: /sitemap.xml
         target: _self
         icon: sitemap
+        aria_label: Site internal link
+        title: Link to the Sitemap
       - text: Privacy Policy
         href: #
         target: _self
         icon: privacy
+        aria_label: Site internal link
+        title: Link to the Privacy Policy
       - text: Github Repository for this Site
         href: https://github.com/eSolia/blog.esolia.pro
         target: _blank
         icon: github-logo
+        aria_label: External link
+        title: Link to the GitHub Repository for this site
       - text: eSolia
         href: https://esolia.com
         target: _blank
         icon: building-office
+        aria_label: External link
+        title: Link to eSolia Inc. website
   metas:
     type: website
     site: "eSolia Pro Blog"

--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -44,6 +44,9 @@ nav:
   all_authors: All Authors
   all_posts: All Posts
   return_home: Return to Site Top
+  logo_large_alt: eSolia full size logo linking to site top
+  logo_symbol_alt: eSolia symbol-type logo linking to site top
+  mobile_nav_name: Menu
 post:
   by: by
   reading_time: Reading Time

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -46,6 +46,9 @@ nav:
   all_authors: すべての著者
   all_posts: すべてのポスト
   return_home: サイトトップへ戻る
+  logo_large_alt: サイトのトップへリンクするイソリア社フルサイズのロゴマーク
+  logo_symbol_alt: サイトのトップへリンクするイソリア社シンボルタイプのロゴマーク
+  mobile_nav_name: メニュー
 post:
   by: 著者
   reading_time: 読書時間

--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -14,8 +14,11 @@
               >
                 {{- for item of it.footernav.links }}
                 <a 
-                    class="whitespace-nowrap transition hover:text-teal-500 dark:hover:text-teal-400" href="{{ item.href }}"
-                    {{- if item.target }}target="{{ item.target }}"{{ /if }} >{{ item.text }}</a
+                    class="whitespace-nowrap transition hover:text-teal-500 dark:hover:text-teal-400" 
+                    href="{{ item.href }}"
+                    aria_label="{{ item.aria_label }}"
+                    title="{{ item.title }}"
+                    {{- if item.target }}target="{{ item.target }}"{{ /if }} >{{ item.text }} <span class="sr-only">({{ item.aria_label }})</span></a
                   >
                 {{ /for -}}
               </div>

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -19,7 +19,7 @@
                 href="/"
                 ><img
                   id="large-logo"
-                  alt="eSolia full size logo with dark blue text and transparent background"
+                  alt="{{ i18n.nav.logo_large_alt}}"
                   loading="lazy"
                   fetchpriority="high"
                   decoding="async"
@@ -47,7 +47,7 @@
                 href="/"
                 ><img
                   id="small-logo" 
-                  alt="eSolia symbol logo with dark blue text and transparent background"
+                  alt="{{ i18n.nav.logo_symbol_alt }}"
                   loading="lazy"
                   fetchpriority="high"
                   decoding="async"
@@ -63,7 +63,7 @@
                     type="button"
                     x-data @click="$dispatch('toggle-menu')"
                   >
-                    <span>Menu</span><svg
+                    <span>{{ i18n.nav.mobile_nav_name }}</span><svg
                       viewBox="0 0 8 6"
                       aria-hidden="true"
                       class="ml-3 h-auto w-2 stroke-zinc-500 group-hover:stroke-zinc-700 dark:group-hover:stroke-zinc-400"
@@ -103,8 +103,12 @@
                     {{- for item of it.topnav.links }}
                     <li>
                       <a 
-                        class="relative block whitespace-nowrap px-3 py-2 transition hover:text-teal-500 dark:hover:text-teal-400" href="{{ item.href }}"
-                        {{- if item.target }}target="{{ item.target }}"{{ /if }} >{{ item.text }}</a
+                        class="relative block whitespace-nowrap px-3 py-2 transition hover:text-teal-500 dark:hover:text-teal-400" 
+                        href="{{ item.href }}"
+                        {{- if item.target }}target="{{ item.target }}"{{ /if }} 
+                        aria-label="{{ item.aria_label }}" 
+                        title="{{ item.title }}"
+                        >{{ item.text }} <span class="sr-only">({{ item.aria_label }})</span></a
                       >
                     </li>
                     {{ /for -}}
@@ -116,16 +120,18 @@
                       <img class="h-12 w-12 fill-esoliaamber-400 dark:fill-esoliaamber-300" src="{{ "x" |> icon("phosphor") }}" inline />
                   </button>
                   <div class="mobile-menu" x-bind:class="{'is-active' : open }" :style="{ zIndex: zIndex }">
-                      <div class="text-5xl mobile-menu__item"><a
+                  {{- for item of it.topnav.links }}  
+                    <div class="text-5xl mobile-menu__item">
+                      <a
                       class="link dim white f3 f1-l dib"
-                      href="/"
-                      title="{{ i18n.home.sitename }}"
-                    ><span class="font-thin">{{ "Top" |> toUpperCase }}</span></a></div>
-                      <div class="text-5xl mobile-menu__item"><a
-                      class="link dim white f3 f2-m f1-l dib"
-                      href="/about"
-                      title="test"
-                    ><span class="font-thin">{{ "About" |> toUpperCase }}</span></a></div>
+                      href="{{ item.href }}"
+                      aria-label="{{ item.aria_label }}"
+                      title="{{ item.title }}"
+                      ><span class="font-thin">{{ item.text |> toUpperCase }}</span> <span class="sr-only">({{ item.aria_label }})</span>
+                      </a>
+                    </div>
+                  {{ /for -}}
+
                   </div>
                   </nav>
 


### PR DESCRIPTION
The top and footer navs now have basic accessibility. Added title, aria-label, sr-only parenthetical label after actual link text.

Added various strings to make all of it bilingual.
