### PR TITLE
Add title antialiasing, fix a typo, comment out splide

### DIFF
--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -13,7 +13,7 @@ script: /js/fathom-post-list-event.js
             <h1
               class="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100"
             >
-              <span class="font-light">{{ i18n.home.sitename }}</span>
+              <span class="font-light subpixel-antialiased">{{ i18n.home.sitename }}</span>
               <br class="block sm:hidden">
               <span
                 class="bg-gradient-to-r from-esoliablue-800 to-esoliablue-900 bg-clip-text text-transparent"

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -11,7 +11,7 @@ bodyClass: body-tag
           <header class="max-w-2xl space-y-10">
             <div class=""><a href="/archive/">{{ i18n.nav.back }}</a></div>
             <h1
-              class="text-4xl font-thin tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100"
+              class="text-4xl font-thin tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100 subpixel-antialiased"
             >
               {{ title }}
             </h1>

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -41,15 +41,15 @@
     <script src="/js/main.js?cb={{ cacheBuster }}" type="module" defer></script>
 
     <!-- Splide CSS -->
-    <link
+    {{# <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@splidejs/splide@latest/dist/css/splide.min.css"
-    >
+    > #}}
 
     <!-- Splide JS -->
-    <script
+    {{# <script
       src="https://cdn.jsdelivr.net/npm/@splidejs/splide@latest/dist/js/splide.min.js"
-    ></script>
+    ></script> #}}
 
     <link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
     {{ it.extra_head?.join("\n") }}

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -16,7 +16,7 @@ bodyClass: body-post
                 <header class="flex flex-col">
                   {{ include "templates/post-details.vto" { elapsed: elapseddays } }}
                   <h1
-                    class="mt-6 text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100"
+                    class="mt-6 text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100 subpixel-antialiased"
                   >
                     {{ title }}
                   </h1>

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -9,7 +9,7 @@
           >
             {{# <span class="font-light">{{ i18n.home.company }}</span>
             <br class="block sm:hidden"> #}}
-            <span class="font-light">{{ i18n.home.sitename }}</span>
+            <span class="font-light subpixel-antialiased">{{ i18n.home.sitename }}</span>
             {{# {{ metas.site }} #}}
           </h1>
           <p class="mt-6 text-base text-zinc-600 dark:text-zinc-400">

--- a/src/posts/20250408-outlook-calendar-sync-issues-en.md
+++ b/src/posts/20250408-outlook-calendar-sync-issues-en.md
@@ -6,7 +6,7 @@ lang: en
 id: 202503e-outlook-calender-sync-issues
 date: 2025-04-08T07:31:31.905Z
 last_modified: 2025-04-22T00:48:00.000Z
-title: How to Fix Outlook Calendar Sync Issues.
+title: How to Fix Outlook Calendar Sync Issues
 description: >-
   Here are some methods to help resolve outlook calendar sync problems and
   ensure smoother scheduling.


### PR DESCRIPTION
b83da4b39915035b09abd24046618cbf9ca3a153
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 23 20:31:01 2025 +0900

### Add antialiasing to titles
Antialiasing looks a little nicer for titles so take advantage of the class for them for top page header, archive and archive results pages, and post title.



839f267dfccd725174c7a37bbb4ff718caaaa68b
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 23 20:30:07 2025 +0900

### Remove unneeded period



a0afbc14f51d57ef3bb69b00144d9a5a0ad1953a
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed Apr 23 20:28:06 2025 +0900

### Comment out splide



