### PR TITLE
Prevent menu name wrap on mobile

### DIFF
--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -56,7 +56,7 @@
                 <div class="pointer-events-auto md:hidden relative">
                   <button
                     aria-label="Toggle menu"
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-zinc-800 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-zinc-800 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     x-data
                     @click="$dispatch('toggle-menu')"


### PR DESCRIPTION
d419fa58e71fffb08a460daad4f1a631b0847810
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 23 16:52:29 2025 +0900

### Prevent menu name wrap on mobile
Use "whitespace-nowrap" to prevent mobile "menu" name from wrapping on mobile. English was fine, but Japanese would wrap weirdly.

Fixes #170


![JRC CleanShot Microsoft Edge 2025-04-23-165338JST@2x](https://github.com/user-attachments/assets/86b8ad75-bf1d-469d-a495-66a1b328f0de)


