### PR TITLE
Various visual tweaks

### DIFF
--- a/src/_data.yml
+++ b/src/_data.yml
@@ -3,17 +3,11 @@ extra_head: []
 lang: ja
 site:
   author: "イソリア"
-  title: "Tech IT Easy Blog"
+  title: "Tech It Easy Blog"
   description: "株式会社イソリア IT Tips ブログのページ"
   isolang: "ja-JP"
 topnav:
   links: 
-    - text: アーカイブ
-      href: /archive
-      target: _self
-      icon: archive
-      aria_label: サイト内リンク
-      title: アーカイブページへのリンク
     - text: イソリア
       href: https://esolia.co.jp
       target: _blank
@@ -56,9 +50,9 @@ footernav:
 metas:
   lang: ja
   type: website
-  site: "=site.title || イソリア Tech IT Easy Blog"
-  title: "=title || イソリア Tech IT Easy Blog ブログ ページ"
-  description: "=description || イソリア Tech IT Easy Blog ブログより、一つの記事"
+  site: "=site.title || イソリア Tech It Easy Blog"
+  title: "=title || イソリア Tech It Easy Blog ブログ ページ"
+  description: "=description || イソリア Tech It Easy Blog ブログより、一つの記事"
   author: "イソリア"
   image: "=image || /assets/blog-esolia-pro-default.png"
   icon: "/assets/symbol_darkblue_bgtransparent_2.svg"
@@ -91,17 +85,11 @@ en:
   lang: en
   site:
     author: "eSolia"
-    title: "Tech IT Easy Blog"
+    title: "Tech It Easy Blog"
     description: "IT Tips Blog page from eSolia Inc., Tokyo, Japan"
     isolang: "en-US"
   topnav:
     links: 
-      - text: Archive
-        href: /en/archive
-        target: _self
-        icon: archive
-        aria_label: Site internal link
-        title: Link to the Archive page
       - text: eSolia Inc.
         href: https://esolia.com
         target: _blank
@@ -143,8 +131,8 @@ en:
   metas:
     lang: en
     type: website
-    site: "=site.title || eSolia Tech IT Easy Blog"
-    title: "=title || eSolia Tech IT Easy Blog Page"
+    site: "=site.title || eSolia Tech It Easy Blog"
+    title: "=title || eSolia Tech It Easy Blog Page"
     description: "=description || An article from the Tech IT Easy Tips Blog page from eSolia Inc., Tokyo, Japan"
     author: "eSolia"
     image: "=image || /assets/blog-esolia-pro-default.png"

--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -4,6 +4,8 @@ home:
   company: eSolia
   company_long: eSolia Inc.
   company_address: Shiodome City Center 5F (Work Styling), 1-5-2 Higashi-Shimbashi, Minato-ku, Tokyo, Japan, 105-7105
+  skip_to_main_content_label: Skip to main content
+  skip_to_main_content_aria: Skip to main content skip link
 archive: 
   title: Archive
   description: Browse our archive of past articles. Use categories and tags to quickly find the topics that interest you, or search from the magnifying glass icon in the navigation bar at the top of the page.

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -4,6 +4,8 @@ home:
   company: イソリア
   company_long: 株式会社イソリア
   company_address: 〒105-7105 東京都港区東新橋1-5-2 汐留シティセンター5F（ワークスタイリング）
+  skip_to_main_content_label: メインコンテンツへスキップ
+  skip_to_main_content_aria: メインコンテンツへスキップするためのリンク
 archive: 
   title: アーカイブ
   description: 過去の記事を一覧でご紹介しています。カテゴリやタグを活用して、興味のある情報にすばやくアクセスできます。または、ページ上部のナビゲーションバーにある虫眼鏡アイコンから検索してください。

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -19,7 +19,7 @@ script: /js/fathom-post-list-event.js
                 class="bg-gradient-to-r from-esoliablue-800 via-esoliablue-700 to-esoliablue-900 dark:from-esoliablue-600 dark:via-esoliablue-500 dark:to-esoliablue-700 bg-clip-text text-transparent"
               >{{ i18n.archive.title }}</span>
             </h1>
-            <p class="mt-6 text-base text-zinc-800 dark:text-zinc-400">
+            <p class="mt-6 text-base text-zinc-900 dark:text-zinc-400">
               {{ i18n.archive.description }}
             </p>
 

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -4,14 +4,14 @@ bodyClass: body-tag
 script: /js/fathom-post-list-event.js
 ---
 <!-- ===== archive.vto LAYOUT START ===== -->
-<main class="flex-auto">
+<main id="main-content" class="flex-auto">
   <div class="mt-16 sm:mt-32 sm:px-8">
     <div class="mx-auto w-full max-w-full lg:px-8">
       <div class="relative px-4 sm:px-8 lg:px-12">
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl">
             <h1
-              class="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100"
+              class="text-4xl font-bold tracking-tight text-zinc-900 sm:text-5xl dark:text-zinc-100"
             >
               <span class="font-light subpixel-antialiased">{{ site.title }}</span>
               <br class="block sm:hidden">

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -11,11 +11,11 @@ bodyClass: body-tag
           <header class="max-w-2xl space-y-10">
             <div class=""><a href="/archive/">{{ i18n.nav.back }}</a></div>
             <h1
-              class="text-4xl font-thin tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100 subpixel-antialiased"
+              class="text-4xl font-thin tracking-tight text-zinc-900 sm:text-5xl dark:text-zinc-100 subpixel-antialiased"
             >
               {{ title }}
             </h1>
-            <p class="text-zinc-800 dark:text-zinc-200">{{ summary }}</p>
+            <p class="text-zinc-900 dark:text-zinc-200">{{ summary }}</p>
             {{
               include "templates/post-list.vto" { postslist: search.pages(search_query) }
             }}

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -3,7 +3,7 @@ layout: layouts/base.vto
 bodyClass: body-tag
 ---
 <!-- ===== archive_result.vto LAYOUT START ===== -->
-<main class="flex-auto">
+<main id="main-content" class="flex-auto">
   <div class="mt-16 sm:mt-32 sm:px-8">
     <div class="mx-auto w-full max-w-full lg:px-8">
       <div class="relative px-4 sm:px-8 lg:px-12">

--- a/src/_includes/layouts/base-old.vto
+++ b/src/_includes/layouts/base-old.vto
@@ -158,7 +158,7 @@
         </div> #}}
       </div>
 
-      <main class="{{ it.bodyClass }}">
+      <main id="main-content" class="{{ it.bodyClass }}">
         {{ content }}
       </main>
     </div>

--- a/src/_includes/layouts/base-old.vto
+++ b/src/_includes/layouts/base-old.vto
@@ -37,7 +37,7 @@
     <script src="/js/main.js" type="module"></script>
     {{ it.extra_head?.join("\n") }}
   </head>
-  <body class="m-auto p-8 pb-32 max-w-6xl md:px-16 text-zinc-800 bg-zinc-50">
+  <body class="m-auto p-8 pb-32 max-w-6xl md:px-16 text-zinc-900 bg-zinc-50">
     {{ include "templates/top-nav.vto" }}
 
     <nav class="navbar">

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -43,6 +43,7 @@
     {{ it.extra_head?.join("\n") }}
   </head>
   <body class="flex h-full bg-zinc-50 dark:bg-black">
+    {{ include "templates/skiplink.vto" }}
     <!-- Container start -->
     <div class="flex w-full">
       <div class="fixed inset-0 flex justify-center sm:px-8">

--- a/src/_includes/layouts/page.vto
+++ b/src/_includes/layouts/page.vto
@@ -3,7 +3,7 @@ layout: layouts/base.vto
 bodyClass: body-tag
 ---
 <!-- ===== page.vto LAYOUT START ===== -->
-<main class="flex-auto">
+<main id="main-content" class="flex-auto">
   <div class="mt-16 sm:px-8 lg:mt-32">
     <div class="mx-auto w-full max-w-7xl lg:px-8">
       <div class="relative px-4 sm:px-8 lg:px-12">

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -17,7 +17,7 @@ bodyClass: body-post
                 <header class="flex flex-col -top-4">
                   {{# {{ include "templates/post-details.vto" { elapsed: elapseddays } }} #}}
                   <h1
-                    class="mt-1 text-3xl font-bold tracking-tight text-zinc-800 sm:text-4xl dark:text-zinc-100 subpixel-antialiased"
+                    class="mt-1 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl dark:text-zinc-100 subpixel-antialiased"
                   >
                     {{ title }}
                   </h1>

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -3,7 +3,7 @@ layout: layouts/base.vto
 bodyClass: body-post
 ---
 <!-- ===== post.vto LAYOUT START ===== -->
-<main class="flex-auto">
+<main id="main-content" class="flex-auto">
   <div class="mt-16 sm:px-8 lg:mt-32">
     <div class="mx-auto w-full max-w-7xl lg:px-8">
       <div class="relative px-4 sm:px-8 lg:px-12">

--- a/src/_includes/templates/footer2.vto
+++ b/src/_includes/templates/footer2.vto
@@ -8,7 +8,7 @@
               class="flex flex-col items-center justify-between gap-6 md:flex-row"
             >
               <div
-                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-zinc-800 dark:text-zinc-200"
+                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-zinc-900 dark:text-zinc-200"
               >
                 {{- for item of it.footernav.links }}
                   <a

--- a/src/_includes/templates/post-list.vto
+++ b/src/_includes/templates/post-list.vto
@@ -3,7 +3,7 @@
   <article class="md:grid md:grid-cols-4 md:items-baseline">
     <div class="group relative flex flex-col items-start md:col-span-3">
       <h2
-        class="text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100"
+        class="text-base font-semibold tracking-tight text-zinc-900 dark:text-zinc-100"
       >
         <div
           class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-zinc-800/50"

--- a/src/_includes/templates/skiplink.vto
+++ b/src/_includes/templates/skiplink.vto
@@ -1,0 +1,12 @@
+<!-- ===== skiplink.vto TEMPLATE START ===== -->
+<a href="#main-content" 
+  class="absolute top-0 left-0 transform -translate-x-full z-[9999] focus-visible:translate-x-0 focus-visible:p-4 focus-visible:bg-sky-600 focus-visible:text-white focus-visible:border-2 focus-visible:border-sky-800 focus-visible:rounded-md focus-visible:underline focus-visible:font-semibold focus-visible:transition-all focus-visible:duration-300 focus-visible:ease-in-out focus:outline-none"
+  id="skip-to-content"
+  role="link"
+  aria-label="{{ i18n.home.skip_to_main_content_aria }}"
+  title="{{ i18n.home.skip_to_main_content_label }}"
+  tabindex="0"   
+>
+  {{ i18n.home.skip_to_main_content_label }}
+</a>
+<!-- ===== skiplink.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/social-icons.vto
+++ b/src/_includes/templates/social-icons.vto
@@ -1,0 +1,48 @@
+<!-- ===== socialicons.vto TEMPLATE START ===== -->
+<div class="mt-6 flex gap-6 no-external-icon">
+  <a
+    class="group -m-1 p-1"
+    aria-label="{{ i18n.social.linkedin_label }}"
+    href="{{ i18n.social.linkedin_profile_url }}"
+    target="_blank"
+    rel="noopener"
+  ><img
+      class="h-6 w-6 fill-sky-800 dark:fill-sky-600 transition hover:scale-110"
+      src='{{ "linkedin-logo" |> icon("phosphor", "duotone") }}'
+      inline
+    ></a>
+  <a
+    class="group -m-1 p-1"
+    aria-label="{{ i18n.social.bluesky_label }}"
+    href="{{ i18n.social.bluesky_profile_url }}"
+    target="_blank"
+    rel="noopener"
+  ><img
+      class="h-6 w-6 fill-sky-400 dark:fill-sky-300 transition hover:scale-110"
+      src='{{ "butterfly" |> icon("phosphor", "duotone") }}'
+      inline
+    ></a>
+  <a
+    class="group -m-1 p-1"
+    aria-label="{{ i18n.social.twitter_label }}"
+    href="{{ i18n.social.twitter_profile_url }}"
+    target="_blank"
+    rel="noopener"
+  ><img
+      class="h-6 w-6 fill-black-600 dark:fill-zinc-50 transition hover:scale-110"
+      src='{{ "x-logo" |> icon("phosphor", "duotone") }}'
+      inline
+    ></a>
+  <a
+    class="group -m-1 p-1"
+    aria-label="{{ i18n.social.github_label }}"
+    href="{{ i18n.social.github_profile_url }}"
+    target="_blank"
+    rel="noopener"
+  ><img
+      class="h-6 w-6 fill-green-600 dark:fill-green-500 transition hover:scale-110"
+      src='{{ "github-logo" |> icon("phosphor", "duotone") }}'
+      inline
+    ></a>
+</div>
+<!-- ===== socialicons.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -18,7 +18,7 @@
                   loading="lazy"
                   fetchpriority="high"
                   decoding="async"
-                  class="-ml-4 w-64 object-cover dark:grayscale dark:invert dark:saturate-[.1] transition-opacity duration-300"
+                  class="-ml-5 w-64 object-cover dark:grayscale dark:invert dark:saturate-[.1] transition-opacity duration-300"
                   src="/assets/logo_horiz_darkblue_bgtransparent_2.svg"
                 /></a>
             </div>

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -29,7 +29,7 @@
   </div>
   <div
     id="top-nav-bg"
-    class="fixed top-0 z-10 h-20 pt-6 w-full bg-zinc-50/50 dark:bg-zinc-700/50 transition-all duration-700 shadow-xs"
+    class="fixed top-0 z-10 h-20 pt-6 w-full bg-zinc-50/50 dark:bg-zinc-700/50 transition-all duration-700 backdrop-blur shadow-xs"
   >
     <div class="top-(--header-top,--spacing(6)) w-full sm:px-8 fixed">
       <div class="mx-auto w-full max-w-7xl lg:px-8">
@@ -56,7 +56,7 @@
                 <div class="pointer-events-auto md:hidden relative">
                   <button
                     aria-label="Toggle menu"
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-zinc-800 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-zinc-900 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     x-data
                     @click="$dispatch('toggle-menu')"
@@ -130,29 +130,42 @@
                     x-bind:class="{'is-active' : open }"
                     :style="{ zIndex: zIndex }"
                   >
+                    {{ if alternates && alternates.length > 1 }}
+                    <div class="mobile-menu__item space-y-4">
+                    {{- for alt of alternates }}{{ if alt.lang !== lang }}
+                      <a
+                        class="bg-sky-700 hover:bg-sky-600 hover:text-white rounded-md p-4 text-5xl inline-block"
+                        href="{{ alt.url }}"
+                        title="{{ alt.title |> escape }}"
+                      >
+                        <span class="text-white font-thin">{{ if alt.lang == "ja" }}日本語{{ else }}ENGLISH{{ /if }}</span>
+                      </a>
+                      {{ /if }}{{ /for }}
+                    </div>
+                    {{ /if }} 
                     {{- for item of it.topnav.links }}
-                      <div class="mobile-menu__item space-y-4">
-                        <a
-                          class="text-white font-thin hover:text-sky-400 text-5xl inline-block {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
-                          href="{{ item.href }}"
-                          {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
-                          role="menuitem"
-                          aria-label="{{ item.aria_label }}"
-                          title="{{ item.title }}"
-                        ><span class="text-white">{{
-                            item.text
-                            |> toUpperCase
-                          }}</span>
-                          <span class="sr-only">({{ item.aria_label }})</span>
-                        </a>
-                      </div>
+                    <div class="mobile-menu__item space-y-4">
+                      <a
+                        class="text-white font-thin hover:text-sky-400 text-5xl inline-block {{- if item.target === '_blank'  }} after:content-['_↗']{{ /if -}}"
+                        href="{{ item.href }}"
+                        {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
+                        role="menuitem"
+                        aria-label="{{ item.aria_label }}"
+                        title="{{ item.title }}"
+                      ><span class="text-white">{{
+                          item.text
+                          |> toUpperCase
+                        }}</span>
+                        <span class="sr-only">({{ item.aria_label }})</span>
+                      </a>
+                    </div>
                     {{ /for -}}
                   </div>
                 </nav>
               </div>
               <div class="flex justify-end md:flex-1 z-50 space-x-1">
                 {{ if alternates && alternates.length > 1 }}
-                  <div class="pointer-events-auto z-50">
+                  <div class="pointer-events-auto z-50 hidden md:block">
                     <button
                       type="button"
                       aria-label="Toggle language"

--- a/src/_includes/templates/top-nav2.vto
+++ b/src/_includes/templates/top-nav2.vto
@@ -79,7 +79,7 @@
                   data-headlessui-state=""
                 >
                   <button
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-zinc-800 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-zinc-900 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     aria-expanded="false"
                     data-headlessui-state=""
@@ -107,7 +107,7 @@
                 </div>
                 <nav class="pointer-events-auto hidden md:block">
                   <ul
-                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-zinc-800 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
+                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-zinc-900 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
                   >
                     <li>
                       <a

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -61,7 +61,7 @@
             <a
               href="{{ post.url }}"
               data-faid="{{ post.lang }}-{{ if post.id.length > 0 }}{{ post.id }}{{ else }}{{ loop.index }}{{ /if }}"
-              class="data-fatrigger text-zinc-800 hover:text-sky-500 dark:text-zinc-50 dark:hover:text-sky-500"
+              class="data-fatrigger text-zinc-900 hover:text-sky-500 dark:text-zinc-50 dark:hover:text-sky-500"
               {{ if post.url == url }}
                 aria-current="page"{{ /if }}
             >

--- a/src/_includes/templates/top-post-list.vto
+++ b/src/_includes/templates/top-post-list.vto
@@ -13,7 +13,7 @@
       }}
     </div>
     <h2
-      class="text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-100"
+      class="text-base font-semibold tracking-tight text-zinc-900 dark:text-zinc-100"
     >
       <div
         class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-zinc-800/50"

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -5,13 +5,13 @@
       <div class="mx-auto max-w-2xl lg:max-w-5xl">
         <div class="max-w-2xl">
           <h1
-            class="text-4xl tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100"
+            class="text-4xl tracking-tight font-semibold text-esoliablue-900 sm:text-5xl dark:text-zinc-100"
           >
             {{# <span class="font-light">{{ i18n.home.company }}</span>
             <br class="block sm:hidden"> #}}
-            <span class="font-light subpixel-antialiased">{{ site.title }}</span>
+            <span class="subpixel-antialiased">{{ site.title }}</span>
           </h1>
-          <p class="mt-6 text-base text-zinc-800 dark:text-zinc-400">
+          <p class="mt-6 text-base text-zinc-900 dark:text-zinc-400">
             {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
           </p>
           <div class="mt-6 flex gap-6 no-external-icon">

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -14,52 +14,7 @@
           <p class="mt-6 text-base text-zinc-900 dark:text-zinc-400">
             {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
           </p>
-          <div class="mt-6 flex gap-6 no-external-icon">
-            <a
-              class="group -m-1 p-1"
-              aria-label="{{ i18n.social.linkedin_label }}"
-              href="{{ i18n.social.linkedin_profile_url }}"
-              target="_blank"
-              rel="noopener"
-            ><img
-                class="h-6 w-6 fill-sky-800 dark:fill-sky-600 transition hover:scale-110"
-                src='{{ "linkedin-logo" |> icon("phosphor", "duotone") }}'
-                inline
-              ></a>
-            <a
-              class="group -m-1 p-1"
-              aria-label="{{ i18n.social.bluesky_label }}"
-              href="{{ i18n.social.bluesky_profile_url }}"
-              target="_blank"
-              rel="noopener"
-            ><img
-                class="h-6 w-6 fill-sky-400 dark:fill-sky-300 transition hover:scale-110"
-                src='{{ "butterfly" |> icon("phosphor", "duotone") }}'
-                inline
-              ></a>
-            <a
-              class="group -m-1 p-1"
-              aria-label="{{ i18n.social.twitter_label }}"
-              href="{{ i18n.social.twitter_profile_url }}"
-              target="_blank"
-              rel="noopener"
-            ><img
-                class="h-6 w-6 fill-black-600 dark:fill-zinc-50 transition hover:scale-110"
-                src='{{ "x-logo" |> icon("phosphor", "duotone") }}'
-                inline
-              ></a>
-            <a
-              class="group -m-1 p-1"
-              aria-label="{{ i18n.social.github_label }}"
-              href="{{ i18n.social.github_profile_url }}"
-              target="_blank"
-              rel="noopener"
-            ><img
-                class="h-6 w-6 fill-green-600 dark:fill-green-500 transition hover:scale-110"
-                src='{{ "github-logo" |> icon("phosphor", "duotone") }}'
-                inline
-              ></a>
-          </div>
+          {{# {{ include "templates/socialicons.vto" }} #}}
           {{# {{ include "templates/featured1.vto" }} #}}
         </div>
       </div>

--- a/src/en/index.vto
+++ b/src/en/index.vto
@@ -7,7 +7,7 @@ title: Home
 script: /js/fathom-post-list-event.js
 ---
 <!-- ===== index.vto LAYOUT START ===== -->
-<main class="flex-auto">
+<main id="main-content" class="flex-auto">
   {{ include "templates/top-welcome-header.vto" }}
   {{# {{ include "templates/slider1.vto" }} #}}
   <div class="mt-12 sm:px-8 md:mt-16">

--- a/src/index.vto
+++ b/src/index.vto
@@ -7,7 +7,7 @@ title: ホーム
 script: /js/fathom-post-list-event.js
 ---
 <!-- ===== index.vto LAYOUT START ===== -->
-<main class="flex-auto">
+<main id="main-content" class="flex-auto">
   {{ include "templates/top-welcome-header.vto" }}
   {{# {{ include "templates/slider1.vto" }} #}}
   <div class="mt-12 sm:px-8 md:mt-16">

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "ETIEB",
-  "name": "eSolia Tech IT Easy Blog",
+  "name": "eSolia Tech It Easy Blog",
   "start_url": "/",
   "background_color": "#2d2f63",
   "theme_color": "#ffbc68",

--- a/src/styles.css
+++ b/src/styles.css
@@ -120,7 +120,7 @@
 }
 
 body article > div > p:first-of-type {
-  @apply text-base text-lg lg:text-xl font-light leading-relaxed text-zinc-800 dark:text-zinc-200;
+  @apply text-base text-lg lg:text-xl font-light leading-relaxed text-zinc-900 dark:text-zinc-200;
 }
 
 body article > div > figure > picture > img {
@@ -129,7 +129,7 @@ body article > div > figure > picture > img {
 
 /* MDN keyboard shortcut style for kbd tag */
 kbd {
-  @apply bg-zinc-200 rounded border border-zinc-400 shadow-md text-zinc-800 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap
+  @apply bg-zinc-200 rounded border border-zinc-400 shadow-md text-zinc-900 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap
 }
 
 /*----------------------------


### PR DESCRIPTION
ff7984d54c8a67b6024c9d1e8ec6fbbdcdc6cc98
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 14:46:21 2025 +0900

### Set logo position on singleton
Logo position is very, very slightly too far to the right, because of the way it is shaped. Changed from -4 to -5, and that pushes the tip of the leaf slightly to the left of the text and/or back icon.

Maybe a slightly better balance.



398baed88679b54ca35d3be699ae91adf571f2ef
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 14:32:45 2025 +0900

### Remove social icons from top
It's possible that having social icons right before the main content will draw attention. They are in the footer, so that should be ok.

Templatized, for easy reversion or placement elsewhere.



85a68853ce0192b5594ee15bb372b5c1277d71cb
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 14:19:43 2025 +0900

### Various nav tweaks
Make main language switcher visible from md breakpoint only, when mobile menu disappears.

Add language switcher to mobile menu, which is visible up until md breakpoint, so that the language switcher goes from inside the mobile menu to on the main menu.

Add blur to nav, so the transparency is not as jarring.



eda7885436e3cb4d8d6e7a74e7cc1352b245c745
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 14:17:20 2025 +0900

### Change title
Change "Take IT Easy Blog" to "Take It Easy Blog", in various strings.

Make main title semibold, one step bolder than before.

Remove archive from top nav, since it is in the footer.



07fcf64a44d571f37aa2677b8a0fb42b7255078f
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 14:14:54 2025 +0900

### Increase contrast
Had all body text set to text-zinc-800, but changed to text-zinc-900 for better contrast.



97d2547e4427188a8a5bd38bccae21c0d7d5ddf3
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 14:12:10 2025 +0900

### Add skip-link
Skip link allows screen reader users to skip the navigation which is typically first in the tab order. Added via a template partial to base, and then added the id="main-content" to all the main tags.



