### PR TITLE
Various cosmetic edits per issue 214

### DIFF
--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -1,6 +1,6 @@
 lang: ja
 home:
-  welcome: 東京を拠点にYEARS_IN_BUSINESS周年を迎えるバイリンガルITアウトソーシングの<strong>イソリア</strong>は、 長年の経験をもとに、現場の視点で選んだ「知って得するTips」を紹介しています。
+  welcome: 東京を拠点にYEARS_IN_BUSINESS周年を迎えるバイリンガルITアウトソーシングの<strong>イソリア</strong>は<br class="hidden md:inline">長年の経験をもとに、現場の視点で選んだ「知って得するTips」を紹介しています。
   company: イソリア
   company_long: 株式会社イソリア
   company_address: 〒105-7105 東京都港区東新橋1-5-2 汐留シティセンター5F（ワークスタイリング）

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -15,9 +15,9 @@ bodyClass: body-post
               </a>
               <article data-pagefind-body data-title="{{ title }}" data-pagefind-index-attrs="data-title">
                 <header class="flex flex-col -top-4">
-                  {{ include "templates/post-details.vto" { elapsed: elapseddays } }}
+                  {{# {{ include "templates/post-details.vto" { elapsed: elapseddays } }} #}}
                   <h1
-                    class="mt-6 text-3xl font-bold tracking-tight text-zinc-800 sm:text-4xl dark:text-zinc-100 subpixel-antialiased"
+                    class="mt-1 text-3xl font-bold tracking-tight text-zinc-800 sm:text-4xl dark:text-zinc-100 subpixel-antialiased"
                   >
                     {{ title }}
                   </h1>
@@ -61,8 +61,9 @@ bodyClass: body-post
                   </dl>
                 </aside>
                 {{ /if }}
+                {{ include "templates/post-details.vto" { elapsed: elapseddays } }}
                 {{ include "templates/post-share.vto" }}
-                {{ include "templates/post-image.vto" }}
+                {{# {{ include "templates/post-image.vto" }} #}}
                 {{# <nav class="page-pagination pagination">
                   <ul>
                     {{- set previousPost = search.previousPage(url, "type=post") }}

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -23,7 +23,7 @@ bodyClass: body-post
                   </h1>
 
                   {{ if toc.length }}
-                    <nav class="max-w-2xl mt-4 mr-auto bg-white prose prose-zinc dark:prose-invert dark:bg-zinc-800 p-6 rounded-lg shadow-md prose-a:transition">
+                    <nav class="max-w-2xl mt-4 mr-auto bg-zinc-50 prose prose-zinc dark:prose-invert dark:bg-zinc-800 p-6 rounded-lg shadow-md prose-a:transition">
                       <h2 class="mb-1 font-light">{{ i18n.nav.toc }}</h2>
                       <ul class="list-disc list-inside space-y-2 text-sm">
                         {{ for item of toc }}

--- a/src/_includes/templates/post-share.vto
+++ b/src/_includes/templates/post-share.vto
@@ -7,10 +7,10 @@
       class="text-gray-600 text-center"
     >
       <span class="font-bold">{{ i18n.social.share_ask }}</span><br>
-      <span class="underline underline-offset-4 decoration-fuchsia-500/60 decoration-wavy">{{ i18n.social.share_title }}</span>
+      <span class="font-base">{{ i18n.social.share_title }}</span>
     </p>
   </div>
-  <div class="mt-1 flex justify-center gap-x-4 pb-3 no-external-icon">
+  <div class="mt-0 flex justify-center gap-x-4 pb-3 no-external-icon">
     <a
       class="group -m-1 p-1"
       aria-label="{{ i18n.social.linkedin_share }}"

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -85,14 +85,14 @@
                 </div>
                 <nav class="pointer-events-auto hidden md:block">
                   <ul
-                    class="flex rounded-full bg-esoliaamber-500/90 px-3 text-sm font-medium ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:ring-white/10 divide-x-1 divide-zinc-50/50 dark:divide-zinc-200/50"
+                    class="flex rounded-full bg-sky-700/90 px-3 text-sm font-medium ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:ring-white/10 divide-x-1 divide-zinc-50/50 dark:divide-zinc-200/50"
                     role="menubar"
                     aria-label="{{ i18n.nav.aria_label }}"
                   >
                     {{- for item of it.topnav.links }}
                       <li>
                         <a
-                          class="group relative block whitespace-nowrap px-3 py-2 transition text-zinc-50 dark:text-zinc-200 hover:text-sky-400 dark:hover:text-sky-500 {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
+                          class="group relative block whitespace-nowrap px-3 py-2 transition text-zinc-50 dark:text-zinc-200 hover:text-esoliaamber-400 dark:hover:text-esoliaamber-500 {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
                           href="{{ item.href }}"
                           {{- if item.target }}target="{{ item.target }}"{{ /if -}}
                           {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
@@ -156,11 +156,11 @@
                     <button
                       type="button"
                       aria-label="Toggle language"
-                      class="group rounded-full bg-esoliaamber-500/90 px-3 py-2 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50 text-sm font-medium dark:group-hover:text-zinc-100"
+                      class="group rounded-full bg-sky-700/90 px-3 py-2 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20 z-50 text-sm font-medium dark:group-hover:text-zinc-100"
                     >
                       {{- for alt of alternates }}{{ if alt.lang !== lang }}
                           <a
-                            class="group text-zinc-50 dark:text-zinc-200 hover:text-sky-400 dark:hover:text-sky-500"
+                            class="group text-zinc-50 dark:text-zinc-200 hover:text-esoliaamber-400 dark:hover:text-esoliaamber-500"
                             href="{{ alt.url }}"
                             title="{{ alt.title |> escape }}"
                           >

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -6,7 +6,7 @@
       <div class="relative px-4 sm:px-8 lg:px-12">
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <div class="top-(--avatar-top,--spacing(3)) w-full">
-            <div class="relative mt-20">
+            <div class="relative mt-12">
               <a
                 aria-label="{{ i18n.nav.return_home }}"
                 type="button"

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -23,7 +23,7 @@
         >
         </div> #}}
         <div
-          class="absolute inset-0 bg-zinc-50/30 dark:bg-zinc-800/60 rounded-2xl transition-opacity duration-300 mix-blend-luminosity dark:mix-blend-color"
+          class="absolute inset-0 bg-white/10 dark:bg-zinc-800/60 rounded-2xl transition-opacity duration-300 mix-blend-luminosity dark:mix-blend-color"
         >
         </div>
         <img

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -1,5 +1,5 @@
 <!-- ===== top-welcome-header.vto TEMPLATE START ===== -->
-<div class="mt-9 sm:px-8">
+<div class="mt-6 sm:px-8">
   <div class="mx-auto w-full max-w-7xl lg:px-8">
     <div class="relative px-4 sm:px-8 lg:px-12">
       <div class="mx-auto max-w-2xl lg:max-w-5xl">

--- a/src/posts/20250430-it担当者必見-社内のパスワード管理を強化する方法-ja.md
+++ b/src/posts/20250430-it担当者必見-社内のパスワード管理を強化する方法-ja.md
@@ -6,7 +6,7 @@ lang: ja
 id: 202503h-password-management
 date: 2025-04-30T01:38:06.024Z
 last_modified: 2025-05-01T11:59:00.000Z
-title: IT担当者必見！社内のパスワード管理を強化する方法
+title: IT担当者必見！<br>社内のパスワード管理を強化する方法
 description: >-
   企業のパスワード管理を強化するための具体的な方法を解説。多要素認証（MFA）、パスワードポリシーの策定、パスワードマネージャーの活用など、IT担当者・決裁者向けに実践的な対策を紹介します。 
 image: /uploads/202503h-password-management-ja.jpeg


### PR DESCRIPTION
c58073e74f2a6cc63e1a398a281eed0580cad294
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 16:44:40 2025 +0900

### Set TOC background to grey (zinc)
Set the TOC background to zinc to be consistent with other parts of the UI.

The numbers are there if you put them there in the title. So, if you don't want numbers, don't add.

WIP #214



5d8c658cdb917d525afd74ac7673099c3a0477eb
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 16:41:28 2025 +0900

### Add hard break to split title
Added one as an example.

You can add a br tag in the title, and it will add a br to the title. The problem is, when you see the post on mobile, it gets messy quickly, if you add a lot of br tags.

You can add one main br tag for the main break, and then add wbr tags to handle the mobile sizes. The wbr tag is a conditional tag and I like to remember it as "will break". This lets you tell the browser where to break when the width of the text container is constrained.

You should add this to the authoring guide because you'll need to test on various screen sizes.

WIP #214



909fdc26ee14baffc024c00a9686b7988567b46f
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 16:33:21 2025 +0900

### Remove text decoration from share ask section
Removing the decoration means too much space is open, so reduce margin to address that

WIP #214



f2255b9e7083e4092ccd2253896b6ca31ab3dc93
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 16:32:12 2025 +0900

### Various visual and positional changes to post
move post details to bottom above share
fix title top margin which looks bad due to the details move - title now aligns with back button again
hide post image

WIP #214



1c071687fc6e42bb324ffdbe2cda582cbd857a6b
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 16:17:52 2025 +0900

### Change overlay to very low opacity and white
This does not resolve the problem of choosing an image incorrectly. If you select an image that is actually a graphic design, this problem will persist. If you choose photos, the slight overlay will even out the tone of the photos making the selection job a little easier. The current image for the password manager post already has a strong overlay, so that is why you are seeing what you are seeing.

Please specify rules about picking images for these, and I would say, stick to photos, not graphic design images, because there is no way you can control what they look like. Photos are going to be a little easier to handle.

WIP #214



c96033006f58996d709ee499105d94caa96769cf
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 16:10:14 2025 +0900

### Conditional break at md breakpoint and above
WIP #214



45c18b71c145ce262079466314972f7aeced1bd8
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 15:56:28 2025 +0900

### Update nav lozenge color to medium-dark sky
eSolia's logo navy looks too dark, almost black, and a light version looks 'washed' so, like many other UI elements in this design, I change it to a medium dark shade of 'sky'.

WIP #214



ec4d4795f5fa22d1ce8c6f5b4fd6f662fb1c5d55
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 12 15:45:11 2025 +0900

### Tighten up vertical spacing on top
It's not a simple matter to just put the large logo in the nav bar, considering mobile devices. And from a branding perspective I don't want to get rid of the large logo on top. 

There may be a way to improve, but it will take time to design properly and is not going to be phase 1. Maybe we can push the large logo to the right on larger screens, but this is more complicated than it seems. 

For now I tightened up the vertical spacing so scrolling gets to the text more quickly.

WIP #214



