### PR TITLE
Adjust prose block width to 70ch

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@2f3d7c6b9aa9a1856d7f62cc3ee62ad8a4495a39/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@24fa52c6b4a3f7e83c434ce52baa75127a192e6a/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@6a17aac8bb5b95ba9c22f0bc36645c17e56c9b5d/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.8/jsx-runtime.ts"
   },

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -8,7 +8,7 @@ bodyClass: body-post
       <div class="relative px-4 sm:px-8 lg:px-12">
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <div class="xl:relative">
-            <div class="mx-auto max-w-2xl">
+            <div class="mx-auto max-w-3xl">
               <a type="button" href="/{{ if lang === "en"}}en{{/if}}" aria-label="{{ i18n.nav.return_home }}" class="btn group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 transition lg:absolute lg:-left-5 lg:-mt-2 lg:mb-0 xl:-top-1.5 xl:left-0 xl:mt-0 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
               <img class="size-6 stroke-zinc-300 transition group-hover:stroke-zinc-700 dark:stroke-zinc-500 dark:group-hover:stroke-zinc-400" src="{{ "arrow-left" |> icon("phosphor", "duotone") }}" inline />
               </a>
@@ -44,7 +44,7 @@ bodyClass: body-post
                   {{ /if }}
                 </header>
                 <div
-                  class="prose prose-zinc sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
+                  class="prose max-w-[70ch] prose-zinc sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
                   data-mdx-content="true"
                 >
                 {{ content }}


### PR DESCRIPTION
2695208cc52b398d229ec54646bf57a46b5e9bc5
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 24 20:21:37 2025 +0900

### Update lume to latest v3 dev

* * * 

bd2519db9a007170793c383f3a6ab269bc55a652
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu Apr 24 20:20:32 2025 +0900

### Change prose width to 70ch from 65ch
This was a combination of the max width of the container, and prose's width.

Container - change to max-w-3xl
Prose - change div's class to max-w-[70ch] (easier to specify as class, than to try to override theme)

Fixes: #185

![JRC CleanShot Microsoft Edge 2025-04-24-202500JST@2x](https://github.com/user-attachments/assets/aeeb7070-ec66-4183-bdb1-7c950ddf7b74)

![JRC CleanShot Microsoft Edge 2025-04-24-202648JST@2x](https://github.com/user-attachments/assets/4b4f5bf5-006b-4dbf-8b7b-1d741cef3c3e)

