### PR TITLE
Implement modal search

### DIFF
--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -71,6 +71,7 @@ search:
   filter_by_author: Filter by Author
   filter_by_tag: Filter by Tag
   filter_by_category: Filter by Category
+  close_link: Close
 comments:
   title: Comments
   description: |

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -73,6 +73,7 @@ search:
   filter_by_author: 著者でフィルター
   filter_by_tag: タグでフィルター
   filter_by_category: カテゴリーでフィルター
+  close_link: 閉じる
 comments:
   title: Comments
   description: |

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -33,8 +33,6 @@ script: /js/fathom-post-list-event.js
                 href="/feed.json"
               >JSON</a>
             </div>
-            <div class="search" id="search"></div>
-
             {{ if pagination.page === 1 }}
               {{
                 set pageCats = search.pages(

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -23,7 +23,7 @@ script: /js/fathom-post-list-event.js
               {{ i18n.archive.description }}
             </p>
 
-            <div class="flex items-center space-x-2 mt-3">
+            <div class="flex items-center space-x-2 mt-4">
               <img
                 class="size-6 fill-esoliaamber-400"
                 src='{{ "rss" |> icon("phosphor", "duotone") }}'
@@ -43,7 +43,7 @@ script: /js/fathom-post-list-event.js
                 )
               }}
               {{ if pageCats.length }}
-                <div class="text-zinc-500 ml-1 mt-2">
+                <div class="text-zinc-500 ml-1 mt-6">
                   <nav class="">
                     <h2>{{ i18n.search.categories }}:</h2>
                     <ul class="flex flex-wrap space-x-2 space-y-2">
@@ -62,7 +62,7 @@ script: /js/fathom-post-list-event.js
 
               {{ set pageTags = search.pages(`type=tag lang=${lang}`, "tag") }}
               {{ if pageTags.length }}
-                <div class="text-zinc-500 ml-1 mt-2">
+                <div class="text-zinc-500 ml-1 mt-4">
                   <nav class="">
                     <h2>{{ i18n.search.tags }}:</h2>
                     <ul class="flex flex-wrap space-x-2 space-y-2">

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -73,6 +73,7 @@
 
         <!-- Current page: {{ url }} -->
         {{ include "templates/footer.vto" }}
+        {{ include "templates/search-modal.vto" }}
       </div>
     </div>
     <!-- Container end -->

--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -1,3 +1,4 @@
+<!-- ===== footer.vto TEMPLATE START ===== -->
 <footer class="mt-32 flex-none bg-zinc-100 dark:bg-zinc-800">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="py-16">
@@ -86,3 +87,4 @@
     </div>
   </div>
 </footer>
+<!-- ===== footer.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/search-modal.vto
+++ b/src/_includes/templates/search-modal.vto
@@ -1,9 +1,9 @@
 <!-- ===== search-modal.vto TEMPLATE START ===== -->
 <div id="searchModal" class="fixed top-0 left-0 z-1000 w-full h-full overflow-auto hidden">
   <div class="relative w-3/4 h-3/4 mx-auto mt-16 overflow-auto p-5 bg-white/95 dark:bg-zinc-800/95 border border-zinc-100 dark:border-zinc-700/40 rounded-lg shadow-md">
-    <div class="block text-right items-right font-bold text-sm mb-2 pr-2">
+    <div class="block text-right items-right font-bold text-sm">
       <a id="modal-close" href="#">{{ i18n.search.close_link }}</a>
-    <div id="search" tabindex="0"></div>
+    <div id="search" class="text-left mt-6" tabindex="0"></div>
   </div>
 </div>
 <!-- ===== search-modal.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/search-modal.vto
+++ b/src/_includes/templates/search-modal.vto
@@ -1,6 +1,6 @@
 <!-- ===== search-modal.vto TEMPLATE START ===== -->
 <div id="searchModal" class="fixed top-0 left-0 z-1000 w-full h-full overflow-auto hidden">
-  <div class="relative w-3/4 h-3/4 mx-auto mt-16 overflow-auto p-5 bg-white/95 dark:bg-zinc-800/95 border border-zinc-100 dark:border-zinc-700/40 rounded-lg shadow-md">
+  <div class="relative w-3/4 h-3/4 mx-auto mt-24 overflow-auto p-5 bg-white/95 dark:bg-zinc-800/95 border border-zinc-100 dark:border-zinc-700/40 rounded-lg shadow-md">
     <div class="block text-right items-right font-bold text-sm">
       <a id="modal-close" href="#">{{ i18n.search.close_link }}</a>
     <div id="search" class="text-left mt-6" tabindex="0"></div>

--- a/src/_includes/templates/search-modal.vto
+++ b/src/_includes/templates/search-modal.vto
@@ -1,0 +1,9 @@
+<!-- ===== search-modal.vto TEMPLATE START ===== -->
+<div id="searchModal" class="fixed top-0 left-0 z-1000 w-full h-full overflow-auto hidden">
+  <div class="relative w-3/4 h-3/4 mx-auto mt-16 overflow-auto p-5 bg-white/95 dark:bg-zinc-800/95 border border-zinc-100 dark:border-zinc-700/40 rounded-lg shadow-md">
+    <div class="block text-right items-right font-bold text-sm mb-2 pr-2">
+      <a id="modal-close" href="#">{{ i18n.search.close_link }}</a>
+    <div id="search" tabindex="0"></div>
+  </div>
+</div>
+<!-- ===== search-modal.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -168,6 +168,24 @@
                 {{ /if }}
                 <div
                   class="pointer-events-auto z-50"
+                >
+                  <button
+                    type="button"
+                    id="search-button" 
+                    aria-label="Popup Search"
+                    class="group rounded-full bg-white/90 px-3 py-2 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50"
+                  >
+                    <span>
+                      <img
+                        class="h-5 w-5 fill-esoliaamber-500 stroke-esoliaamber-800 transition group-hover:fill-esoliaamber-600 group-hover:stroke-esoliaamber-900 transition hover:scale-110"
+                        src='{{ "magnifying-glass" |> icon("phosphor", "duotone") }}'
+                        inline
+                      />
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="pointer-events-auto z-50"
                   x-data="themeToggle"
                   :class="{ 'dark': darkMode }"
                 >

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -57,9 +57,7 @@
                 inline
               ></a>
           </div>
-          <div class="search mt-6" id="search"></div>
           {{# {{ include "templates/featured1.vto" }} #}}
-
         </div>
       </div>
     </div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -74,9 +74,42 @@ loadVendorScript('https://cdn.usefathom.com/script.js', { 'data-site': 'OIXGEUHR
   console.log('Fathom Analytics loaded with defer and data-site attribute');
 });
 
-// Handle click event for the button with role="button"
-document.querySelector('a[role="button"]').addEventListener('keydown', function(event) {
+// Handle keydown event for anchor tags with role="button"
+const buttons = document.querySelectorAll('a[role="button"]');
+buttons.forEach(button => {
+  button.addEventListener('keydown', function(event) {
     if (event.key === 'Enter') {
       this.click();
     }
+  });
+});
+
+// Search modal
+const modal = document.getElementById("searchModal");
+const searchButton = document.getElementById("search-button"); // Select the button by its ID
+const close = document.getElementById("modal-close");
+
+searchButton.onclick = function() { // Change the event listener target to the button
+  modal.style.display = "block";
+  // Focus on the Pagefind input if it exists after the modal is shown
+  const pageFind = modal.querySelector(".pagefind-ui__search-input");
+  if (pageFind) {
+    pageFind.focus();
+  }
+}
+close.onclick = function () {
+  modal.style.display = "none";
+}
+window.onclick = function(event) {
+    if (event.target == modal) {
+        modal.style.display = "none";
+    }
+}
+// Close modal on Escape key press
+document.addEventListener('keydown', function(event) {
+  if (event.key === 'Escape' || event.keyCode === 27) { // Check for Escape key
+    if (modal.style.display === 'block') {
+    modal.style.display = 'none';
+    }
+ }
 });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -113,3 +113,17 @@ document.addEventListener('keydown', function(event) {
     }
  }
 });
+// Open modal on Cmd+K (Mac) or Ctrl+K (Windows/Linux)
+document.addEventListener('keydown', function(event) {
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    const isCmdOrCtrl = isMac ? event.metaKey : event.ctrlKey;
+
+    if (isCmdOrCtrl && event.key === 'k') {
+        event.preventDefault(); // Prevent browser's default search shortcut
+        modal.style.display = 'block';
+        const pageFind = modal.querySelector(".pagefind-ui__search-input");
+        if (pageFind) {
+        pageFind.focus();
+        }
+    }
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,19 +8,6 @@
 @import "css/alerts.css";
 /* @import "css/vendor/splidejs/splide-skyblue.min.css"; */
 
-/* @layer base {
-  body prose a {
-    text-decoration: underline;
-    text-decoration: wavy;
-    text-decoration-thickness: 1px;
-    text-decoration-color: theme("colors.zinc.300");
-  }
-  body prose a:hover {
-    color: theme("colors.zinc.950");
-    text-decoration-color: theme("colors.zinc.500");
-  }
-} */
-
 @layer base {
   a {
     @apply text-zinc-500 dark:text-zinc-100 hover:text-sky-600 dark:hover:text-sky-400; /* Example base link styles */


### PR DESCRIPTION
6f3e397b4eb3d6e7cff7de94e7e725f49ac6b33d
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 10 14:12:24 2025 +0900

Implement modal search

Add strings to i18n data files so they can be pulled onto the popup form.

Remove the pagefind placeholder from top-welcome-header and archive.vto. Create a template "search-modal.vto" and include it in base.vto under the footer, then include the code for the popup window there, including the target div for the pagefindjs. This makes it easy to have the search on every page, because the search icon in the nav bar will be.

Update the main.js to allow modal popup to open and be closed with either the "close" button, or via ESC.

De-conflict the a11y code for allowing screen reader users to press enter on anchor tags that are marked as buttons via aria role. Was conflicting with the search modal open/close code.

Migrate the initial standard css for the popup modal, to tailwind classes, and test in light and dark modes, on desktop and mobile. Everything is basically working.

Fixes: #128



471f760f271aba9fa5897650f9797a67135b4d40
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 10 14:05:25 2025 +0900

Fix margin

Archive page spacing needed breathing room, so fixed the margin settings



2c50dd638bbbcd1dee411f3ef5e5fa203906e096
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 10 14:04:35 2025 +0900

Add template start and end comments

Need these markers to make troubleshooting easier



7d4e5e14c2ca878d016decbbee6d2fad78163a38
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 10 14:03:42 2025 +0900

Remove commented css

Another variant of this was implemented, so we do not need


fc851581a6649f1365275d194410f66586147aea
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 10 15:03:39 2025 +0900

Balance spacing in popup

Putting padding on the close link did not work, so I put margin on the top of the search form element, which pushed the search form down a bit. Now the form looks balanced, with the close button in the corner, but away from the search input.

Fixes: #128

c94704008a2ca6071582fcd43062096f069edede
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 10 15:24:59 2025 +0900

Fix search modal position to a little lower

Use mt-24 on the modal to make it appear just a little lower down the page. It's more attractive that way, and does not overlap the nav.

Fixes: #128



e077441edeee72f8314347bd53846055403c2e80
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 10 15:23:37 2025 +0900

Add hot key to search modal

Search Modal should open on Cmd+K (Mac) or Ctrl+K (Windows/Linux), like you see in many modern UI's like github. Added js to listen for these keys. It's easy to press those to open, and ESC to close.

Fixes: #128

### Screenshots

![JRC CleanShot Microsoft Edge 2025-04-10-150648JST@2x](https://github.com/user-attachments/assets/65938b21-0d87-4cb6-a345-0e9f186aa801)

![JRC CleanShot Microsoft Edge 2025-04-10-152941JST](https://github.com/user-attachments/assets/826f3390-841f-4953-aeae-b6fdb2fa7e74)


Closes: #123


