### PR TITLE
Tune markdown settings, fix missing figure tags

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -56,11 +56,22 @@ import "npm:prismjs@1.29.0/components/prism-json5.js";
 
 // ERRORS: import purgecss from "lume/plugins/purgecss.ts";
 // import minify_html from "lume/plugins/minify_html.ts";
+// Change markdown-it configuration
+
+const markdown = {
+  options: {
+    typographer: true,
+    breaks: true,
+    xhtmlOut: false,
+  },
+};
 
 const site = lume({
   src: "./src",
   location: new URL("https://blog.esolia.pro"),
-});
+},
+{ markdown }
+);
 
 site.use(googleFonts({
   subsets: [

--- a/src/posts/20250408-バッテリーのヘタリ具合を確認する方法-ja.md
+++ b/src/posts/20250408-バッテリーのヘタリ具合を確認する方法-ja.md
@@ -5,7 +5,7 @@ featured: false
 lang: ja
 id: 202503f-laptop-battery-health
 date: 2025-04-08T08:12:43.429Z
-last_modified: 2025-04-09T13:00:00.000Z
+last_modified: 2025-04-09T23:33:00.000Z
 title: 'WindowsでノートPCのバッテリーのヘタリ具合を確認する方法 '
 description: ノートPCのバッテリーの劣化度を確認する方法を紹介します。
 image: /uploads/blog-esolia-pro-default.png
@@ -29,23 +29,24 @@ B. 検索バーに「cmd」と入力して Enter キーを押す
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of searching comand prompt on windows" src="/uploads/202503e-laptop-battery-health-ja(1).png" width="600px" transform-images="avif webp png jpeg 600@2">
-<br>
-<br>
+</figure>
+
   
 ## 2. バッテリー レポートを生成する
-
 コマンドプロンプトの黒い画面が表示されたら、以下のコマンドを入力して Enter キーを押します。 
 
 ```powershell
 PS c:\KY> powercfg/batteryreport 
 ```
 
-<br>
+
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of Typing a command into the Command Prompt" src="/uploads/202503e-laptop-battery-health-ja(2).png" width="600px" transform-images="avif webp png jpeg 600@2">  
-<br>
+</figure>
+
+
 「バッテリ寿命レポートがファイル パス XXXXXに保存されました。」という表示が出ました。
-<br>
+
   
 > [!TIP]
 > **XXXXX**の部分をドラッグして選択、<kbd>Ctrl</kbd> + <kbd>C</kbd> でコピーし、エクスプローラー開いて、<kbd>Ctrl</kbd> + <kbd>V</kbd>でペーストします。
@@ -53,26 +54,27 @@ PS c:\KY> powercfg/batteryreport
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of Typing the path into explorer" src="/uploads/202503e-laptop-battery-health-ja(3).png" width="600px" transform-images="avif webp png jpeg 600@2">
+</figure>
 
-<br>
+
 ↑このようにエクスプローラーのフォルダパス入力の部分（画像参照）にコピーしたフォルダ パスを貼り付けて Enter キーを押します。 
-<br>
-<br>
+
 
 ## 3. バッテリー レポートを確認 
-
 エンターを押すとWeb ブラウザが自動で起動して、このようなレポート ページが表示されます。  
+
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of the battery report" src="/uploads/202503e-laptop-battery-health(4).png" width="600px" transform-images="avif webp png jpeg 600@2">
+</figure>
 
 > [!TIP]
 > **DESIGN CAPACITY**がもともと（工場出荷時）のバッテリーの最大容量で、 
 **FULL CHARGE CAPACITY**は今のバッテリーの最大容量となります。
 
-この２つの数字を見比べてみましょう。Full charge Capacityの数字が下がり、Design capacityの数字との乖離があるほど、バッテリーが劣化していることを意味しています。<br><br>
-  
-例えば「FULL CHARGE CAPACITY」が「DESIGN CAPACITY」の70% くらいになってしまっている場合は、そろそろバッテリーの交換を行うか、それが出来ないモデルの場合はPC自体の交換を行うことも視野に入れるべきタイミングです。  <br><br>
-  
-ちなみに **CYCLE COUNT**は、何回充電したかの回数カウントです。だいたい 300 ～ 500 回くらい充電を繰り返したらそろそろ交換時期だと言われています。  <br><br>
-  
-自分のパソコンのバッテリーがどれだけ劣化しているかを客観的な数字として確認できる方法を紹介いたしました。「最近ノートPCのバッテリーがすぐに無くなってしまう」と思っている方は、上記の方法で劣化具合を一度チェックしてみてください。  <br><br>
+この２つの数字を見比べてみましょう。Full charge Capacityの数字が下がり、Design capacityの数字との乖離があるほど、バッテリーが劣化していることを意味しています。
+
+例えば「FULL CHARGE CAPACITY」が「DESIGN CAPACITY」の70% くらいになってしまっている場合は、そろそろバッテリーの交換を行うか、それが出来ないモデルの場合はPC自体の交換を行うことも視野に入れるべきタイミングです。
+
+ちなみに **CYCLE COUNT**は、何回充電したかの回数カウントです。だいたい 300 ～ 500 回くらい充電を繰り返したらそろそろ交換時期だと言われています。
+
+自分のパソコンのバッテリーがどれだけ劣化しているかを客観的な数字として確認できる方法を紹介いたしました。「最近ノートPCのバッテリーがすぐに無くなってしまう」と思っている方は、上記の方法で劣化具合を一度チェックしてみてください。

--- a/src/styles.css
+++ b/src/styles.css
@@ -63,6 +63,19 @@
   .prose :where(a) {
     @apply hover:opacity-60;
   }
+
+  .prose figure + p {
+    margin-top: 1.3333333em; /* Add top margin to paragraphs after figures */
+  }
+
+  .prose p {
+    margin-bottom: 1.3333333em; /* Add bottom margin to all paragraphs */
+  }
+
+  /* Optional: Adjust top margin for the very first paragraph in the prose block */
+  .prose > *:first-child:is(p) {
+    margin-top: 0;
+  }
 }
 
 /* prose-a:text-sky-900 dark:prose-a:text-sky-200  prose-a:decoration-sky-700 prose-a:underline  */


### PR DESCRIPTION
b81c3e75750ee3e31bf7e19ec1c56be66cc52c1c
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 10 08:52:09 2025 +0900

Tune markdown settings, fix missing figure tags

It should be easy to author in markdown, without needing so much html tags. Fine tuned the markdownit library settings, and set up margin after paragraphs.

Discovered that figures in the battery post did NOT have a closing tag. This caused a lot of problems which I did not figure out at first. Then I saw </figure> tags in strange places in the source, and it occurred to me that something was wrong. Went through and fixed all of these, and now the formatting is clean.

Open the battery post in Japanese, and see how br's are not needed now...

Fixes: #138

![JRC CleanShot Microsoft Edge 2025-04-10-085443JST@2x](https://github.com/user-attachments/assets/5808ec57-837c-4fa4-8ffc-0766b8786f54)
