### PR TITLE
Remove novalidate and pattern

### DIFF
--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -4,7 +4,6 @@
     class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40 group"
     name="frm"
     method="post"
-    novalidate
     id="newsletter"
     role="form"
     action="https://pro.dbflex.net/secure/gateway.aspx?action=WebToRecord&amp;app=15331&amp;table=1510483"
@@ -35,7 +34,6 @@
         placeholder="{{ i18n.newsletter.placeholder }}"
         aria-label="{{ i18n.newsletter.placeholder }}"
         required
-        xpattern="^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
         class="min-w-0 flex-auto appearance-none rounded-md border border-zinc-900/10 bg-white px-3 py-[calc(--spacing(2)-1px)] shadow-md shadow-zinc-800/5 placeholder:text-zinc-400 focus:border-sky-500 focus:ring-4 focus:ring-sky-500/10 focus:outline-hidden sm:text-sm dark:border-zinc-700 dark:bg-zinc-700/[0.15] dark:text-zinc-200 dark:placeholder:text-zinc-500 dark:focus:border-sky-400 dark:focus:ring-sky-400/10 invalid:[&:not(:placeholder-shown):not(:focus)]:border-red-500 peer"
       />
       <span class="mt-2 hidden text-sm text-red-500 peer-[&:not(:placeholder-shown):not(:focus):invalid]:block">


### PR DESCRIPTION
7e9385a1da474034ad51178a487b8a92a89aba2a
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Fri May 2 10:05:13 2025 +0900

### Remove novalidate and pattern
Rely instead on browser's validation and just remove novalidate and the regex.

Fixes: #205




