### PR TITLE
Change specific categories in Ja side to be same as En side

### DIFF
--- a/_cms.ts
+++ b/_cms.ts
@@ -385,13 +385,13 @@ cms.collection({
         let allCats = [];
         const staticCategoriesByLang = {
           ja: [
-            "マイクロソフト365",
+            "Microsoft-365",
             "セキュリティ",
             "ネットワーク",
             "クラウド",
             "トラブルシューティング",
             "AI活用",
-            "ウィンドウズ",
+            "Windows",
             "周辺機器",
             "その他",
           ],

--- a/src/_data/featurecats.yml
+++ b/src/_data/featurecats.yml
@@ -1,4 +1,4 @@
-- key: マイクロソフト365
+- key: Microsoft-365
   id: cat1
   color: cyan
   image: /assets/cat1a-bg.jpg
@@ -34,7 +34,7 @@
   image: /assets/cat6-bg.jpg
   summary: >-
     AIの使用に関する記事です。AIツールを効果的に使用するためのヒントやコツを含みます。これらの記事は、eSoliaの専門家がこれらの製品や技術に関する経験に基づいて執筆しています。
-- key: ウィンドウズ
+- key: Windows
   id: cat7
   color: sky
   image: /assets/cat7-bg.jpg

--- a/src/posts/20250227-これがタイトル-ja.md
+++ b/src/posts/20250227-これがタイトル-ja.md
@@ -7,7 +7,7 @@ title: 水行末 雲来末 風来末
 description: Description だね
 image: /uploads/blog-esolia-pro-default.png
 author: 石川 絵奈
-category: マイクロソフト365
+category: Microsoft-365
 tags:
   - 一
   - 二

--- a/src/posts/20250402-sharepoint-online-移行後問題原因と対策-ja.md
+++ b/src/posts/20250402-sharepoint-online-移行後問題原因と対策-ja.md
@@ -10,7 +10,7 @@ description: >-
   Onlineへ移行した後に『ファイルが開けない！』というトラブルに直面していませんか？本記事では、SPOのフォルダー構造やURL制限、アクセス管理の違いを解説し、実践的な対策を紹介します。検索性を向上させるためのメタデータ管理方法も詳しく解説！ 
 image: /uploads/blog-esolia-pro-default.png
 author: Ena Ishikawa
-category: マイクロソフト365
+category: Microsoft-365
 comments: {}
 date: 2025-04-10T01:07:00.000Z
 last_modified: 2025-04-22T06:34:00.000Z

--- a/src/posts/20250403-使えるキーボードショートカット基本編-ja.md
+++ b/src/posts/20250403-使えるキーボードショートカット基本編-ja.md
@@ -8,7 +8,7 @@ title: 時短の第一歩はコレ！今日から使えるショートカット�
 description: 'WindowsとOffice 365の便利なショートカットキーを紹介。業務効率を向上させるための必須テクニックをチェック！ '
 image: /uploads/blog-esolia-pro-default.png
 author: Yorihisa Nakada
-category: マイクロソフト365
+category: Microsoft-365
 comments: {}
 date: 2025-03-28T03:12:00.000Z
 last_modified: 2025-04-10T10:40:00.000Z

--- a/src/posts/20250407-pc-簡単メンテナンス方法-ja.md
+++ b/src/posts/20250407-pc-簡単メンテナンス方法-ja.md
@@ -10,7 +10,7 @@ title: 'PCを元気に保つ簡単メンテナンス方法 '
 description: 簡単なメンテナスを定期的に行うことでPCのパフォーマンスを維持し、快適に使うことができる方法を紹介します！
 image: /uploads/blog-esolia-pro-default.png
 author: Sachiko Kosuge
-category: ウィンドウズ
+category: トラブルシューティング
 tags:
   - PC定期メンテ
 comments: {}

--- a/src/posts/20250408-outlookで予定表が同期されない-ja.md
+++ b/src/posts/20250408-outlookで予定表が同期されない-ja.md
@@ -9,8 +9,8 @@ last_modified: 2025-04-22T06:38:00.000Z
 title: Outlookで予定表が同期されない?!
 description: 'アプリ版OutLookのよくあるトラブルの解消法をご説明いたします。 '
 image: /uploads/blog-esolia-pro-default.png
-author: 'Kylie Cogley '
-category: マイクロソフト365
+author: 'Kylie Cogley'
+category: Microsoft-365
 tags:
   - Outlook
   - PCトラブル


### PR DESCRIPTION
f9d185b82f15bacb063fc7246d721156a2505b81
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 24 13:05:34 2025 +0900

### Change specific categories in Ja side to be same as En side
Per discussion in 20250424 mtg,
Japanese user opinion is that it's cooler to have Microsoft-365 and Windows category names in English, so here we attempt the change.

* Update cms to show them in picker
* Update featurecats data to have the preferred string instead of Japanese ones
* Update posts that have these categories set already, to the correct English one

Result - it works, and when creating a new post, the picker shows the categories from both languages, except for the ones that are the same, which are shown at the top with the Japanese. For the two changed ones, pick from the ja list.

Once the file is saved, the category list should be limited to those on either language.

Fixes: #180


![JRC CleanShot Microsoft Edge 2025-04-24-125530JST@2x](https://github.com/user-attachments/assets/312b0e3f-f4b1-4006-a5ce-e6052b338e62)

