### PR TITLE
Style images in blog posts

### DIFF
--- a/src/posts/20250501-how-to-strengthen-password-management-in-your-company-en.md
+++ b/src/posts/20250501-how-to-strengthen-password-management-in-your-company-en.md
@@ -58,7 +58,7 @@ Password managers such as Zetetic [Codebook](https://www.zetetic.net/codebook/){
   
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of the main page in Zetetic Codebook" src="/uploads/202503h-password-management-(1).png" width="600px" transform-images="avif webp png jpeg 600@2">
-<figcaption class="text-left mt-2"><small>ex）the main page in Zetetic Codebook </small></figcaption>
+<figcaption class="text-left mt-2"><small>Fig）the main screen in Zetetic Codebook</small></figcaption>
 </figure>
 
 ### 4.Strengthen Access Control

--- a/src/styles.css
+++ b/src/styles.css
@@ -120,6 +120,10 @@ body article > div > p:first-of-type {
   @apply text-base md:text-lg lg:text-xl font-light leading-relaxed text-esoliablue-800 dark:text-esoliablue-200;
 }
 
+body article > div > figure > picture > img {
+  @apply shadow-md rounded-md;
+}
+
 /* MDN keyboard shortcut style for kbd tag */
 kbd {
   @apply bg-zinc-200 rounded border border-zinc-400 shadow-md text-zinc-800 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap


### PR DESCRIPTION
994397891ea232213b41a92e3617a2009641e892
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 1 15:09:22 2025 +0900

### Style images in blog posts
Images being shared were 'bare' inside the figure, and I had time to style them today. Added a subtle shadow to the images, so that it is easy to see / differentiate their border. This will add visual consistency as well.

Fixes: #200



9ca4e43aaa9dace2f87f30cc3ef26b8ba234e316
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 1 15:04:48 2025 +0900

### Fix small typo
Probably 'screen' is better word for inside an app



