### PR TITLE
Automate years in business

### DIFF
--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -1,6 +1,6 @@
 lang: en
 home:
-  welcome: Based in Tokyo and celebrating 25 years in business, bilingual IT outsourcing company <strong>eSolia</strong> shares practical, field-tested tips that are genuinely useful&mdash;drawn from years of hands-on experience.
+  welcome: Based in Tokyo and approaching YEARS_IN_BUSINESS years in business, bilingual IT outsourcing company <strong>eSolia</strong> shares practical, field-tested tips that are genuinely useful&mdash;drawn from years of hands-on experience.
   company: eSolia
   company_long: eSolia Inc.
   company_address: Shiodome City Center 5F (Work Styling), 1-5-2 Higashi-Shimbashi, Minato-ku, Tokyo, Japan, 105-7105

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -1,6 +1,6 @@
 lang: ja
 home:
-  welcome: 東京を拠点に25周年を迎えるバイリンガルITアウトソーシングの<strong>イソリア</strong>は、 長年の経験をもとに、現場の視点で選んだ「知って得するTips」を紹介しています。
+  welcome: 東京を拠点にYEARS_IN_BUSINESS周年を迎えるバイリンガルITアウトソーシングの<strong>イソリア</strong>は、 長年の経験をもとに、現場の視点で選んだ「知って得するTips」を紹介しています。
   company: イソリア
   company_long: 株式会社イソリア
   company_address: 〒105-7105 東京都港区東新橋1-5-2 汐留シティセンター5F（ワークスタイリング）

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -13,7 +13,7 @@
             {{# {{ metas.site }} #}}
           </h1>
           <p class="mt-6 text-base text-zinc-600 dark:text-zinc-400">
-            {{ i18n.home.welcome }}
+            {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
           </p>
           <div class="mt-6 flex gap-6 no-external-icon">
             <a


### PR DESCRIPTION
ff613cb81b87a5e3c8712e6e73a22edff153c25d
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 24 13:40:26 2025 +0900

### Automate years in business
Per discussion during mtg of 20250424
Can use js inside vento, so after pulling welcome blurb string from i18n data, replace a token in the string, with the number of years in business (this year, minus 1999).

`{{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}`

Fixes: #182




