### PR TITLE
Implement some aspects of Satoshi's top nav design idea

### DIFF
--- a/_cms.ts
+++ b/_cms.ts
@@ -306,10 +306,10 @@ cms.collection({
       label: "作成日 Created Date",
       description: "作成された日付<br>The date the page was posted",
       init(field) {
-        field.value = new Date();
+        field.value = new Date().toISOString();
       },
       attributes: {
-        required: false,
+        required: true,
       },
     },
     {

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@df45f7086d6c982cb116be2ae76dfb45dc22ac8f/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@c3f79197ee5413fb4e7633571f70176177b9e4ad/"
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@c078fae6aa3f272e028f2c4d6f11efc35f1920da/"
   },
   "tasks": {
     "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",

--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -37,25 +37,25 @@
               aria-label="{{ i18n.social.linkedin_label }}"
               href="{{ i18n.social.linkedin_profile_url }}"
               target="_blank"
-              ><img class="h-6 w-6 fill-sky-800 dark:fill-sky-600" src="{{ "linkedin-logo" |> icon("phosphor", "duotone") }}" inline></a>
+              ><img class="h-6 w-6 fill-sky-800 dark:fill-sky-600 transition hover:scale-110" src="{{ "linkedin-logo" |> icon("phosphor", "duotone") }}" inline></a>
             <a
               class="group -m-1 p-1"
               aria-label="{{ i18n.social.bluesky_label }}"
               href="{{ i18n.social.bluesky_profile_url }}"
               target="_blank"
-              ><img class="h-6 w-6 fill-sky-400 dark:fill-sky-300" src="{{ "butterfly" |> icon("phosphor", "duotone") }}" inline></a>
+              ><img class="h-6 w-6 fill-sky-400 dark:fill-sky-300 transition hover:scale-110" src="{{ "butterfly" |> icon("phosphor", "duotone") }}" inline></a>
             <a
               class="group -m-1 p-1"
               aria-label="{{ i18n.social.twitter_label }}"
               href="{{ i18n.social.twitter_profile_url }}"
               target="_blank"
-              ><img class="h-6 w-6 fill-black-600 dark:fill-zinc-50" src="{{ "x-logo" |> icon("phosphor", "duotone") }}" inline></a>
+              ><img class="h-6 w-6 fill-black-600 dark:fill-zinc-50 transition hover:scale-110" src="{{ "x-logo" |> icon("phosphor", "duotone") }}" inline></a>
             <a
               class="group -m-1 p-1"
               aria-label="{{ i18n.social.github_label }}"
               href="{{ i18n.social.github_profile_url }}"
               target="_blank"
-              ><img class="h-6 w-6 fill-green-600 dark:fill-green-500" src="{{ "github-logo" |> icon("phosphor", "duotone") }}" inline></a>
+              ><img class="h-6 w-6 fill-green-600 dark:fill-green-500 transition hover:scale-110" src="{{ "github-logo" |> icon("phosphor", "duotone") }}" inline></a>
           </div>
     <p class="mt-6 text-sm text-zinc-500 sm:mt-0">©{{ new Date().getFullYear() }} {{ i18n.home.company_long }} All rights reserved.<br><span class="text-xs text-zinc-400">{{ i18n.home.company_address }}</span></p>
     </div>

--- a/src/_includes/templates/post-share.vto
+++ b/src/_includes/templates/post-share.vto
@@ -9,21 +9,21 @@
       aria-label="{{ i18n.social.linkedin_share }}"
       href="https://www.linkedin.com/sharing/share-offsite/?url={{ url }}"
       target="_blank"
-      ><img class="size-6 fill-sky-800 dark:fill-sky-600" aria-hidden="true" src="{{ "linkedin-logo" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.linkedin_share }}</span>
+      ><img class="size-6 fill-sky-800 dark:fill-sky-600 transition hover:scale-110" aria-hidden="true" src="{{ "linkedin-logo" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.linkedin_share }}</span>
     </a>
     <a
       class="group -m-1 p-1"
       aria-label="{{ i18n.social.bluesky_share }}"
       href="https://bsky.app/intent/compose?text={{ i18n.social.share_placeholder |> encodeURI() }}&url={{ url }}"
       target="_blank"
-      ><img class="size-6 fill-sky-400 dark:fill-sky-300" aria-hidden="true" src="{{ "butterfly" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.bluesky_share }}</span>
+      ><img class="size-6 fill-sky-400 dark:fill-sky-300 transition hover:scale-110" aria-hidden="true" src="{{ "butterfly" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.bluesky_share }}</span>
     </a> 
     <a
       class="group -m-1 p-1"
       aria-label="{{ i18n.social.twitter_share }}"
       href="https://x.com/intent/post?text={{ i18n.social.share_placeholder |> encodeURI() }}&url={{ url }}"
       target="_blank"
-      ><img class="size-6 fill-black-600 dark:fill-zinc-50" aria-hidden="true" src="{{ "x-logo" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.twitter_share }}</span>
+      ><img class="size-6 fill-black-600 dark:fill-zinc-50 transition hover:scale-110" aria-hidden="true" src="{{ "x-logo" |> icon("phosphor", "duotone") }}" inline><span class="sr-only">{{ i18n.social.twitter_share }}</span>
     </a>
   </div>
 </div>

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -12,7 +12,7 @@
           <div
             class="top-(--avatar-top,--spacing(3)) w-full"
           >
-            <div class="relative">
+            <div class="relative mt-20">
               <a
                 aria-label="Home"
                 class="pointer-events-auto block origin-left"
@@ -23,7 +23,7 @@
                   loading="lazy"
                   fetchpriority="high"
                   decoding="async"
-                  class="w-64 object-cover dark:grayscale dark:invert dark:saturate-[.1] transition-opacity duration-300"
+                  class="-ml-4 w-64 object-cover dark:grayscale dark:invert dark:saturate-[.1] transition-opacity duration-300"
                   src="/assets/logo_horiz_darkblue_bgtransparent_2.svg"
               /></a>
             </div>
@@ -32,15 +32,15 @@
       </div>
     </div>
   </div>
-  <div class="top-0 z-10 h-16 pt-6">
+  <div class="fixed top-0 z-10 h-24 pt-6 w-full bg-zinc-50/70">
     <div
       class="top-(--header-top,--spacing(6)) w-full sm:px-8 fixed"
     >
       <div class="mx-auto w-full max-w-7xl lg:px-8">
         <div class="relative px-4 sm:px-8 lg:px-12">
           <div class="mx-auto max-w-2xl lg:max-w-5xl">
-            <div class="relative flex gap-4">
-              <div class="flex flex-1">
+            <div class="relative flex gap-4 items-center">
+              <div class="flex flex-1 items-center">
               <a
                 aria-label="Home"
                 class="pointer-events-auto block origin-left"
@@ -98,12 +98,12 @@
                 <nav
                   class="pointer-events-auto hidden md:block">
                   <ul 
-                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-zinc-800 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
+                    class="flex rounded-full bg-esoliaamber-500/90 px-3 text-sm font-medium text-zinc-50 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
                   >
                     {{- for item of it.topnav.links }}
                     <li>
                       <a 
-                        class="relative block whitespace-nowrap px-3 py-2 transition hover:text-teal-500 dark:hover:text-teal-400" 
+                        class="relative block whitespace-nowrap px-3 py-2 transition hover:text-sky-400 dark:hover:text-sky-500 no-underline" 
                         href="{{ item.href }}"
                         {{- if item.target }}target="{{ item.target }}"{{ /if }} 
                         aria-label="{{ item.aria_label }}" 
@@ -143,11 +143,11 @@
                   <button
                       type="button"
                       aria-label="Toggle language"
-                      class="group rounded-full bg-white/90 px-3 py-2 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50 text-sm font-medium text-zinc-800 dark:text-zinc-200 dark:group-hover:text-zinc-100"
+                      class="group rounded-full bg-esoliaamber-500/90 px-3 py-2 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50 text-sm font-medium text-zinc-50 dark:text-zinc-200 dark:group-hover:text-zinc-100"
                     >
                     
                     {{- for alt of alternates }}{{ if alt.lang !== lang }}
-                    <a href="{{ alt.url }}" title="{{ alt.title |> escape }}">
+                    <a class="hover:text-sky-400 dark:hover:text-sky-500 no-underline" href="{{ alt.url }}" title="{{ alt.title |> escape }}">
                       {{ if alt.lang == "ja" }}日本語{{ else }}English{{ /if }}
                     </a>
                     {{ /if }}{{ /for }}
@@ -162,9 +162,9 @@
                     class="group rounded-full bg-white/90 px-3 py-2 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50"
                     @click="darkMode = !darkMode">
                     <span x-show="!darkMode">
-                      <img class="h-5 w-5 fill-esoliaamber-500 stroke-esoliaamber-800 transition group-hover:fill-esoliaamber-600 group-hover:stroke-esoliaamber-900 " src="{{ "sun" |> icon("phosphor", "duotone") }}" inline />
+                      <img class="h-5 w-5 fill-esoliaamber-500 stroke-esoliaamber-800 transition group-hover:fill-esoliaamber-600 group-hover:stroke-esoliaamber-900 transition hover:scale-110" src="{{ "sun" |> icon("phosphor", "duotone") }}" inline />
                     </span><span x-show="darkMode">
-                      <img class="h-5 w-5 fill-teal-300 stroke-teal-500 transition group-hover:fill-teal-400 group-hover:stroke-teal-700 " src="{{ "moon-stars" |> icon("phosphor", "duotone") }}" inline />
+                      <img class="h-5 w-5 fill-sky-300 stroke-sky-500 transition group-hover:fill-sky-400 group-hover:stroke-sky-700 transition hover:scale-110" src="{{ "moon-stars" |> icon("phosphor", "duotone") }}" inline />
                     </span>
                   </button>
                 </div>

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -19,25 +19,25 @@
               aria-label="{{ i18n.social.linkedin_label }}"
               href="{{ i18n.social.linkedin_profile_url }}"
               target="_blank"
-              ><img class="h-6 w-6 fill-sky-800 dark:fill-sky-600" src="{{ "linkedin-logo" |> icon("phosphor", "duotone") }}" inline></a>
+              ><img class="h-6 w-6 fill-sky-800 dark:fill-sky-600 transition hover:scale-110" src="{{ "linkedin-logo" |> icon("phosphor", "duotone") }}" inline></a>
             <a
               class="group -m-1 p-1"
               aria-label="{{ i18n.social.bluesky_label }}"
               href="{{ i18n.social.bluesky_profile_url }}"
               target="_blank"
-              ><img class="h-6 w-6 fill-sky-400 dark:fill-sky-300" src="{{ "butterfly" |> icon("phosphor", "duotone") }}" inline></a>
+              ><img class="h-6 w-6 fill-sky-400 dark:fill-sky-300 transition hover:scale-110" src="{{ "butterfly" |> icon("phosphor", "duotone") }}" inline></a>
             <a
               class="group -m-1 p-1"
               aria-label="{{ i18n.social.twitter_label }}"
               href="{{ i18n.social.twitter_profile_url }}"
               target="_blank"
-              ><img class="h-6 w-6 fill-black-600 dark:fill-zinc-50" src="{{ "x-logo" |> icon("phosphor", "duotone") }}" inline></a>
+              ><img class="h-6 w-6 fill-black-600 dark:fill-zinc-50 transition hover:scale-110" src="{{ "x-logo" |> icon("phosphor", "duotone") }}" inline></a>
             <a
               class="group -m-1 p-1"
               aria-label="{{ i18n.social.github_label }}"
               href="{{ i18n.social.github_profile_url }}"
               target="_blank"
-              ><img class="h-6 w-6 fill-green-600 dark:fill-green-500" src="{{ "github-logo" |> icon("phosphor", "duotone") }}" inline></a>
+              ><img class="h-6 w-6 fill-green-600 dark:fill-green-500 transition hover:scale-110" src="{{ "github-logo" |> icon("phosphor", "duotone") }}" inline></a>
           </div>
         </div>
       </div>

--- a/src/posts/firstpost_en.md
+++ b/src/posts/firstpost_en.md
@@ -11,6 +11,9 @@ description: This is the description...
 image: /uploads/blog-esolia-pro-default.png
 category: AI-Usage
 hot: false
+tags: []
+date: 2018-08-22T16:01:00.000Z
+last_modified: 2025-04-04T10:29:00.000Z
 ---
 TEST Leverage agile frameworks to provide a robust synopsis for high level overviews.
 Iterative approaches to corporate strategy foster collaborative thinking to


### PR DESCRIPTION
Design already in use from tailwind plus, is different and more sophisticated compared to the basic tailwind header design, but some of what Satoshi asked about can be incorporated. 

This change was kind of major "surgery" to the design, but I managed to get a div behind the top nav to be sticky and full width. Sticking with the design concept, this is translucent. That goes better with our logo anyway, rather than on a full gray bg.

Logo still set to morph via js, from large to small in-nav as you scroll up. 

Set bg colors to nav elements as esolia yellow, and hover to sky blue. Keep dark/light icon as is. Sky blue seems to be a good accent color for our logo colors. 

Balanced top nav better, with all elements aligned vertically with better flex box settings. Upper nav is a little "taller" now as a result, but it looks good and balanced. 

Separately from the above, made each set of social icons grow on hover using "scale" to 1.1x.

Fixes: #107
Fixes: #108