### PR TITLE
Fix mobile menu, prose, code highlight via prism

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -12,7 +12,6 @@ import googleFonts from "lume/plugins/google_fonts.ts";
 import attributes from "lume/plugins/attributes.ts";
 import esbuild from "lume/plugins/esbuild.ts";
 // import terser from "lume/plugins/terser.ts";
-import prism from "lume/plugins/prism.ts";
 import basePath from "lume/plugins/base_path.ts";
 // import slugifyUrls from "lume/plugins/slugify_urls.ts";
 // import jaconv from "npm:jaconv@1.0.4";
@@ -40,19 +39,20 @@ import shuffle from "https://raw.githubusercontent.com/RickCogley/hibana/refs/he
 import { time } from "node:console";
 import inline from "lume/plugins/inline.ts";
 import seo from "https://raw.githubusercontent.com/timthepost/cushytext/refs/heads/main/src/_plugins/seo/mod.ts";
-import codeHighlight from "lume/plugins/code_highlight.ts";
-import lang_javascript from "npm:highlight.js/lib/languages/javascript";
-import lang_bash from "npm:highlight.js/lib/languages/bash";
-import lang_css from "npm:highlight.js/lib/languages/css";
-import lang_html from "npm:highlight.js/lib/languages/xml";
-import lang_json from "npm:highlight.js/lib/languages/json";
-import lang_javascript_ts from "npm:highlight.js/lib/languages/typescript";
-import lang_javascript_json from "npm:highlight.js/lib/languages/javascript";
-import lang_javascript_js from "npm:highlight.js/lib/languages/javascript";
-import lang_powershell from "npm:highlight.js/lib/languages/powershell";
-import lang_shell from "npm:highlight.js/lib/languages/shell";
-import lang_sql from "npm:highlight.js/lib/languages/sql";
-import lang_yaml from "npm:highlight.js/lib/languages/yaml";
+
+import prism from "lume/plugins/prism.ts";
+import "npm:prismjs@1.29.0/components/prism-git.js";
+import "npm:prismjs@1.29.0/components/prism-json.js";
+import "npm:prismjs@1.29.0/components/prism-markup.js";
+import "npm:prismjs@1.29.0/components/prism-sql.js";
+import "npm:prismjs@1.29.0/components/prism-yaml.js";
+import "npm:prismjs@1.29.0/components/prism-bash.js";
+import "npm:prismjs@1.29.0/components/prism-css.js";
+import "npm:prismjs@1.29.0/components/prism-javascript.js";
+import "npm:prismjs@1.29.0/components/prism-typescript.js";
+import "npm:prismjs@1.29.0/components/prism-powershell.js";
+import "npm:prismjs@1.29.0/components/prism-shell-session.js";
+import "npm:prismjs@1.29.0/components/prism-json5.js";
 
 // ERRORS: import purgecss from "lume/plugins/purgecss.ts";
 // import minify_html from "lume/plugins/minify_html.ts";
@@ -196,10 +196,26 @@ site.use(googleFonts({
 site.use(attributes());
 site.use(picture(/* Options */));
 site.use(transformImages());
+
+site.use(prism({
+  theme: [
+    {
+      name: "default",
+      cssFile: "styles.css",
+      placeholder: "/* light-theme-here */"
+    },
+    {
+      name: "okaidia",
+      cssFile: "styles.css",
+      placeholder: "/* dark-theme-here */"
+    },
+  ]
+}));
+
 site.use(tailwindcss());
 // site.use(lightningCss());
 // site.use(terser());
-site.use(prism());
+
 site.use(basePath());
 site.use(title());
 site.use(toc());
@@ -333,36 +349,7 @@ site.use(
     },
   }),
 );
-site.use(codeHighlight(
-  {
-    theme: [
-      {
-        name: "atom-one-light",
-        cssFile: "styles.css",
-        placeholder: "/* light-theme-here */"
-      },
-      {
-        name: "atom-one-dark",
-        cssFile: "styles.css",
-        placeholder: "/* dark-theme-here */"
-      },
-    ],
-    languages: {
-      bash: lang_bash,
-      css: lang_css,
-      html: lang_html,
-      json: lang_javascript_json,
-      javascript: lang_javascript,
-      typescript: lang_javascript_ts,
-      js: lang_javascript,
-      ts: lang_javascript_ts,
-      powershell: lang_powershell,
-      shell: lang_shell,
-      sql: lang_sql,
-      yaml: lang_yaml,
-    },
-  },
-));
+
 
 site.add([".css"]);
 site.add("fonts");

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -44,7 +44,7 @@ bodyClass: body-post
                   {{ /if }}
                 </header>
                 <div
-                  class="prose mt-8 dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition"
+                  class="prose prose-zinc sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
                   data-mdx-content="true"
                 >
                 {{ content }}

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -127,13 +127,13 @@
                     :style="{ zIndex: zIndex }"
                   >
                     {{- for item of it.topnav.links }}
-                      <div class="text-5xl mobile-menu__item">
+                      <div class="mobile-menu__item space-y-4">
                         <a
-                          class="link dim white f3 f1-l dib"
+                          class="text-white hover:text-sky-400 text-5xl inline-block"
                           href="{{ item.href }}"
                           aria-label="{{ item.aria_label }}"
                           title="{{ item.title }}"
-                        ><span class="font-thin">{{
+                        ><span class="text-white font-thin">{{
                             item.text
                             |> toUpperCase
                           }}</span>

--- a/src/posts/20250408-バッテリーのヘタリ具合を確認する方法-ja.md
+++ b/src/posts/20250408-バッテリーのヘタリ具合を確認する方法-ja.md
@@ -5,7 +5,7 @@ featured: false
 lang: ja
 id: 202503f-laptop-battery-health
 date: 2025-04-08T08:12:43.429Z
-last_modified: 2025-04-09T04:30:00.000Z
+last_modified: 2025-04-09T13:00:00.000Z
 title: 'WindowsでノートPCのバッテリーのヘタリ具合を確認する方法 '
 description: ノートPCのバッテリーの劣化度を確認する方法を紹介します。
 image: /uploads/blog-esolia-pro-default.png
@@ -28,7 +28,7 @@ A. Windows ボタンを押す
 B. 検索バーに「cmd」と入力して Enter キーを押す
 
 <figure class="flex flex-col justify-start items-left">
-  <img alt="Screenshot of searching comand prompt on windows" src="/uploads/202503e-laptop-battery-health-ja(1).png" width="400px" transform-images="avif webp png jpeg 400@2">
+  <img alt="Screenshot of searching comand prompt on windows" src="/uploads/202503e-laptop-battery-health-ja(1).png" width="600px" transform-images="avif webp png jpeg 600@2">
 <br>
 <br>
   
@@ -37,19 +37,24 @@ B. 検索バーに「cmd」と入力して Enter キーを押す
 コマンドプロンプトの黒い画面が表示されたら、以下のコマンドを入力して Enter キーを押します。 
 
 ```powershell
-PS c:\KY> powercfg/batteryreport    
+PS c:\KY> powercfg/batteryreport 
 ```
 
+<br>
 <figure class="flex flex-col justify-start items-left">
-  <img alt="Screenshot of Typing a command into the Command Prompt" src="/uploads/202503e-laptop-battery-health-ja(2).png" width="400px" transform-images="avif webp png jpeg 400@2">  
-
+  <img alt="Screenshot of Typing a command into the Command Prompt" src="/uploads/202503e-laptop-battery-health-ja(2).png" width="600px" transform-images="avif webp png jpeg 600@2">  
+<br>
 「バッテリ寿命レポートがファイル パス XXXXXに保存されました。」という表示が出ました。
-
+<br>
+  
 > [!TIP]
 > **XXXXX**の部分をドラッグして選択、<kbd>Ctrl</kbd> + <kbd>C</kbd> でコピーし、エクスプローラー開いて、<kbd>Ctrl</kbd> + <kbd>V</kbd>でペーストします。
 
+
 <figure class="flex flex-col justify-start items-left">
-  <img alt="Screenshot of Typing the path into explorer" src="/uploads/202503e-laptop-battery-health-ja(3).png" width="400px" transform-images="avif webp png jpeg 400@2">
+  <img alt="Screenshot of Typing the path into explorer" src="/uploads/202503e-laptop-battery-health-ja(3).png" width="600px" transform-images="avif webp png jpeg 600@2">
+
+<br>
 ↑このようにエクスプローラーのフォルダパス入力の部分（画像参照）にコピーしたフォルダ パスを貼り付けて Enter キーを押します。 
 <br>
 <br>
@@ -71,4 +76,3 @@ PS c:\KY> powercfg/batteryreport
 ちなみに **CYCLE COUNT**は、何回充電したかの回数カウントです。だいたい 300 ～ 500 回くらい充電を繰り返したらそろそろ交換時期だと言われています。  <br><br>
   
 自分のパソコンのバッテリーがどれだけ劣化しているかを客観的な数字として確認できる方法を紹介いたしました。「最近ノートPCのバッテリーがすぐに無くなってしまう」と思っている方は、上記の方法で劣化具合を一度チェックしてみてください。  <br><br>
-

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,7 +116,7 @@
 }
 
 body article > div > p:first-of-type {
-  @apply text-lg font-light leading-relaxed text-esoliablue-800 dark:text-esoliablue-200;
+  @apply text-base md:text-lg lg:text-xl font-light leading-relaxed text-esoliablue-800 dark:text-esoliablue-200;
 }
 
 /* MDN keyboard shortcut style for kbd tag */


### PR DESCRIPTION
60354a6632d0e63bcffa0f93363fcd7b2df9227d
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 9 22:05:07 2025 +0900

Test making images 600 instead of 400



3d78a5c4ac01f4034600127472034543b7c1dc52
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 9 22:04:43 2025 +0900

tweak prose classes for more consistent design



5b5e37f150906d60d9a424e523ca389ebf5dbabe
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 9 22:04:08 2025 +0900

Fix mobile menu by setting text to white etc
Fixes #135



8d643577326eff26f4304d8818b8a150615a7dfc
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 9 22:02:46 2025 +0900

Tweak lede
Make lede larger than body, at all sizes



eb86acc3f41b3d7807489107553c6cde5c5a38b7
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 9 22:01:51 2025 +0900

Swap in prism for highlightjs
Lots of pain-in-the-neck css problems w/ highlightjs.
Tested prism and it works well and quickly. Use that.

Fixes #133



