### PR TITLE
Optimize top card images and minify html

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -55,7 +55,7 @@ import "npm:prismjs@1.29.0/components/prism-shell-session.js";
 import "npm:prismjs@1.29.0/components/prism-json5.js";
 
 // ERRORS: import purgecss from "lume/plugins/purgecss.ts";
-// import minify_html from "lume/plugins/minify_html.ts";
+import minify_html from "lume/plugins/minify_html.ts";
 // Change markdown-it configuration
 
 const markdown = {
@@ -206,7 +206,9 @@ site.use(googleFonts({
 
 site.use(attributes());
 site.use(picture(/* Options */));
-site.use(transformImages());
+site.use(transformImages({
+  cache: true, // Toggle cache
+}));
 
 site.use(prism({
   theme: [
@@ -318,7 +320,7 @@ site.use(cssBanner({
 }));
 site.use(shuffle());
 // ERRORS: site.use(purgecss());
-// site.use(minify_html());
+site.use(minify_html());
 site.use(inline());
 
 site.use(

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -9,6 +9,7 @@
   class="mx-auto mt-2 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3"
 >
   {{ for post of search.pages(`type=post lang=${lang}`, "date=desc", 9) }}
+    <!-- == CARD == -->
     <article class="flex flex-col items-start">
       <div class="relative w-full">
         {{
@@ -33,6 +34,7 @@
           loading="lazy"
           fetchpriority="high"
           decoding="async"
+          transform-images="avif webp jpg 600@2"
         >
         <div
           class="absolute inset-0 rounded-2xl ring-1 ring-gray-900/10 ring-inset"


### PR DESCRIPTION
652fbfdfdfce795b50dccabfbebeadd5a213886c
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 1 08:49:56 2025 +0900

### Optimize top page card images
Use transform-images to optimize images of top cards, to avif and webp, at 600px including retina versions.

Fixes: #198



ff2ba715b2e55f798b24354215a1ab4bec06f2cd
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 1 08:48:31 2025 +0900

### Minify html and set transform images to use cache

It's the default so there should be no difference, but I would rather declare specifically

