### PR TITLE
Various font, contrast, and color formatting enhancements

### DIFF
--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -19,7 +19,7 @@ script: /js/fathom-post-list-event.js
                 class="bg-gradient-to-r from-esoliablue-800 via-esoliablue-700 to-esoliablue-900 dark:from-esoliablue-600 dark:via-esoliablue-500 dark:to-esoliablue-700 bg-clip-text text-transparent"
               >{{ i18n.archive.title }}</span>
             </h1>
-            <p class="mt-6 text-base text-zinc-600 dark:text-zinc-400">
+            <p class="mt-6 text-base text-zinc-800 dark:text-zinc-400">
               {{ i18n.archive.description }}
             </p>
 

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -23,17 +23,17 @@ bodyClass: body-post
                   </h1>
 
                   {{ if toc.length }}
-                    <nav class="max-w-2xl mt-4 mr-auto bg-white prose dark:prose-invert dark:bg-zinc-800 p-6 rounded-lg shadow-md">
+                    <nav class="max-w-2xl mt-4 mr-auto bg-white prose prose-zinc dark:prose-invert dark:bg-zinc-800 p-6 rounded-lg shadow-md prose-a:transition">
                       <h2 class="mb-1 font-light">{{ i18n.nav.toc }}</h2>
-                      <ul class="list-disc list-inside space-y-2 text-sm font-light">
+                      <ul class="list-disc list-inside space-y-2 text-sm">
                         {{ for item of toc }}
-                        <li class="font-light">
-                          <a class="text-zinc-500 hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
+                        <li class="">
+                          <a class="font-light text-zinc-700 hover:text-sky-600 dark:text-zinc-200 dark:hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
                           {{ if item.children.length }}
                           <ul>
                             {{ for child of item.children }}
                             <li>
-                              <a href="#{{ child.slug }}">{{ child.text }}</a>
+                              <a class="font-light text-zinc-700 hover:text-sky-600 dark:text-zinc-200 dark:hover:text-sky-500" href="#{{ child.slug }}">{{ child.text }}</a>
                             </li>
                             {{ /for }}
                           </ul>

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -183,7 +183,7 @@
                   >
                     <span>
                       <img
-                        class="h-5 w-5 fill-esoliaamber-500 stroke-esoliaamber-800 transition group-hover:fill-esoliaamber-600 group-hover:stroke-esoliaamber-900 transition hover:scale-110"
+                        class="h-5 w-5 fill-esoliaamber-500 stroke-esoliaamber-800 dark:fill-sky-300 dark:stroke-sky-500 transition group-hover:fill-esoliaamber-600 group-hover:stroke-esoliaamber-900 dark:group-hover:fill-sky-400 dark:group-hover:stroke-sky-600 transition hover:scale-110"
                         src='{{ "magnifying-glass" |> icon("phosphor", "duotone") }}'
                         inline
                       />
@@ -208,14 +208,14 @@
                   >
                     <span x-show="!darkMode">
                       <img
-                        class="h-5 w-5 fill-esoliaamber-500 stroke-esoliaamber-800 transition group-hover:fill-esoliaamber-600 group-hover:stroke-esoliaamber-900 transition hover:scale-110"
+                        class="h-5 w-5 fill-esoliaamber-500 stroke-esoliaamber-800 transition group-hover:fill-sky-400 group-hover:stroke-sky-600 transition hover:scale-110"
                         src='{{ "sun" |> icon("phosphor", "duotone") }}'
                         inline
                       />
                     </span>
                     <span x-show="darkMode">
                       <img
-                        class="h-5 w-5 fill-sky-300 stroke-sky-500 transition group-hover:fill-sky-400 group-hover:stroke-sky-700 transition hover:scale-110"
+                        class="h-5 w-5 fill-sky-300 stroke-sky-500 transition group-hover:fill-esoliaamber-600 group-hover:stroke-esoliaamber-900 transition hover:scale-110"
                         src='{{ "moon-stars" |> icon("phosphor", "duotone") }}'
                         inline
                       />

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,7 @@
 @plugin "@tailwindcss/typography";
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/container-queries";
+/* @plugin "tailwindcss-opentype"; */
 /* @plugin "daisyui@5.0.27"; */
 /* @plugin "flyonui@2.0.0"; */
 /* @plugin "tailwind-every-layout@latest"; */
@@ -70,6 +71,8 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
+  --default-font-feature-settings: "kern" 1, "liga" 1, "clig" 1, "calt" 1, "palt" 0, "zero" 1, "sups" 0, "frac" 0, "ordn" 0;
+  --default-font-variant-ligatures: common-ligatures;
   --header-top: 1rem;
   --font-sans: textface, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;


### PR DESCRIPTION
1fca7849c7ac39f59b16f69cce1c80ebc82c28d2
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sun May 4 11:10:11 2025 +0900

### Fix table of contents contrast and colors
Toc was kind of all over the place in terms of color formatting, so made it consistent. Now the anchors all are set to dark gray one step lighter than body text, with a light weight font, and hover to sky.

Fixes: #208



367c9fb69a1b331f5a51e5cba92d2dedbf93981e
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sun May 4 11:08:50 2025 +0900

### Fix color logic of search and mode toggle
Color logic design needed improved, so made that consistent for the search and light/dark mode toggles.

That is, in light mode, search stays amber on hover, but the toggle hovers to sky, to indicate darkness.
Conversely, in dark mode, search stays sky on hover, but the toggle hovers to amber, to indicate lightness.

Fixes: #210



5b6ff4e475bcdd1479d0a9aceea32d357e4815c7
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sun May 4 11:06:52 2025 +0900

### Fix contrast on archive pages
Increase contrast on archive pages to make it consistent with top page.
Other contrast areas seem ok.

Fixes: #208



d2b7c9e3dc0fafb0e1810f9994e6d1337b40794a
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sun May 4 11:05:01 2025 +0900

### Enable opentype features
Opentype fonts allow ligatures and kerning to be set, so enable those for better typography.

Fixes: #209



