### PR TITLE
Improve nav opacity on scroll and consolidate UI

### DIFF
--- a/src/_data.yml
+++ b/src/_data.yml
@@ -30,12 +30,12 @@ footernav:
       aria_label: サイト内リンク
       title: サイトマップへのリンク
     - text: プライバシーポリシー
-      href: #
+      href: https://esolia.co.jp/privacy
       target: _self
       icon: privacy
       aria_label: サイト内リンク
       title: プライバシーポリシーへのリンク
-    - text: 当サイトのGitHubリポジトリ
+    - text: GitHubリポジトリ
       href: https://github.com/eSolia/blog.esolia.pro
       target: _blank
       icon: github-logo
@@ -98,12 +98,12 @@ en:
         aria_label: Site internal link
         title: Link to the Sitemap
       - text: Privacy Policy
-        href: #
+        href: https://esolia.com/privacy
         target: _self
         icon: privacy
         aria_label: Site internal link
         title: Link to the Privacy Policy
-      - text: Github Repository for this Site
+      - text: Github Repo
         href: https://github.com/eSolia/blog.esolia.pro
         target: _blank
         icon: github-logo

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -29,7 +29,7 @@ bodyClass: body-post
                       <ul class="list-disc list-inside space-y-2 text-sm font-light">
                         {{ for item of toc }}
                         <li class="font-light">
-                          <a class="text-zinc-500 no-underline hover:text-teal-500 hover:underline" href="#{{ item.slug }}">{{ item.text }}</a>
+                          <a class="text-zinc-500 hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
 
                           {{ if item.children.length }}
                           <ul>

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -47,7 +47,7 @@ bodyClass: body-post
                   {{ /if }}
                 </header>
                 <div
-                  class="prose mt-8 dark:prose-invert"
+                  class="prose mt-8 dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition"
                   data-mdx-content="true"
                 >
                   {{ content }}

--- a/src/_includes/templates/panel-categories.vto
+++ b/src/_includes/templates/panel-categories.vto
@@ -163,7 +163,7 @@
         alt=""
         loading="lazy"
         decoding="async"
-        class="h-6 w-6 fill-teal-800 dark:fill-teal-600" 
+        class="h-6 w-6 fill-sky-800 dark:fill-sky-600" 
         src="{{ "arrow-circle-down" |> icon("phosphor", "duotone") }}" inline>
     </a>
 </div>

--- a/src/_includes/templates/panel-newsletter.vto
+++ b/src/_includes/templates/panel-newsletter.vto
@@ -25,9 +25,9 @@
       placeholder="{{ i18n.newsletter.placeholder }}"
       aria-label="{{ i18n.newsletter.placeholder }}"
       required=""
-      class="min-w-0 flex-auto appearance-none rounded-md border border-zinc-900/10 bg-white px-3 py-[calc(--spacing(2)-1px)] shadow-md shadow-zinc-800/5 placeholder:text-zinc-400 focus:border-teal-500 focus:ring-4 focus:ring-teal-500/10 focus:outline-hidden sm:text-sm dark:border-zinc-700 dark:bg-zinc-700/[0.15] dark:text-zinc-200 dark:placeholder:text-zinc-500 dark:focus:border-teal-400 dark:focus:ring-teal-400/10"
+      class="min-w-0 flex-auto appearance-none rounded-md border border-zinc-900/10 bg-white px-3 py-[calc(--spacing(2)-1px)] shadow-md shadow-zinc-800/5 placeholder:text-zinc-400 focus:border-sky-500 focus:ring-4 focus:ring-sky-500/10 focus:outline-hidden sm:text-sm dark:border-zinc-700 dark:bg-zinc-700/[0.15] dark:text-zinc-200 dark:placeholder:text-zinc-500 dark:focus:border-sky-400 dark:focus:ring-sky-400/10"
     /><button
-      class="ml-4 inline-flex flex-none items-center justify-center gap-2 rounded-md bg-teal-800 px-3 py-2 text-sm font-semibold text-teal-100 outline-offset-2 transition hover:bg-teal-700 active:bg-teal-800 active:text-teal-100/70 active:transition-none dark:bg-teal-700 dark:hover:bg-teal-600 dark:active:bg-teal-700 dark:active:text-teal-100/70"
+      class="ml-4 inline-flex flex-none items-center justify-center gap-2 rounded-md bg-sky-800 px-3 py-2 text-sm font-semibold text-sky-100 outline-offset-2 transition hover:bg-sky-700 active:bg-sky-800 active:text-sky-100/70 active:transition-none dark:bg-sky-700 dark:hover:bg-sky-600 dark:active:bg-sky-700 dark:active:text-sky-100/70"
       type="submit"
     >
       {{ i18n.newsletter.button }}

--- a/src/_includes/templates/post-details.vto
+++ b/src/_includes/templates/post-details.vto
@@ -4,7 +4,7 @@
   <time datetime="{{ date }}" class="order-first flex items-center text-zinc-400 dark:text-zinc-500">
     <span class="h-4 w-0.5 rounded-full bg-zinc-200 dark:bg-zinc-500"></span>
     <span class="ml-3">{{ date |> date("DATE")}}</span>
-    {{ if elapsed < 40 }}<img class="size-6 fill-emerald-400" src="{{ "dot-outline" |> icon("phosphor", "duotone") }}" inline>{{ /if }}
+    {{ if elapsed < 40 }}<img class="size-6 fill-sky-400" src="{{ "dot-outline" |> icon("phosphor", "duotone") }}" inline>{{ /if }}
   </time>
   {{ /if }}
   {{ set catColor = featurecats.find((item) => item.key === category)?.color }}

--- a/src/_includes/templates/post-list.vto
+++ b/src/_includes/templates/post-list.vto
@@ -45,19 +45,19 @@
       author: post.author,
       readingInfo: post.readingInfo
     } }}
-    <div aria-hidden="true" class="relative z-10 mt-4 flex items-center text-sm font-medium text-teal-500">
+    <div aria-hidden="true" class="relative z-10 mt-4 flex items-center text-sm font-medium text-sky-500">
     {{ i18n.nav.continue_reading }}<img 
       alt=""
       loading="lazy"
       decoding="async"
-      class="h-4 w-4 fill-teal-500 dark:fill-teal-300" 
+      class="h-4 w-4 fill-sky-500 dark:fill-sky-300" 
       src="{{ "caret-right" |> icon("phosphor") }}" inline>
     </div>
   </div>
   <time
     class="relative z-10 order-first mt-1 mb-3 flex items-center text-sm text-zinc-400 max-md:hidden dark:text-zinc-500"
     datetime="{{ post.date }}"
-    >{{ post.date |> date("DATE")}}{{ if post.elapseddays < 40 }}<img class="size-6 fill-emerald-400" src="{{ "dot-outline" |> icon("phosphor", "duotone") }}" inline>{{ /if }}</time
+    >{{ post.date |> date("DATE")}}{{ if post.elapseddays < 40 }}<img class="size-6 fill-sky-400" src="{{ "dot-outline" |> icon("phosphor", "duotone") }}" inline>{{ /if }}</time
   >
 </article>
 {{ /for }}

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -32,7 +32,7 @@
       </div>
     </div>
   </div>
-  <div id="top-nav-bg" class="fixed top-0 z-10 h-24 pt-6 w-full bg-zinc-50/70">
+  <div id="top-nav-bg" class="fixed top-0 z-10 h-24 pt-6 w-full bg-zinc-50/50 dark:bg-zinc-700/50 transition-all duration-700 shadow-xs">
     <div
       class="top-(--header-top,--spacing(6)) w-full sm:px-8 fixed"
     >

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -98,12 +98,12 @@
                 <nav
                   class="pointer-events-auto hidden md:block">
                   <ul 
-                    class="flex rounded-full bg-esoliaamber-500/90 px-3 text-sm font-medium text-zinc-50 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
+                    class="flex rounded-full bg-esoliaamber-500/90 px-3 text-sm font-medium ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:ring-white/10"
                   >
                     {{- for item of it.topnav.links }}
                     <li>
                       <a 
-                        class="relative block whitespace-nowrap px-3 py-2 transition hover:text-sky-400 dark:hover:text-sky-500 no-underline" 
+                        class="relative block whitespace-nowrap px-3 py-2 transition text-zinc-50 dark:text-zinc-200 hover:text-sky-400 dark:hover:text-sky-500" 
                         href="{{ item.href }}"
                         {{- if item.target }}target="{{ item.target }}"{{ /if }} 
                         aria-label="{{ item.aria_label }}" 
@@ -143,11 +143,11 @@
                   <button
                       type="button"
                       aria-label="Toggle language"
-                      class="group rounded-full bg-esoliaamber-500/90 px-3 py-2 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50 text-sm font-medium text-zinc-50 dark:text-zinc-200 dark:group-hover:text-zinc-100"
+                      class="group rounded-full bg-esoliaamber-500/90 px-3 py-2 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50 text-sm font-medium dark:group-hover:text-zinc-100"
                     >
                     
                     {{- for alt of alternates }}{{ if alt.lang !== lang }}
-                    <a class="hover:text-sky-400 dark:hover:text-sky-500 no-underline" href="{{ alt.url }}" title="{{ alt.title |> escape }}">
+                    <a class="text-zinc-50 dark:text-zinc-200 hover:text-sky-400 dark:hover:text-sky-500" href="{{ alt.url }}" title="{{ alt.title |> escape }}">
                       {{ if alt.lang == "ja" }}日本語{{ else }}English{{ /if }}
                     </a>
                     {{ /if }}{{ /for }}

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -32,7 +32,7 @@
       </div>
     </div>
   </div>
-  <div class="fixed top-0 z-10 h-24 pt-6 w-full bg-zinc-50/70">
+  <div id="top-nav-bg" class="fixed top-0 z-10 h-24 pt-6 w-full bg-zinc-50/70">
     <div
       class="top-(--header-top,--spacing(6)) w-full sm:px-8 fixed"
     >

--- a/src/_includes/templates/top-post-list.vto
+++ b/src/_includes/templates/top-post-list.vto
@@ -36,13 +36,13 @@
   <p class="relative z-10 mt-2 text-sm text-zinc-600 dark:text-zinc-400">{{- post.excerpt |> md(true) -}}</p>
   <div
     aria-hidden="true"
-    class="relative z-10 mt-4 flex items-center text-sm font-medium text-teal-500"
+    class="relative z-10 mt-4 flex items-center text-sm font-medium text-sky-500"
   >
     {{ i18n.nav.continue_reading }}<img 
       alt=""
       loading="lazy"
       decoding="async"
-      class="h-4 w-4 fill-teal-500 dark:fill-teal-300" 
+      class="h-4 w-4 fill-sky-500 dark:fill-sky-300" 
       src="{{ "caret-right" |> icon("phosphor") }}" inline>
   </div>
 </article>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -17,15 +17,22 @@ function loadVendorScript(src, attributes, callback) {
 window.addEventListener('scroll', () => {
   const largeLogo = document.getElementById('large-logo');
   const smallLogo = document.getElementById('small-logo');
+  const topNavBG = document.getElementById('top-nav-bg');
   const scrollPosition = window.scrollY;
 
   if (scrollPosition > 10) {
       largeLogo.classList.add('opacity-0');
       smallLogo.classList.remove('opacity-0');
+      topNavBG.classList.remove('bg-zinc-50/60');
+      topNavBG.classList.add('bg-zinc-50/90');
   } else {
       largeLogo.classList.remove('opacity-0');
       smallLogo.classList.add('opacity-0');
+      topNavBG.classList.remove('bg-zinc-50/90');
+      topNavBG.classList.add('bg-zinc-50/60');
   }
+
+  // <div id="top-nav-bg" class="fixed top-0 z-10 h-24 pt-6 w-full bg-zinc-50/70"></div>
 });
 
 // Theme Toggle with Alpine.js

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -13,26 +13,36 @@ function loadVendorScript(src, attributes, callback) {
   document.head.appendChild(script);
 }
   
-// Swap logo on scroll
+// Swap logo on scroll and make nav bg more opaque
 window.addEventListener('scroll', () => {
   const largeLogo = document.getElementById('large-logo');
   const smallLogo = document.getElementById('small-logo');
   const topNavBG = document.getElementById('top-nav-bg');
   const scrollPosition = window.scrollY;
 
+  // Handle logo swap
   if (scrollPosition > 10) {
       largeLogo.classList.add('opacity-0');
       smallLogo.classList.remove('opacity-0');
-      topNavBG.classList.remove('bg-zinc-50/60');
-      topNavBG.classList.add('bg-zinc-50/90');
   } else {
       largeLogo.classList.remove('opacity-0');
       smallLogo.classList.add('opacity-0');
-      topNavBG.classList.remove('bg-zinc-50/90');
-      topNavBG.classList.add('bg-zinc-50/60');
   }
 
-  // <div id="top-nav-bg" class="fixed top-0 z-10 h-24 pt-6 w-full bg-zinc-50/70"></div>
+  // Handle background color changes
+  if (scrollPosition > 50) {
+      topNavBG.classList.remove('bg-zinc-50/50', 'dark:bg-zinc-700/50', 'bg-zinc-50/70', 'dark:bg-zinc-700/70');
+      topNavBG.classList.add('bg-zinc-50/95', 'dark:bg-zinc-700/95');
+  } else if (scrollPosition > 30 && scrollPosition <= 50) {
+      topNavBG.classList.remove('bg-zinc-50/50', 'dark:bg-zinc-700/50', 'bg-zinc-50/95', 'dark:bg-zinc-700/95');
+      topNavBG.classList.add('bg-zinc-50/70', 'dark:bg-zinc-700/70');
+  } else if (scrollPosition > 10 && scrollPosition <= 30) {
+      topNavBG.classList.remove('bg-zinc-50/70', 'dark:bg-zinc-700/70', 'bg-zinc-50/95', 'dark:bg-zinc-700/95');
+      topNavBG.classList.add('bg-zinc-50/50', 'dark:bg-zinc-700/50');
+  } else {
+      topNavBG.classList.remove('bg-zinc-50/70', 'dark:bg-zinc-700/70', 'bg-zinc-50/95', 'dark:bg-zinc-700/95');
+      topNavBG.classList.add('bg-zinc-50/50', 'dark:bg-zinc-700/50');
+  }
 });
 
 // Theme Toggle with Alpine.js

--- a/src/posts/20250403-essential-keyboard-shortcuts-en.md
+++ b/src/posts/20250403-essential-keyboard-shortcuts-en.md
@@ -28,16 +28,17 @@ Here, we’ve gathered a collection of basic shortcuts you can start using right
 No complicated steps, no advanced knowledge required. Just simple, practical shortcuts that feel intuitive — ones your fingers will remember for you. 
 
 ## Useful Shortcut Keys for Windows
-**Basic operations (for relieving everyday little frustrations)**
+### Basic operations 
+For relieving everyday little frustrations...
 
-<table class="table-fixed">
-  <caption class="caption-bottom text-xs text-zinc-400">
+<table class="not-prose w-full text-sm">
+  <caption>
     Table: Basic Windows Keyboard Shortcuts
   </caption>
-  <thead class="bg-zinc-50">
+  <thead>
     <tr>
-      <th class="p-2">Shortcut Key</th>
-      <th class="p-2">Action</th>
+      <th>Shortcut Key</th>
+      <th>Action</th>
     </tr>
   </thead>
   <tbody>
@@ -64,9 +65,13 @@ No complicated steps, no advanced knowledge required. Just simple, practical sho
   </tbody>
 </table>
 
-**Boost productivity (quiet time-savers for smart workers)**
+### Boost productivity 
+Quiet time-savers for smart workers...
 
-<table class="table-fixed">
+<table class="not-prose w-full text-sm">
+  <caption>
+    Table: Productivity Keyboard Shortcuts
+  </caption>
   <thead>
     <tr>
       <th>Shortcut Key</th>
@@ -98,11 +103,13 @@ No complicated steps, no advanced knowledge required. Just simple, practical sho
 </table>
 
 
-## Shortcut Keys for Office 365 (Word, Excel, Outlook)
+## Shortcut Keys for Office 365 
+### Word 
 
-**Word** 
-
-<table class="table-fixed">
+<table class="not-prose w-full text-sm">
+  <caption>
+    Table: Word Keyboard Shortcuts
+  </caption>
   <thead>
     <tr>
       <th>Shortcut Key</th>
@@ -133,9 +140,12 @@ No complicated steps, no advanced knowledge required. Just simple, practical sho
   </tbody>
 </table>
 
-**Excel** 
+### Excel
 
-<table class="table-fixed">
+<table class="not-prose w-full text-sm">
+  <caption>
+    Table: Excel Keyboard Shortcuts
+  </caption>
   <thead>
     <tr>
       <th>Shortcut Key</th>
@@ -166,9 +176,12 @@ No complicated steps, no advanced knowledge required. Just simple, practical sho
   </tbody>
 </table>
 
-**Outlook** 
+### Outlook
 
-<table class="table-fixed">
+<table class="not-prose w-full text-sm">
+  <caption>
+    Table: Outlook Keyboard Shortcuts
+  </caption>
   <thead>
     <tr>
       <th>Shortcut Key</th>

--- a/src/posts/20250403-使えるキーボードショートカット基本編-ja.md
+++ b/src/posts/20250403-使えるキーボードショートカット基本編-ja.md
@@ -27,14 +27,12 @@ WindowsとOffice 365の便利なショートカットキーを紹介。業務効
 <br>
 <br>
 
-## **Windowsの便利なショートカットキー** 
+## Windowsの便利なショートカットキー
+### 基本操作
+（＝日常の小さなストレスを解消）
 
-
-
-**基本操作（＝日常の小さなストレスを解消）** 
-
-<table class="table-fixed">
-  <caption class="caption-bottom text-xs text-zinc-400">
+<table  class="not-prose w-full text-sm">
+  <caption>
     表: 日常Windowsキーボード操作
   </caption>
   <thead class="bg-zinc-50">
@@ -67,9 +65,13 @@ WindowsとOffice 365の便利なショートカットキーを紹介。業務効
   </tbody>
 </table>
 
-**作業効率アップ（＝できる人の“静かな時短”）** 
+### 作業効率アップ
+（＝できる人の“静かな時短”）
 
-<table border="1">
+<table class="not-prose w-full text-sm">
+  <caption>
+    表: 効率アップ用キーボード操作
+  </caption>
   <thead>
     <tr>
       <th>ショートカットキー</th>
@@ -102,13 +104,13 @@ WindowsとOffice 365の便利なショートカットキーを紹介。業務効
 
 
 
-## **Office 365（Word・Excel・Outlook）のショートカットキー** 
+## Office 365のショートカットキー
+### Word
 
-
-
-**Word** 
-
-<table border="1">
+<table class="not-prose w-full text-sm">
+  <caption>
+    表: Word用キーボード操作
+  </caption>
   <thead>
     <tr>
       <th>ショートカットキー</th>
@@ -140,10 +142,12 @@ WindowsとOffice 365の便利なショートカットキーを紹介。業務効
 </table>
 
 
+### Excel 
 
-**Excel** 
-
-<table border="1">
+<table class="not-prose w-full text-sm">
+  <caption>
+    表: Excel用キーボード操作
+  </caption>
   <thead>
     <tr>
       <th>ショートカットキー</th>
@@ -175,10 +179,12 @@ WindowsとOffice 365の便利なショートカットキーを紹介。業務効
 </table>
 
 
+### Outlook
 
-**Outlook** 
-
-<table border="1">
+<table class="not-prose w-full text-sm">
+  <caption>
+    表: Outlook用キーボード操作
+  </caption>
   <thead>
     <tr>
       <th>ショートカットキー</th>
@@ -209,13 +215,7 @@ WindowsとOffice 365の便利なショートカットキーを紹介。業務効
   </tbody>
 </table>
 
-
-
-
-
 実際にショートカットキーを使うようになると、驚くほど作業スピードが変わります。1つひとつの時間はわずかでも、それが何十回も積み重なると大きな違いになります。 
-
- 
 
 **ショートカットキーは、「知る」だけでは意味がありません。大事なのは“使う”こと。** 
 
@@ -230,4 +230,4 @@ WindowsとOffice 365の便利なショートカットキーを紹介。業務効
 > - <kbd>Win</kbd> + <kbd>L</kbd>: 画面を即ロック 
 > - <kbd>Win</kbd> + <kbd>V</kbd>: クリップボード履歴を表示する
 > - <kbd>Win</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd>: スクリーンショット（範囲指定）
-> <br>
+> <br><br>

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,7 +116,7 @@
 }
 
 body article > div > p:first-of-type {
-  @apply text-lg font-light leading-relaxed text-esoliablue-800;
+  @apply text-lg font-light leading-relaxed text-esoliablue-800 dark:text-esoliablue-200;
 }
 
 /* MDN keyboard shortcut style for kbd tag */

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,17 +7,65 @@
 /* @plugin "tailwind-every-layout@latest"; */
 @import "css/alerts.css";
 /* @import "css/vendor/splidejs/splide-skyblue.min.css"; */
+
+/* @layer base {
+  body prose a {
+    text-decoration: underline;
+    text-decoration: wavy;
+    text-decoration-thickness: 1px;
+    text-decoration-color: theme("colors.zinc.300");
+  }
+  body prose a:hover {
+    color: theme("colors.zinc.950");
+    text-decoration-color: theme("colors.zinc.500");
+  }
+} */
+
 @layer base {
   a {
-    text-decoration: underline;
-    text-decoration-thickness: 2px;
-    text-decoration-color: theme("colors.gray.300");
+    @apply text-zinc-500 hover:text-sky-700 no-underline; /* Example base link styles */
+    transition: color 0.15s ease-in-out;
+    text-decoration-thickness: 1px; /* Set your desired default thickness here as well */
+    text-decoration-color: theme('colors.zinc.500'); /* Match the text color */
   }
-  a:hover {
-    color: theme("colors.gray.950");
-    text-decoration-color: theme("colors.gray.500");
+
+  /* You could also style specific link states globally */
+  a:focus {
+    @apply outline-none ring-2 ring-sky-700/50 ring-offset-2;
   }
 }
+@layer components {
+  /* Apply base styles to tables with not-prose */
+  table not-prose {
+    @apply table-fixed w-full text-left text-sm; 
+  }
+
+  table.not-prose thead {
+    @apply bg-zinc-50 text-zinc-700 dark:bg-zinc-600 dark:text-zinc-300 text-left;
+  }
+
+  table.not-prose th,
+  table.not-prose td {
+    @apply p-2;
+  }
+
+  table.not-prose th {
+    @apply font-semibold;
+  }
+
+  table.not-prose tbody {
+    @apply divide-y divide-zinc-200 dark:divide-zinc-700;
+  }
+  table.not-prose caption {
+    @apply caption-bottom text-left p-2 text-xs text-zinc-400;
+  }
+    /* Override the prose <a> tag hover classes */
+  .prose :where(a) {
+    @apply hover:opacity-60;
+  }
+}
+
+/* prose-a:text-sky-900 dark:prose-a:text-sky-200  prose-a:decoration-sky-700 prose-a:underline  */
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -129,7 +129,7 @@ kbd {
 *----------------------------*/
 :root {
   --pagefind-ui-scale: 1;
-  --pagefind-ui-primary: var(--color-teal-500);
+  --pagefind-ui-primary: var(--color-sky-500);
   --pagefind-ui-text: var(--color-zinc-900);
   --pagefind-ui-background: #ffffff;
   --pagefind-ui-border: var(--color-zinc-200);
@@ -140,15 +140,15 @@ kbd {
   --pagefind-ui-image-box-ratio: 3 / 2;
   --pagefind-ui-font: textface, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   .dark {
-    --pagefind-ui-primary: var(--color-teal-500);
+    --pagefind-ui-primary: var(--color-sky-500);
     --pagefind-ui-text: var(--color-zinc-200);
     --pagefind-ui-background: var(--color-zinc-900);
     --pagefind-ui-border: var(--color-zinc-700);
-    --pagefind-ui-tag: var(--color-teal-400);
+    --pagefind-ui-tag: var(--color-sky-400);
   }
 }
 #search mark {
-  background-color: var(--color-teal-300);
+  background-color: var(--color-sky-300);
 }
 
 /*----------------------------


### PR DESCRIPTION
e8d6545913d63d24e38649b94baca3c02462efb6  
Author: James R. Cogley <rick.cogley@esolia.co.jp>  
Date:   Sun Apr 6 15:10:50 2025 +0900  

Handle dark mode and improve transition in opacity scroll  
Opacity scroll was too abrupt for the nav part (logo was fine), and the dark mode was not working. Handle both. Dark mode by adding dark:foobar class, adding scrollPosition ranges and swapping classes for more granular opacity change, and finally changing the type of transition from transition-opacity to transition-all, along with making the duration longer, changing from 300 to 700. Changing to all has an interesting effect of making the nav bg kind of "glow" when switching dark/light mode.

N.b. tried various more involved js methods, but they don't assume tailwind and add an inline class to override (because of the specificity) the default tailwind classes. For whatever reason, although the html was cleaner, the code was more complex than just an if/else/else, hence a bit fragile, I think.

Fixes #111



294ec43e629880e1fe9b7406a1b2611364916e6a  
Author: James R. Cogley <rick.cogley@esolia.co.jp>  
Date:   Sun Apr 6 09:14:20 2025 +0900  

Set base UI accent to color sky  
UI accent is kind of all over the place. Test with various then settle on tailwind's sky blue.

Fixes #117



af5ff07d855974eabb18c9a32ff34dbd76173349  
Author: James R. Cogley <rick.cogley@esolia.co.jp>  
Date:   Sun Apr 6 09:03:16 2025 +0900  

Set footer privacy link to actual policy  
Set to point at esolia main site policies.

Fixes #116



a81233cf5e0a21c793c93ac34bdb32d8c77ae800  
Author: James R. Cogley <rick.cogley@esolia.co.jp>  
Date:   Sun Apr 6 09:02:02 2025 +0900  

Fix lede on dark  
Lede is invisible on dark, so set a lighter color.

Fixes #115



6aecefb51da5ed4a925e0b5aaffe0015a035ee39  
Author: James R. Cogley <rick.cogley@esolia.co.jp>  
Date:   Sun Apr 6 08:59:43 2025 +0900  

Set global table and anchor styles and test  
It is a pain to add a table and have to add a lot of styles. Fix this by adding global table styles to styles.css @layer components. The key to achieving this was using "not-prose". That is, if you set a table in HTML with "not-prose", then these styles will take effect. Set a light gray background on header, padding 2 on cells, applying caption to bottom. Now authors just have to add class="not-prose w-full text-sm" to the table to get a good reasonable default, which keeps the html nice and clean.

Second, addressed anchor tags in @layer base (where you set things like html, body, a, h1 etc). The previous way of working does not work, and you need to use @apply. What it does is, to set anchor tag styling OUTSIDE prose blocks.

The prose function sets anchors strongly, so you need to address generic aspects of them with more specificity in @layer components, using .prose :where(a), changing the opacity on hover. Then, in the div around your content block, use something like "prose mt-8 dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition" to specify, say, the size of the underline, or, even turn off underline. This works well with the layer style. Now, when you hover over a link, no matter the color, it changes opacity which comes from the global style.

Fixes #112
Fixes #114



d0a9cb91e69f620e49fb55dcff9f45e18ecc87ba  
Author: James R. Cogley <rick.cogley@esolia.co.jp>  
Date:   Sun Apr 6 08:23:41 2025 +0900  

Make top header nav more opaque on scroll  
The initial implementation of the header's new design had a too-translucent look, which is distracting when you're scrolling, so change the opacity with scroll, to alleviate that.

Fixes #111.