### PR TITLE
Add tooltip to search modal icon showing keyb shortcuts

### DIFF
--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -73,7 +73,8 @@ search:
   filter_by_author: Filter by Author
   filter_by_tag: Filter by Tag
   filter_by_category: Filter by Category
-  close_link: Close
+  close_link: Close (Esc)
+  tooltip: <kbd>Cmd</kbd>+<kbd>k</kbd> (Mac) or <br><kbd>Ctrl</kbd>+<kbd>k</kbd> (Win/Linux) <br>to Search
 comments:
   title: Comments
   description: |

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -75,7 +75,8 @@ search:
   filter_by_author: 著者でフィルター
   filter_by_tag: タグでフィルター
   filter_by_category: カテゴリーでフィルター
-  close_link: 閉じる
+  close_link: 閉じる (Esc)
+  tooltip: <kbd>Cmd</kbd>+<kbd>k</kbd> (Mac) または <br><kbd>Ctrl</kbd>+<kbd>k</kbd> (Win/Linux) <br>で検索
 comments:
   title: Comments
   description: |

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -173,7 +173,7 @@
                   </div>
                 {{ /if }}
                 <div
-                  class="pointer-events-auto z-50"
+                  class="pointer-events-auto z-50 relative group"
                 >
                   <button
                     type="button"
@@ -189,6 +189,11 @@
                       />
                     </span>
                   </button>
+                  <div
+                    class="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 px-2 py-1 bg-zinc-200 text-zinc-900 dark:bg-zinc-700 dark:text-zinc-200  text-sm rounded-md opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-300 pointer-events-none z-50 whitespace-nowrap before:content-[''] before:absolute before:bottom-full before:left-1/2 before:transform before:-translate-x-1/2 before:border-8 before:border-x-transparent before:border-t-0 before:border-b-zinc-200 dark:before:border-b-zinc-700"
+                  >
+                    {{ i18n.search.tooltip }}
+                  </div>
                 </div>
                 <div
                   class="pointer-events-auto z-50"


### PR DESCRIPTION
178e55ff767070382962dd71ec3e6ebdab3feb0f
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sat Apr 26 06:18:43 2025 +0900

### Add tooltip to search modal icon showing keyb shortcuts
Tailwind's native classes can be used to make a tooltip appear on hover, over the search modal icon in the top nav. Tooltip shows keyb shortcuts cmd-k / ctrl-k to open search modal. Also add "ESC" to close text so people get the idea you can use the ESC key.

The idea is to set the tooltip div with opacity-0 at first, then change to opacity-100 on hover, but you have to do it with "group". Another key was relative on the outer div, and absolute on the tooltip div. Button and tooltip divs are sibs.

```
<div class="pointer-events-auto z-50 relative group">
   <button class="group...">SEARCH SVG HERE</button>
   <div class="absolute top-full ...group-hover:opacity-100..."></div>
</div>
```

Fixes: #192

![JRC CleanShot Microsoft Edge 2025-04-26-062015JST@2x](https://github.com/user-attachments/assets/b47886fc-1050-41ae-8ace-843b8ea73116)


