### PR TITLE
Test color overlay for top grid

### DIFF
--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -17,15 +17,19 @@
         {{
           set catImage = featurecats.find((item) => item.key === post.category)?.image
         }}
-        <div
+        {{# <div
           class="absolute inset-0 bg-{{ if catColor }}{{ catColor }}{{ else }}zinc{{ /if }}-500 opacity-80 rounded-2xl transition-opacity duration-300 mix-blend-color"
+        >
+        </div> #}}
+        <div
+          class="absolute inset-0 bg-zinc-50/40 dark:bg-zinc-800/60 rounded-2xl transition-opacity duration-300 mix-blend-luminosity dark:mix-blend-color"
         >
         </div>
         <img
           {{# src="{{ if catImage }}{{ catImage }}{{ else }}/assets/cat0-bg.jpg{{ /if }}" #}}
           src="{{ if post.image_top }}{{ post.image_top }}{{ else }}/assets/blog-esolia-pro-default-top.png{{ /if }}"
           alt=""
-          class="aspect-video w-full rounded-2xl bg-blend-overlay object-cover sm:aspect-2/1 lg:aspect-3/2 transition-opacity duration-300 filter dark:invert mix-blend-normal dark:mix-blend-luminosity"
+          class="aspect-video w-full rounded-2xl bg-blend-overlay object-cover sm:aspect-2/1 lg:aspect-3/2 transition-opacity duration-300 mix-blend-normal dark:mix-blend-luminosity"
           loading="lazy"
           fetchpriority="high"
           decoding="async"


### PR DESCRIPTION
c6ce0824e5b83682fdc5ece391cd5164ee1e7e09
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Fri Apr 25 13:58:47 2025 +0900

### Test color overlay for top grid
Putting no overlay at all is one choice if you have an art director who will stay on top of the design of the photos in terms of processing and their color space. Realistically that's not us. In lieu of that, it's best to put a slight "wash" overlay, over the photos, lending a designed look to the page. That way, no matter what photo is chosen, it will probably still look ok, without too much trouble.

In the screenshot, you can see an example. The default image is more of an illustration, with some graphic element. If you look at the photos one by one, you see that it looks pretty different, stylistically. However, with a slight gray "wash" (zinc color in tailwind-land, to match the other grays in the site) it reduces that feeling of "otherness".  

Fixes: #187



![JRC CleanShot Microsoft Edge 2025-04-25-135405JST@2x](https://github.com/user-attachments/assets/444a3b2d-e8d0-4fb8-9215-0373de423999)



