### PR TITLE
Install check_urls and lume-bar

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -37,6 +37,7 @@ import source_maps from "lume/plugins/source_maps.ts";
 // Modify URLs
 import basePath from "lume/plugins/base_path.ts";
 import resolveUrls from "lume/plugins/resolve_urls.ts";
+import checkUrls from "lume/plugins/check_urls.ts";
 
 // Images
 import favicon from "lume/plugins/favicon.ts";
@@ -256,6 +257,9 @@ site.use(source_maps());
 // Modify URLs
 site.use(basePath());
 site.use(resolveUrls());
+site.use(checkUrls({
+  external: true,
+}));
 
 // Images 
 site.use(favicon({

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@05d0af5986378ca5f29a12922eadc9c30fd9b653/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@518ddc9734bf817e699b05e14ef21ed2e5efd78e/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@f9227cd040b3eabc67ca70f07f58b8d233e5d8fd/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@ba24aa8acb3eefb1cc0ef88c198c468793bcf286/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.9/jsx-runtime.ts"
   },
   "tasks": {
@@ -28,7 +28,7 @@
       ]
     },
     "plugins": [
-      "https://cdn.jsdelivr.net/gh/lumeland/lume@05d0af5986378ca5f29a12922eadc9c30fd9b653/lint.ts"
+      "https://cdn.jsdelivr.net/gh/lumeland/lume@f9227cd040b3eabc67ca70f07f58b8d233e5d8fd/lint.ts"
     ]
   },
   "fmt": {

--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -13,7 +13,7 @@ social:
   share_title: Share this post on social media!
   linkedin_label: Follow on LinkedIn
   linkedin_share: Share on LinkedIn
-  linkedin_profile_url: https://www.linkedin.com/company/esolia
+  linkedin_profile_url: https://www.linkedin.com/company/esolia-inc
   twitter_label: Follow on X Twitter
   twitter_profile_url: https://x.com/esolia_inc
   bluesky_label: Follow on Bluesky

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -13,7 +13,7 @@ social:
   share_title: SNSでシェアしてみませんか？
   linkedin_label: LinkedInでフォローする
   linkedin_share: LinkedInでシェアする
-  linkedin_profile_url: https://www.linkedin.com/company/esolia
+  linkedin_profile_url: https://www.linkedin.com/company/esolia-inc
   twitter_label: X Twitterでフォローする
   twitter_share: X Twitterでシェアする
   twitter_profile_url: https://x.com/esolia_inc


### PR DESCRIPTION
99117b8f996206be6ab80e4e35277daa7a1c2906
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 5 07:18:18 2025 +0900

### Install check_urls and lume-bar
Lume-bar is a new feature that allows you to more easily see certain plugin output from a little console in dev mode, similar to what Astro has. Now it works with check_urls plugin only.

You can set check_urls to check external, and it found that our linkedin profile link was broken, so I fixed it.



