### PR TITLE
Add jsonLD meta for better SEO and clean up metadata in general

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -8,6 +8,7 @@ import { ja } from "npm:date-fns/locale/ja";
 import { getGitDate } from "lume/core/utils/date.ts";
 import { time } from "node:console";
 import { getCurrentVersion } from "lume/core/utils/lume_version.ts";
+import jsonLd from "lume/plugins/json_ld.ts";
 import readingInfo from "lume/plugins/reading_info.ts";
 import metas from "lume/plugins/metas.ts";
 import multilanguage from "lume/plugins/multilanguage.ts";
@@ -90,6 +91,7 @@ const site = lume({
 // Load First, order does not matter
 site.use(attributes());
 site.use(date({ locales: { enUS, ja } }));
+site.use(jsonLd());
 site.use(readingInfo());
 site.use(metas());
 site.use(multilanguage({

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@b32c3acc59051eb89faa3b79c532d638767213ff/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@05d0af5986378ca5f29a12922eadc9c30fd9b653/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@518ddc9734bf817e699b05e14ef21ed2e5efd78e/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.9/jsx-runtime.ts"
   },
@@ -27,7 +27,9 @@
         "recommended"
       ]
     },
-    "plugins": ["https://cdn.jsdelivr.net/gh/lumeland/lume@b32c3acc59051eb89faa3b79c532d638767213ff/lint.ts"]
+    "plugins": [
+      "https://cdn.jsdelivr.net/gh/lumeland/lume@05d0af5986378ca5f29a12922eadc9c30fd9b653/lint.ts"
+    ]
   },
   "fmt": {
     "exclude": [

--- a/src/_data.yml
+++ b/src/_data.yml
@@ -1,6 +1,11 @@
 logo: /assets/logo_horiz_darkblue_bgtransparent.svg
 extra_head: []
 lang: ja
+site:
+  author: "イソリア"
+  title: "Tech IT Easy Blog"
+  description: "株式会社イソリア IT Tips ブログのページ"
+  isolang: "ja-JP"
 topnav:
   links: 
     - text: アーカイブ
@@ -51,9 +56,10 @@ footernav:
 metas:
   lang: ja
   type: website
-  site: "イソリア IT Tips ブログ"
-  title: "=title || イソリア IT Tips ブログ ページ"
-  description: "=description || 株式会社イソリア IT Tips ブログのページ"
+  site: "=site.title || イソリア Tech IT Easy Blog"
+  title: "=title || イソリア Tech IT Easy Blog ブログ ページ"
+  description: "=description || イソリア Tech IT Easy Blog ブログより、一つの記事"
+  author: "イソリア"
   image: "=image || /assets/blog-esolia-pro-default.png"
   icon: "/assets/symbol_darkblue_bgtransparent_2.svg"
   keywords: ["イソリア", "ブログ", "ウェブログ", "プロ", "プロフェッショナル", "東京ITサービス", "日本語", "Tips"]
@@ -66,9 +72,28 @@ metas:
   "twitter:data1": "チーム イソリア"
   "twitter:label2": "読了目安"
   "twitter:data2": "$ .reading-info || 2 分"
+jsonLd:
+  "@type": WebSite
+  inLanguage: "=site.isolang"
+  isFamilyFriendly: true
+  url: =url
+  headline: =metas.title
+  name: =site.title
+  description: =metas.description
+  author:
+    "@type": Organization
+    name: =site.author
+  editor:
+      "@type": Organization
+      name: "=site.author"
 
 en:
   lang: en
+  site:
+    author: "eSolia"
+    title: "Tech IT Easy Blog"
+    description: "IT Tips Blog page from eSolia Inc., Tokyo, Japan"
+    isolang: "en-US"
   topnav:
     links: 
       - text: Archive
@@ -118,9 +143,10 @@ en:
   metas:
     lang: en
     type: website
-    site: "eSolia IT Tips Blog"
-    title: "=title || eSolia IT Tips Blog Page"
-    description: "=description || IT Tips Blog page from eSolia Inc., Tokyo, Japan"
+    site: "=site.title || eSolia Tech IT Easy Blog"
+    title: "=title || eSolia Tech IT Easy Blog Page"
+    description: "=description || An article from the Tech IT Easy Tips Blog page from eSolia Inc., Tokyo, Japan"
+    author: "eSolia"
     image: "=image || /assets/blog-esolia-pro-default.png"
     icon: "/assets/symbol_darkblue_bgtransparent_2.svg"
     keywords: ["eSolia", "blog", "tips", "weblog", "pro", "professional", "tokyo it service", "japan", "english"]
@@ -133,3 +159,17 @@ en:
     "twitter:data1": "Team eSolia"
     "twitter:label2": "Reading Time"
     "twitter:data2": "$ .reading-info || 2 min"
+  jsonLd:
+    "@type": WebSite
+    inLanguage: "=site.isolang"
+    isFamilyFriendly: true
+    url: =url
+    headline: =metas.title
+    name: =site.title
+    description: =metas.description
+    author:
+      "@type": Organization
+      name: =site.author
+    editor:
+      "@type": Organization
+      name: "=site.author"

--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -4,7 +4,6 @@ home:
   company: eSolia
   company_long: eSolia Inc.
   company_address: Shiodome City Center 5F (Work Styling), 1-5-2 Higashi-Shimbashi, Minato-ku, Tokyo, Japan, 105-7105
-  sitename: IT Tips Blog
 archive: 
   title: Archive
   description: Browse our archive of past articles. Use categories and tags to quickly find the topics that interest you, or search from the magnifying glass icon in the navigation bar at the top of the page.

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -4,7 +4,6 @@ home:
   company: イソリア
   company_long: 株式会社イソリア
   company_address: 〒105-7105 東京都港区東新橋1-5-2 汐留シティセンター5F（ワークスタイリング）
-  sitename: IT Tips Blog
 archive: 
   title: アーカイブ
   description: 過去の記事を一覧でご紹介しています。カテゴリやタグを活用して、興味のある情報にすばやくアクセスできます。または、ページ上部のナビゲーションバーにある虫眼鏡アイコンから検索してください。

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -13,7 +13,7 @@ script: /js/fathom-post-list-event.js
             <h1
               class="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100"
             >
-              <span class="font-light subpixel-antialiased">{{ i18n.home.sitename }}</span>
+              <span class="font-light subpixel-antialiased">{{ site.title }}</span>
               <br class="block sm:hidden">
               <span
                 class="bg-gradient-to-r from-esoliablue-800 via-esoliablue-700 to-esoliablue-900 dark:from-esoliablue-600 dark:via-esoliablue-500 dark:to-esoliablue-700 bg-clip-text text-transparent"

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -5,7 +5,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ it.title || metas.title }} - {{ metas.site }}</title>
+    <title>{{ it.title || metas.title }} - {{ site.title }}</title>
 
     <meta name="supported-color-schemes" content="light dark">
     <meta
@@ -28,29 +28,17 @@
       rel="alternate"
       href="/feed.xml"
       type="application/atom+xml"
-      title="{{ metas.site }}"
+      title="{{ site.title }}"
     >
     <link
       rel="alternate"
       href="/feed.json"
       type="application/json"
-      title="{{ metas.site }}"
+      title="{{ site.title }}"
     >
     <link rel="canonical" href="{{ url |> url(true) }}">
     {{# Various js, such as Alpine and Fathom and the theme toggle script #}}
     <script src="/js/main.js?cb={{ cacheBuster }}" type="module" defer></script>
-
-    <!-- Splide CSS -->
-    {{# <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@splidejs/splide@latest/dist/css/splide.min.css"
-    > #}}
-
-    <!-- Splide JS -->
-    {{# <script
-      src="https://cdn.jsdelivr.net/npm/@splidejs/splide@latest/dist/js/splide.min.js"
-    ></script> #}}
-
     <link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
     {{ it.extra_head?.join("\n") }}
   </head>

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -12,7 +12,7 @@
             <span class="font-light subpixel-antialiased">{{ i18n.home.sitename }}</span>
             {{# {{ metas.site }} #}}
           </h1>
-          <p class="mt-6 text-base text-zinc-600 dark:text-zinc-400">
+          <p class="mt-6 text-base text-zinc-800 dark:text-zinc-400">
             {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
           </p>
           <div class="mt-6 flex gap-6 no-external-icon">

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -9,8 +9,7 @@
           >
             {{# <span class="font-light">{{ i18n.home.company }}</span>
             <br class="block sm:hidden"> #}}
-            <span class="font-light subpixel-antialiased">{{ i18n.home.sitename }}</span>
-            {{# {{ metas.site }} #}}
+            <span class="font-light subpixel-antialiased">{{ site.title }}</span>
           </h1>
           <p class="mt-6 text-base text-zinc-800 dark:text-zinc-400">
             {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "EITTB",
-  "name": "eSolia IT Tips Blog",
+  "short_name": "ETIEB",
+  "name": "eSolia Tech IT Easy Blog",
   "start_url": "/",
   "background_color": "#2d2f63",
   "theme_color": "#ffbc68",

--- a/src/posts/_data.yml
+++ b/src/posts/_data.yml
@@ -16,6 +16,15 @@ metas:
   "article:author": "=author"
   "article:section": "=article-type"
   "article:tag": "=tags" 
+jsonLd:
+  "@type": blogPosting
+  image: "=image || /assets/blog-esolia-pro-default.png"
+  "datePublished": "=date"
+  "dateModified": "=last_modified"
+  keywords: "=tags"
+  author:
+    "@type": Person
+    name: "=author"
 
 en: 
   lang: en
@@ -36,3 +45,12 @@ en:
     "article:author": "=author"
     "article:section": "=article-type"
     "article:tag": "=tags"
+  jsonLd:
+    "@type": blogPosting
+    image: "=image || /assets/blog-esolia-pro-default.png"
+    "datePublished": "=date"
+    "dateModified": "=last_modified"
+    keywords: "=tags"
+    author:
+      "@type": Person
+      name: "=author"

--- a/src/styles.css
+++ b/src/styles.css
@@ -117,7 +117,7 @@
 }
 
 body article > div > p:first-of-type {
-  @apply text-base md:text-lg lg:text-xl font-light leading-relaxed text-esoliablue-800 dark:text-esoliablue-200;
+  @apply text-base text-lg lg:text-xl font-light leading-relaxed text-zinc-800 dark:text-zinc-200;
 }
 
 body article > div > figure > picture > img {


### PR DESCRIPTION
310f1897578d49426683e4e213388953b88ccc77
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sat May 3 10:56:48 2025 +0900

### Add jsonLD plugin and configure it for better SEO
jsonLd plugin was added, but there were a number of bugs with it (e.g. field aliases not working, keywords not being picked up). Worked with Oscar to test so he could figure out and fix the problem. Upgraded after and tested again, it worked.

Took the opportunity to clean up data files for both metas and field aliases, adding a node in `src/_data.yml` for the site. Migrated various references to various references to the site name, but there are still a few areas where it must be hard coded like manifest.json. It's cleaner, at least.

A jsonLD meta is now present on all pages which should be good for SEO, but for blog pages, it's set specific to those, with an @type of blogPosting, per the schema, and also has the post's keywords and so on.

Fixes: #202



96ef4c1a56eec35393234dd86efc2bb3217a090b
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sat May 3 10:43:57 2025 +0900

### Increase contrast
Ena pointed out a couple areas that were a little too gray and hard to read so, update those to a darker zinc, to match the body color.



26f5019b4a6e33abe54db0c9838c02f803206a5b
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sat May 3 10:40:26 2025 +0900

### Upgrade lume 3 dev to latest
Oscar fixed a couple bugs in meta and jsonld plugins, re not picking up field aliases etc after recent other upgrades. Tested and now appears ok.



