### PR TITLE
Implement component for inserting icon

### DIFF
--- a/_cms.ts
+++ b/_cms.ts
@@ -264,6 +264,13 @@ cms.collection({
       view: "Show Flags",
     },
     {
+      name: "url",
+      type: "url",
+      label: "URL",
+      description: "The public URL of the page. Leave empty to use the file path",
+      view: "Show Overrides",
+    },
+    {
       name: "lang",
       type: "select",
       label: "言語 Language",
@@ -294,20 +301,15 @@ cms.collection({
       },
     },
     {
-      name: "url",
-      type: "url",
-      label: "URL",
-      description: "The public URL of the page. Leave empty to use the file path",
-      view: "Show Overrides",
-    },
-    {
       name: "date",
       type: "datetime",
       label: "作成日 Created Date",
-      value: new Date().toISOString(),
       description: "作成された日付<br>The date the page was posted",
+      init(field) {
+        field.value = new Date();
+      },
       attributes: {
-        required: true,
+        required: false,
       },
     },
     {
@@ -421,6 +423,10 @@ REPLACE ME. Enter your content here, using **markdown** formatting of _any kind_
   <img class="shadow-lg rounded-lg" alt="EXPLAIN TO SCREENREADER USER" src="/uploads/blog-esolia-pro-default.png" width="1000px" transform-images="avif webp png jpeg 1000@2">
   <figcaption class="text-left mt-2"><small><em>Fig: ADD YOUR CAPTION HERE</em></small></figcaption>
 </figure>`,
+        },
+        {
+          label: "Icon",
+          value: `{{- comp.icon({ name: "fire", size: 4, color: "red" }) -}}`,
         },
         {
           label: "NOTE (Info highlight)",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@4c90aaf24802e663ee9ac9130158153cb9d15a31/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@473537f0087bb9d05ce918fd02b42f590a45b63a/"
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@df45f7086d6c982cb116be2ae76dfb45dc22ac8f/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@c3f79197ee5413fb4e7633571f70176177b9e4ad/"
   },
   "tasks": {
     "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",

--- a/src/_components/icon.vto
+++ b/src/_components/icon.vto
@@ -1,0 +1,5 @@
+{{# Use: 
+{{ comp.icon({ name: "lightbulb", size: 6, color: "esoliaamber" }) }}
+#}}
+
+<img class="size-{{ size }} fill-{{ color }}-400 inline-block align-[-0.1em] mr-1" src="{{ name |> icon("phosphor", "duotone") }}" inline>

--- a/src/posts/_data.yml
+++ b/src/posts/_data.yml
@@ -1,6 +1,9 @@
 lang: ja
 type: post
 layout: layouts/post.vto
+templateEngine:
+  - vto
+  - md
 metas:
   type: blogPosting
   title: "=title"
@@ -18,6 +21,9 @@ en:
   lang: en
   type: post
   layout: layouts/post.vto
+  templateEngine:
+  - vto
+  - md
   metas:
     type: blogPosting
     title: "=title"

--- a/src/posts/firstpost_en.md
+++ b/src/posts/firstpost_en.md
@@ -2,23 +2,15 @@
 lang: en
 id: 20180823a
 title: This is a post with mastodon comments
-date: 2018-08-23T00:00:00.000Z
 author: Óscar Otero
-tags:
-  - English
-  - Placeholder
-  - Example
-  - Lorem ipsum
-  - JavaScript
-  - TypeScript
 comments:
   src: 'https://mastodon.gal/@misteroom/110810445656343599'
 draft: false
 featured: true
-last_modified: 2025-02-26T00:28:00.000Z
 description: This is the description...
 image: /uploads/blog-esolia-pro-default.png
 category: AI-Usage
+hot: false
 ---
 TEST Leverage agile frameworks to provide a robust synopsis for high level overviews.
 Iterative approaches to corporate strategy foster collaborative thinking to
@@ -27,7 +19,11 @@ of disruptive innovation via workplace diversity and empowerment.
 
 <!--more-->
 
-![Image](/uploads/jrc-cleanshot-microsoft-word-2025-02-19-145534jst@2x.png)
+{{- comp.icon({ name: "windows-logo", size: 4, color: "sky" }) -}} This is for Windows
+{{- comp.icon({ name: "apple-logo", size: 4, color: "emerald" }) -}} This is for Mac
+{{- comp.icon({ name: "highlighter", size: 4, color: "yellow" }) -}} This is <mark>a highlight</mark>
+{{- comp.icon({ name: "fire", size: 4, color: "red" }) -}} This is fire!
+
 
 ```js
 // this is a command


### PR DESCRIPTION
Since we are editing markdown, it's a little difficult to simply insert an icon in the usual way. So, implement a component (async as of v3) that allows an easy way to insert an icon from the phosphor icon set with 9000+ icons. This is consistent with other parts of the UI, since we are already using phosphor for those (c.f. social links etc).

This approach requires enabling the vento generator besides the markdown one, and the easiest way to do this is to enable in _data.yml under posts folder. That way, it works for all posts.

Add sample entries in firstpost-en post to show how it works.

Updated CMS "snippets" insert feature, so that it is easy to enter the vento code for this. User selects the "icon" snippet, then updates the icon name, size and color.

All Phosphor icons are here:
https://phosphoricons.com/

Tailwind colors are here:
https://tailwindcss.com/docs/colors

When entering icon name and color, use lowercase letters. Like: fire, windows-logo, acorn, or, red, teal, amber, sky.

Upgrade lume to latest v3.

Fixes: #104
