### PR TITLE
Add rel noopener for better security in navs

### DIFF
--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -25,6 +25,8 @@
               aria_label="{{ item.aria_label }}"
               title="{{ item.title }}"
               {{- if item.target }}target="{{ item.target }}"{{ /if }}
+              {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
+              role="menuitem"
             >
               {{ item.text }}
               <span class="sr-only">({{ item.aria_label }})</span></a>

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -95,6 +95,8 @@
                           class="group relative block whitespace-nowrap px-3 py-2 transition text-zinc-50 dark:text-zinc-200 hover:text-sky-400 dark:hover:text-sky-500 {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
                           href="{{ item.href }}"
                           {{- if item.target }}target="{{ item.target }}"{{ /if -}}
+                          {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
+                          role="menuitem"
                           aria-label="{{ item.aria_label }}"
                           title="{{ item.title }}"
                         >{{ item.text }}<span class="absolute inset-x-1 -bottom-px h-px bg-linear-to-r from-zinc-500/0 via-zinc-500/40 to-zinc-500/0 dark:from-zinc-400/0 dark:via-zinc-400/40 dark:to-zinc-400/0 opacity-0 group-hover:opacity-100 transition duration-300"></span>
@@ -133,6 +135,8 @@
                         <a
                           class="text-white font-thin hover:text-sky-400 text-5xl inline-block {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
                           href="{{ item.href }}"
+                          {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
+                          role="menuitem"
                           aria-label="{{ item.aria_label }}"
                           title="{{ item.title }}"
                         ><span class="text-white">{{


### PR DESCRIPTION
4bc20cda8833628b9d45ed533acd3b7a60fe1c34
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 24 10:21:15 2025 +0900

### Add rel noopener for better security in navs
Use vento conditionals to check if a link has target blank, then add rel noopener if it does.




