### PR TITLE
Make external link processor ignore certain links, drop title size, fix share text

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -405,13 +405,21 @@ site.process([".html"], (pages) => {
   const siteUrl = new URL(location); // Get the base URL of your site
 
   for (const page of pages) {
-    // Use page.document to access the DOM
     const document = page.document;
 
     // Select all <a> tags with target="_blank"
     const links = document.querySelectorAll("a[target='_blank']");
 
     for (const link of links) {
+      // --- NEW CHECK ---
+      // Check if the link is inside an element with the class 'no-external-icon'
+      // The closest() method searches up the DOM tree for the first matching ancestor.
+      if (link.closest('.no-external-icon')) {
+        // If a matching ancestor is found, skip this link
+        continue;
+      }
+      // --- END NEW CHECK ---
+
       const href = link.getAttribute("href");
 
       // Skip if href is missing or is just a fragment link (e.g., #section)
@@ -420,24 +428,19 @@ site.process([".html"], (pages) => {
       }
 
       try {
-        // Create a URL object to easily parse the href relative to the current page URL
-        // This handles relative paths correctly.
         const linkUrl = new URL(href, site.options.url);
 
-        // Check if the link is external (different origin: protocol, hostname, or port)
-        // We also filter for http/https links, excluding mailto:, tel:, etc.
         const isExternal = (linkUrl.protocol === 'http:' || linkUrl.protocol === 'https:') &&
                            (linkUrl.protocol !== siteUrl.protocol ||
                             linkUrl.hostname !== siteUrl.hostname ||
-                            linkUrl.port !== siteUrl.port); // Compare against site's base URL
+                            linkUrl.port !== siteUrl.port);
 
         if (isExternal) {
-          // Add the class if it's an external link with target="_blank"
+          // Add the class if it's an external link with target="_blank" AND not excluded
           link.classList.add("after:content-['_↗']");
         }
 
       } catch (e) {
-        // Handle potential errors if href is malformed and cannot be parsed as a URL
         console.error(`Could not parse URL for link: ${href} on page ${page.src.path}`, e);
       }
     }

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -10,8 +10,8 @@ archive:
   description: 過去の記事を一覧でご紹介しています。カテゴリやタグを活用して、興味のある情報にすばやくアクセスできます。または、ページ上部のナビゲーションバーにある虫眼鏡アイコンから検索してください。
 social:
   share_placeholder: 役立つIT情報をお届け中！当ブログの最新ポストはこちら
-  share_ask: 一つお願いがあります！
-  share_title: SNSでこの記事をシェアしていただけますでしょうか？
+  share_ask: この記事が役に立ったと思ったら
+  share_title: SNSでシェアしてみませんか？
   linkedin_label: LinkedInでフォローする
   linkedin_share: LinkedInでシェアする
   linkedin_profile_url: https://www.linkedin.com/company/esolia

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -16,7 +16,7 @@ bodyClass: body-post
                 <header class="flex flex-col">
                   {{ include "templates/post-details.vto" { elapsed: elapseddays } }}
                   <h1
-                    class="mt-6 text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100 subpixel-antialiased"
+                    class="mt-6 text-3xl font-bold tracking-tight text-zinc-800 sm:text-4xl dark:text-zinc-100 subpixel-antialiased"
                   >
                     {{ title }}
                   </h1>

--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -35,7 +35,7 @@
       </nav>
     </div>
     <div
-      class="flex flex-col items-center border-t border-slate-400/10 py-10 sm:flex-row-reverse sm:justify-between"
+      class="flex flex-col items-center border-t border-slate-400/10 py-10 sm:flex-row-reverse sm:justify-between no-external-icon"
     >
       <div class="mt-6 flex flex-wrap gap-6">
         <a
@@ -43,6 +43,7 @@
           aria-label="{{ i18n.social.linkedin_label }}"
           href="{{ i18n.social.linkedin_profile_url }}"
           target="_blank"
+          rel="noopener"
         ><img
             class="h-6 w-6 fill-sky-800 dark:fill-sky-600 transition hover:scale-110"
             src='{{ "linkedin-logo" |> icon("phosphor", "duotone") }}'
@@ -53,6 +54,7 @@
           aria-label="{{ i18n.social.bluesky_label }}"
           href="{{ i18n.social.bluesky_profile_url }}"
           target="_blank"
+          rel="noopener"
         ><img
             class="h-6 w-6 fill-sky-400 dark:fill-sky-300 transition hover:scale-110"
             src='{{ "butterfly" |> icon("phosphor", "duotone") }}'
@@ -63,6 +65,7 @@
           aria-label="{{ i18n.social.twitter_label }}"
           href="{{ i18n.social.twitter_profile_url }}"
           target="_blank"
+          rel="noopener"
         ><img
             class="h-6 w-6 fill-black-600 dark:fill-zinc-50 transition hover:scale-110"
             src='{{ "x-logo" |> icon("phosphor", "duotone") }}'
@@ -73,6 +76,7 @@
           aria-label="{{ i18n.social.github_label }}"
           href="{{ i18n.social.github_profile_url }}"
           target="_blank"
+          rel="noopener"
         ><img
             class="h-6 w-6 fill-green-600 dark:fill-green-500 transition hover:scale-110"
             src='{{ "github-logo" |> icon("phosphor", "duotone") }}'

--- a/src/_includes/templates/post-share.vto
+++ b/src/_includes/templates/post-share.vto
@@ -10,12 +10,13 @@
       <span class="underline underline-offset-4 decoration-fuchsia-500/60 decoration-wavy">{{ i18n.social.share_title }}</span>
     </p>
   </div>
-  <div class="mt-1 flex justify-center gap-x-4 pb-3">
+  <div class="mt-1 flex justify-center gap-x-4 pb-3 no-external-icon">
     <a
       class="group -m-1 p-1"
       aria-label="{{ i18n.social.linkedin_share }}"
       href="https://www.linkedin.com/sharing/share-offsite/?url={{ url }}"
       target="_blank"
+      rel="noopener"
     ><img
         class="size-6 fill-sky-800 dark:fill-sky-600 transition hover:scale-110"
         aria-hidden="true"
@@ -28,6 +29,7 @@
       aria-label="{{ i18n.social.bluesky_share }}"
       href="https://bsky.app/intent/compose?text={{ i18n.social.share_placeholder |> encodeURI() }}&url={{ url }}"
       target="_blank"
+      rel="noopener"
     ><img
         class="size-6 fill-sky-400 dark:fill-sky-300 transition hover:scale-110"
         aria-hidden="true"
@@ -40,6 +42,7 @@
       aria-label="{{ i18n.social.twitter_share }}"
       href="https://x.com/intent/post?text={{ i18n.social.share_placeholder |> encodeURI() }}&url={{ url }}"
       target="_blank"
+      rel="noopener"
     ><img
         class="size-6 fill-black-600 dark:fill-zinc-50 transition hover:scale-110"
         aria-hidden="true"

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -15,12 +15,13 @@
           <p class="mt-6 text-base text-zinc-600 dark:text-zinc-400">
             {{ i18n.home.welcome }}
           </p>
-          <div class="mt-6 flex gap-6">
+          <div class="mt-6 flex gap-6 no-external-icon">
             <a
               class="group -m-1 p-1"
               aria-label="{{ i18n.social.linkedin_label }}"
               href="{{ i18n.social.linkedin_profile_url }}"
               target="_blank"
+              rel="noopener"
             ><img
                 class="h-6 w-6 fill-sky-800 dark:fill-sky-600 transition hover:scale-110"
                 src='{{ "linkedin-logo" |> icon("phosphor", "duotone") }}'
@@ -31,6 +32,7 @@
               aria-label="{{ i18n.social.bluesky_label }}"
               href="{{ i18n.social.bluesky_profile_url }}"
               target="_blank"
+              rel="noopener"
             ><img
                 class="h-6 w-6 fill-sky-400 dark:fill-sky-300 transition hover:scale-110"
                 src='{{ "butterfly" |> icon("phosphor", "duotone") }}'
@@ -41,6 +43,7 @@
               aria-label="{{ i18n.social.twitter_label }}"
               href="{{ i18n.social.twitter_profile_url }}"
               target="_blank"
+              rel="noopener"
             ><img
                 class="h-6 w-6 fill-black-600 dark:fill-zinc-50 transition hover:scale-110"
                 src='{{ "x-logo" |> icon("phosphor", "duotone") }}'
@@ -51,6 +54,7 @@
               aria-label="{{ i18n.social.github_label }}"
               href="{{ i18n.social.github_profile_url }}"
               target="_blank"
+              rel="noopener"
             ><img
                 class="h-6 w-6 fill-green-600 dark:fill-green-500 transition hover:scale-110"
                 src='{{ "github-logo" |> icon("phosphor", "duotone") }}'


### PR DESCRIPTION
3f7e4bd8b7f578097f6e15cc58c455c3315286b7
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 24 11:51:19 2025 +0900

### Make external link processor ignore social icons
External link processor puts arrow on any external link, but for social icons, we don't want that.
Make the processor ignore certain divs, using a special unused class no-external-icon, to be placed on the parent div.



cd258100f132aef1dd9f067a6889df3a913f4a76
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 24 11:49:09 2025 +0900

### Make title one step smaller per Ena's request
Fixes: #177



e792be4e86331077d7d9d826b51df33dbcab73ef
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 24 11:46:42 2025 +0900

### Update sharing text per Shiori's request
Fixes: #178



