### PR TITLE
Various visual and functional changes after 5/19 mtg

### DIFF
--- a/src/_data.yml
+++ b/src/_data.yml
@@ -7,13 +7,7 @@ site:
   description: "株式会社イソリア IT Tips ブログのページ"
   isolang: "ja-JP"
 topnav:
-  links: 
-    - text: イソリア
-      href: https://esolia.co.jp
-      target: _blank
-      icon: building-office
-      aria_label: 外部リンク
-      title: イソリア社ウェブサイトへのリンク
+  links: []
 footernav:
   links: 
     - text: アーカイブ
@@ -89,13 +83,7 @@ en:
     description: "IT Tips Blog page from eSolia Inc., Tokyo, Japan"
     isolang: "en-US"
   topnav:
-    links: 
-      - text: eSolia Inc.
-        href: https://esolia.com
-        target: _blank
-        icon: building-office
-        aria_label: External link
-        title: Link to eSolia Inc. website
+    links: []
   footernav:
     links: 
       - text: Archive

--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -9,6 +9,9 @@ home:
 archive: 
   title: Archive
   description: Browse our archive of past articles. Use categories and tags to quickly find the topics that interest you, or search from the magnifying glass icon in the navigation bar at the top of the page.
+  button: Browse All Posts
+  aria_label: Archive page link
+  url: /en/archive/
 social:
   share_placeholder: Check out this new post from eSolia's IT Tips Blog
   share_ask: Kindly do us a favor?

--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -1,6 +1,6 @@
 lang: en
 home:
-  welcome: Based in Tokyo and approaching YEARS_IN_BUSINESS years in business, bilingual IT outsourcing company <strong>eSolia</strong> shares practical, field-tested tips that are genuinely useful&mdash;drawn from years of hands-on experience.
+  welcome: Based in Tokyo and approaching YEARS_IN_BUSINESS years in business, bilingual IT outsourcing company <a href="https://esolia.com" target="_blank" ref="noopener"><strong>eSolia</strong></a> shares practical, field-tested tips that are genuinely useful&mdash;drawn from years of hands-on experience.
   company: eSolia
   company_long: eSolia Inc.
   company_address: Shiodome City Center 5F (Work Styling), 1-5-2 Higashi-Shimbashi, Minato-ku, Tokyo, Japan, 105-7105

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -1,6 +1,6 @@
 lang: ja
 home:
-  welcome: 東京を拠点にYEARS_IN_BUSINESS周年を迎え、バイリンガルITアウトソーシングを提供する<strong>イソリア</strong>は<br class="hidden md:inline">長年の経験をもとに現場の視点で選んだ「知って得するTips」を紹介しています。
+  welcome: 東京を拠点にYEARS_IN_BUSINESS周年を迎え、バイリンガルITアウトソーシングを提供する<a href="https://esolia.co.jp" target="_blank" ref="noopener"><strong>イソリア</strong></a>は<br class="hidden md:inline">長年の経験をもとに現場の視点で選んだ「知って得するTips」を紹介しています。
   company: イソリア
   company_long: 株式会社イソリア
   company_address: 〒105-7105 東京都港区東新橋1-5-2 汐留シティセンター5F（ワークスタイリング）

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -9,6 +9,9 @@ home:
 archive: 
   title: アーカイブ
   description: 過去の記事を一覧でご紹介しています。カテゴリやタグを活用して、興味のある情報にすばやくアクセスできます。または、ページ上部のナビゲーションバーにある虫眼鏡アイコンから検索してください。
+  button: 全ポストを見る
+  aria_label: アーカイブページへのリンク
+  url: /archive/
 social:
   share_placeholder: 役立つIT情報をお届け中！当ブログの最新ポストはこちら
   share_ask: この記事が役に立ったと思ったら

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -11,7 +11,7 @@ script: /js/fathom-post-list-event.js
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl">
             <h1
-              class="text-4xl font-bold tracking-tight text-zinc-900 sm:text-5xl dark:text-zinc-100"
+              class="text-4xl font-bold tracking-tight text-zinc-950 sm:text-5xl dark:text-zinc-100"
             >
               <span class="font-light subpixel-antialiased">{{ site.title }}</span>
               <br class="block sm:hidden">
@@ -19,7 +19,7 @@ script: /js/fathom-post-list-event.js
                 class="bg-gradient-to-r from-esoliablue-800 via-esoliablue-700 to-esoliablue-900 dark:from-esoliablue-600 dark:via-esoliablue-500 dark:to-esoliablue-700 bg-clip-text text-transparent"
               >{{ i18n.archive.title }}</span>
             </h1>
-            <p class="mt-6 text-base text-zinc-900 dark:text-zinc-400">
+            <p class="mt-6 text-base text-zinc-950 dark:text-zinc-400">
               {{ i18n.archive.description }}
             </p>
 

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -11,12 +11,12 @@ script: /js/fathom-post-list-event.js
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl">
             <h1
-              class="text-4xl font-bold tracking-tight text-zinc-950 sm:text-5xl dark:text-zinc-100"
+              class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-zinc-950 dark:text-zinc-100"
             >
-              <span class="font-light subpixel-antialiased">{{ site.title }}</span>
-              <br class="block sm:hidden">
+              <span class="font-semibold subpixel-antialiased">{{ site.title }}</span>
+              <br class="block md:hidden">
               <span
-                class="bg-gradient-to-r from-esoliablue-800 via-esoliablue-700 to-esoliablue-900 dark:from-esoliablue-600 dark:via-esoliablue-500 dark:to-esoliablue-700 bg-clip-text text-transparent"
+                class="font-light text-esoliablue-800 dark:text-esoliablue-600"
               >{{ i18n.archive.title }}</span>
             </h1>
             <p class="mt-6 text-base text-zinc-950 dark:text-zinc-400">

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -11,7 +11,7 @@ script: /js/fathom-post-list-event.js
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl">
             <h1
-              class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-zinc-950 dark:text-zinc-100"
+              class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl tracking-tight text-zinc-950 dark:text-zinc-100"
             >
               <span class="font-semibold subpixel-antialiased">{{ site.title }}</span>
               <br class="block md:hidden">

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -11,9 +11,9 @@ bodyClass: body-tag
           <header class="max-w-2xl space-y-10">
             <div class=""><a href="/archive/">{{ i18n.nav.back }}</a></div>
             <h1
-              class="text-4xl font-thin tracking-tight text-zinc-950 sm:text-5xl dark:text-zinc-100 subpixel-antialiased"
+              class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl tracking-tight text-zinc-950 dark:text-zinc-100 subpixel-antialiased"
             >
-              {{ title }}
+              <span class="font-light text-esoliablue-800 dark:text-esoliablue-600">{{ title }}</span> <br class="block md:hidden"> <span class="font-semibold">{{ subtitle }}</span>
             </h1>
             <p class="text-zinc-950 dark:text-zinc-200">{{ summary }}</p>
             {{

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -11,11 +11,11 @@ bodyClass: body-tag
           <header class="max-w-2xl space-y-10">
             <div class=""><a href="/archive/">{{ i18n.nav.back }}</a></div>
             <h1
-              class="text-4xl font-thin tracking-tight text-zinc-900 sm:text-5xl dark:text-zinc-100 subpixel-antialiased"
+              class="text-4xl font-thin tracking-tight text-zinc-950 sm:text-5xl dark:text-zinc-100 subpixel-antialiased"
             >
               {{ title }}
             </h1>
-            <p class="text-zinc-900 dark:text-zinc-200">{{ summary }}</p>
+            <p class="text-zinc-950 dark:text-zinc-200">{{ summary }}</p>
             {{
               include "templates/post-list.vto" { postslist: search.pages(search_query) }
             }}

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -9,7 +9,7 @@ bodyClass: body-tag
       <div class="relative px-4 sm:px-8 lg:px-12">
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl space-y-10">
-            <div class=""><a href="/archive/">{{ i18n.nav.back }}</a></div>
+            <div class="hidden md:block"><a href="/archive/">{{ i18n.nav.back }}</a></div>
             <h1
               class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl tracking-tight text-zinc-950 dark:text-zinc-100 subpixel-antialiased"
             >

--- a/src/_includes/layouts/base-old.vto
+++ b/src/_includes/layouts/base-old.vto
@@ -37,7 +37,7 @@
     <script src="/js/main.js" type="module"></script>
     {{ it.extra_head?.join("\n") }}
   </head>
-  <body class="m-auto p-8 pb-32 max-w-6xl md:px-16 text-zinc-900 bg-zinc-50">
+  <body class="m-auto p-8 pb-32 max-w-6xl md:px-16 text-zinc-950 bg-zinc-50">
     {{ include "templates/top-nav.vto" }}
 
     <nav class="navbar">

--- a/src/_includes/layouts/page.vto
+++ b/src/_includes/layouts/page.vto
@@ -10,9 +10,9 @@ bodyClass: body-tag
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <div class="xl:relative">
             <div class="mx-auto max-w-3xl">
-              <a type="button" href="/{{ if lang === "en"}}en{{/if}}" aria-label="{{ i18n.nav.return_home }}" class="btn group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1  ring-zinc-900/5 transition lg:absolute lg:-left-5 lg:-mt-2 lg:mb-0 xl:-top-1.5 xl:left-0 xl:mt-0 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
+              <div class="hidden md:block"><a type="button" href="/{{ if lang === "en"}}en{{/if}}" aria-label="{{ i18n.nav.return_home }}" class="btn group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1  ring-zinc-900/5 transition lg:absolute lg:-left-5 lg:-mt-2 lg:mb-0 xl:-top-1.5 xl:left-0 xl:mt-0 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
               <img class="size-6 stroke-zinc-300 transition group-hover:stroke-zinc-700 dark:stroke-zinc-500 dark:group-hover:stroke-zinc-400" src="{{ "arrow-left" |> icon("phosphor", "duotone") }}" inline />
-              </a>
+              </a></div>
               <article data-pagefind-body data-title="{{ title }}" data-pagefind-index-attrs="data-title">
                 <header class="flex flex-col">
                   <h1

--- a/src/_includes/layouts/page.vto
+++ b/src/_includes/layouts/page.vto
@@ -44,7 +44,7 @@ bodyClass: body-tag
                   {{ /if }} #}}
                 </header>
                 <div
-                  class="prose max-w-[70ch] prose-zinc sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
+                  class="prose max-w-[70ch] prose-zinc text-zinc-950 sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
                   data-mdx-content="true"
                 >
                 {{ content }}

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -17,7 +17,7 @@ bodyClass: body-post
                 <header class="flex flex-col -top-4">
                   {{# {{ include "templates/post-details.vto" { elapsed: elapseddays } }} #}}
                   <h1
-                    class="mt-1 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl dark:text-zinc-100 subpixel-antialiased"
+                    class="mt-1 text-3xl font-bold tracking-tight text-zinc-950 sm:text-4xl dark:text-zinc-100 subpixel-antialiased"
                   >
                     {{ title }}
                   </h1>

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -4,7 +4,7 @@ bodyClass: body-post
 ---
 <!-- ===== post.vto LAYOUT START ===== -->
 <main id="main-content" class="flex-auto">
-  <div class="mt-16 sm:px-8 lg:mt-32">
+  <div class="mt-1 lg:mt-8 2xl:mt-10 sm:px-8">
     <div class="mx-auto w-full max-w-7xl lg:px-8">
       <div class="relative px-4 sm:px-8 lg:px-12">
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
@@ -17,7 +17,7 @@ bodyClass: body-post
                 <header class="flex flex-col -top-4">
                   {{# {{ include "templates/post-details.vto" { elapsed: elapseddays } }} #}}
                   <h1
-                    class="mt-1 text-3xl font-bold tracking-tight text-zinc-950 sm:text-4xl dark:text-zinc-100 subpixel-antialiased"
+                    class="mt-1 text-xl sm:text-2xl lg:text-3xl 2xl:text-4xl 3xl:text-5xl font-bold tracking-tight text-zinc-950 dark:text-zinc-100 subpixel-antialiased"
                   >
                     {{ title }}
                   </h1>

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -10,9 +10,9 @@ bodyClass: body-post
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
           <div class="xl:relative">
             <div class="mx-auto max-w-3xl">
-              <a type="button" href="/{{ if lang === "en"}}en{{/if}}" aria-label="{{ i18n.nav.return_home }}" class="btn group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1  ring-zinc-900/5 transition lg:absolute lg:-left-5  lg:-mt-0 lg:mb-0 xl:-top-0 xl:left-0 xl:-mt-0 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
+              <div class="hidden md:block"><a type="button" href="/{{ if lang === "en"}}en{{/if}}" aria-label="{{ i18n.nav.return_home }}" class="btn group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1  ring-zinc-900/5 transition lg:absolute lg:-left-5  lg:-mt-0 lg:mb-0 xl:-top-0 xl:left-0 xl:-mt-0 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
               <img class="size-6 stroke-zinc-300 transition group-hover:stroke-zinc-700 dark:stroke-zinc-500 dark:group-hover:stroke-zinc-400" src="{{ "arrow-left" |> icon("phosphor", "duotone") }}" inline />
-              </a>
+              </a></div>
               <article data-pagefind-body data-title="{{ title }}" data-pagefind-index-attrs="data-title">
                 <header class="flex flex-col -top-4">
                   {{# {{ include "templates/post-details.vto" { elapsed: elapseddays } }} #}}

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -45,7 +45,7 @@ bodyClass: body-post
                   {{ /if }}
                 </header>
                 <div
-                  class="prose max-w-[70ch] prose-zinc sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
+                  class="prose max-w-[70ch] prose-zinc text-zinc-950 sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
                   data-mdx-content="true"
                 >
                 {{ content }}

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -23,24 +23,28 @@ bodyClass: body-post
                   </h1>
 
                   {{ if toc.length }}
-                    <nav class="max-w-2xl mt-4 mr-auto bg-zinc-50 prose prose-zinc dark:prose-invert dark:bg-zinc-800 p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5 prose-a:transition">
-                      <h2 class="mb-1 font-light">{{ i18n.nav.toc }}</h2>
-                      <ul class="list-disc list-inside space-y-2 text-sm">
-                        {{ for item of toc }}
-                        <li class="">
-                          <a class="font-light text-zinc-700 hover:text-sky-600 dark:text-zinc-200 dark:hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
-                          {{ if item.children.length }}
-                          <ul>
-                            {{ for child of item.children }}
-                            <li>
-                              <a class="font-light text-zinc-700 hover:text-sky-600 dark:text-zinc-200 dark:hover:text-sky-500" href="#{{ child.slug }}">{{ child.text }}</a>
-                            </li>
-                            {{ /for }}
-                          </ul>
-                          {{ /if }}
-                        </li>
-                        {{ /for }}
-                      </ol>
+                    <nav class="max-w-2xl mt-6 mr-auto bg-zinc-50 prose prose-zinc dark:prose-invert dark:bg-zinc-800 p-2 pr-8 md:p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5 prose-a:transition">
+                      <details id="toc-details" class="block" open>
+                        <summary class="cursor-pointer md:cursor-default p-0">
+                          <h2 class="text-base md:text-xl -mt-4 -mb-2 p-0 font-light inline-block">{{ i18n.nav.toc }}</h2>
+                        </summary>
+                        <ul class="list-disc list-inside space-y-2 text-sm">
+                          {{ for item of toc }}
+                          <li class="">
+                            <a class="font-light text-zinc-700 hover:text-sky-600 dark:text-zinc-200 dark:hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
+                            {{ if item.children.length }}
+                            <ul>
+                              {{ for child of item.children }}
+                              <li>
+                                <a class="font-light text-zinc-700 hover:text-sky-600 dark:text-zinc-200 dark:hover:text-sky-500" href="#{{ child.slug }}">{{ child.text }}</a>
+                              </li>
+                              {{ /for }}
+                            </ul>
+                            {{ /if }}
+                          </li>
+                          {{ /for }}
+                        </ol>
+                      </details>
                     </nav>
                   {{ /if }}
                 </header>

--- a/src/_includes/templates/featured1.vto
+++ b/src/_includes/templates/featured1.vto
@@ -16,7 +16,7 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">Blog Post Title</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-zinc-900 dark:text-zinc-100 whitespace-normal"
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal"
         >
           Featured post title number 1
         </dd>
@@ -51,7 +51,7 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">Blog Post Title</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-zinc-900 dark:text-zinc-100 whitespace-normal"
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal"
         >
           Featured post title number 2
         </dd>
@@ -77,7 +77,7 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">Blog Post Title</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-zinc-900 dark:text-zinc-100 whitespace-normal"
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal"
         >
           Featured post title number 3
         </dd>

--- a/src/_includes/templates/footer2.vto
+++ b/src/_includes/templates/footer2.vto
@@ -8,7 +8,7 @@
               class="flex flex-col items-center justify-between gap-6 md:flex-row"
             >
               <div
-                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-zinc-900 dark:text-zinc-200"
+                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-zinc-950 dark:text-zinc-200"
               >
                 {{- for item of it.footernav.links }}
                   <a

--- a/src/_includes/templates/panel-categories.vto
+++ b/src/_includes/templates/panel-categories.vto
@@ -1,6 +1,6 @@
 <!-- ===== panel-categories.vto TEMPLATE START ===== -->
 <div class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
-  <h2 class="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+  <h2 class="flex text-sm font-semibold text-zinc-950 dark:text-zinc-100">
     <img
       alt=""
       loading="lazy"
@@ -28,7 +28,7 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-zinc-900 dark:text-zinc-100"
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100"
         >
           Stories
         </dd>
@@ -63,7 +63,7 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-zinc-900 dark:text-zinc-100"
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100"
         >
           Tips
         </dd>
@@ -98,7 +98,7 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-zinc-900 dark:text-zinc-100"
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100"
         >
           Tutorials
         </dd>
@@ -133,7 +133,7 @@
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
         <dd
-          class="w-full flex-none text-sm font-medium text-zinc-900 dark:text-zinc-100"
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100"
         >
           Announcements
         </dd>
@@ -154,7 +154,7 @@
     </li>
   </ol>
   <a
-    class="group mt-6 inline-flex w-full items-center justify-center gap-2 rounded-md bg-zinc-50 px-3 py-2 text-sm font-medium text-zinc-900 outline-offset-2 transition hover:bg-zinc-100 active:bg-zinc-100 active:text-zinc-900/60 active:transition-none dark:bg-zinc-800/50 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50 dark:active:bg-zinc-800/50 dark:active:text-zinc-50/70"
+    class="group mt-6 inline-flex w-full items-center justify-center gap-2 rounded-md bg-zinc-50 px-3 py-2 text-sm font-medium text-zinc-950 outline-offset-2 transition hover:bg-zinc-100 active:bg-zinc-100 active:text-zinc-950/60 active:transition-none dark:bg-zinc-800/50 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50 dark:active:bg-zinc-800/50 dark:active:text-zinc-50/70"
     href="#"
   >A Call To Action??
     <img

--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -8,7 +8,7 @@
     role="form"
     action="https://pro.dbflex.net/secure/gateway.aspx?action=WebToRecord&amp;app=15331&amp;table=1510483"
   >
-    <h2 class="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+    <h2 class="flex text-sm font-semibold text-zinc-950 dark:text-zinc-100">
       <img
         alt=""
         loading="lazy"
@@ -48,7 +48,7 @@
     </div>
   </form>
   <div class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40 mt-6 lg:mt-0">
-    <h2 class="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+    <h2 class="flex text-sm font-semibold text-zinc-950 dark:text-zinc-100">
       <img
       alt=""
       loading="lazy"

--- a/src/_includes/templates/post-list.vto
+++ b/src/_includes/templates/post-list.vto
@@ -3,7 +3,7 @@
   <article class="md:grid md:grid-cols-4 md:items-baseline">
     <div class="group relative flex flex-col items-start md:col-span-3">
       <h2
-        class="text-base font-semibold tracking-tight text-zinc-900 dark:text-zinc-100"
+        class="text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-100"
       >
         <div
           class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-zinc-800/50"

--- a/src/_includes/templates/top-lead.vto
+++ b/src/_includes/templates/top-lead.vto
@@ -46,7 +46,7 @@
       >
         <div class="relative w-full lg:max-w-xl lg:shrink-0 xl:max-w-2xl">
           <h1
-            class="text-5xl font-light tracking-tight text-pretty text-zinc-900 sm:text-7xl"
+            class="text-5xl font-light tracking-tight text-pretty text-zinc-950 sm:text-7xl"
           >
             私達、<br>株式会社イソリアは、御社が経験しているITを変更して行きます
           </h1>

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -56,7 +56,7 @@
                 <div class="pointer-events-auto md:hidden relative">
                   <button
                     aria-label="Toggle menu"
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-zinc-900 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm whitespace-nowrap font-medium text-zinc-950 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     x-data
                     @click="$dispatch('toggle-menu')"
@@ -204,7 +204,7 @@
                     </span>
                   </button>
                   <div
-                    class="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 px-2 py-1 bg-zinc-200 text-zinc-900 dark:bg-zinc-700 dark:text-zinc-200  text-sm rounded-md opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-300 pointer-events-none z-50 whitespace-nowrap before:content-[''] before:absolute before:bottom-full before:left-1/2 before:transform before:-translate-x-1/2 before:border-8 before:border-x-transparent before:border-t-0 before:border-b-zinc-200 dark:before:border-b-zinc-700"
+                    class="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 px-2 py-1 bg-zinc-200 text-zinc-950 dark:bg-zinc-700 dark:text-zinc-200  text-sm rounded-md opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-300 pointer-events-none z-50 whitespace-nowrap before:content-[''] before:absolute before:bottom-full before:left-1/2 before:transform before:-translate-x-1/2 before:border-8 before:border-x-transparent before:border-t-0 before:border-b-zinc-200 dark:before:border-b-zinc-700"
                   >
                     {{ i18n.search.tooltip }}
                   </div>

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -18,7 +18,7 @@
                   loading="lazy"
                   fetchpriority="high"
                   decoding="async"
-                  class="-ml-5 w-64 object-cover dark:grayscale dark:invert dark:saturate-[.1] transition-opacity duration-300"
+                  class="-ml-5 w-64 object-cover dark:grayscale dark:invert dark:saturate-[.1] transition-opacity duration-300 opacity-0 hidden md:block md:opacity-100"
                   src="/assets/logo_horiz_darkblue_bgtransparent_2.svg"
                 /></a>
             </div>
@@ -48,7 +48,7 @@
                     loading="lazy"
                     fetchpriority="high"
                     decoding="async"
-                    class="w-12 object-cover rounded-md bg-white/90 dark:bg-white/10 dark:grayscale dark:invert dark:saturate-[.1] opacity-0 transition-opacity duration-300"
+                    class="w-12 object-cover rounded-md bg-white/90 dark:bg-white/10 dark:grayscale dark:invert dark:saturate-[.1] transition-opacity duration-300 block opacity-100 md:opacity-0"
                     src="/assets/symbol_darkblue_bgtransparent_2.svg"
                   /></a>
               </div>

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -197,7 +197,7 @@
                   >
                     <span>
                       <img
-                        class="h-5 w-5 fill-esoliaamber-500 stroke-esoliaamber-800 dark:fill-sky-300 dark:stroke-sky-500 transition group-hover:fill-esoliaamber-600 group-hover:stroke-esoliaamber-900 dark:group-hover:fill-sky-400 dark:group-hover:stroke-sky-600 transition hover:scale-110"
+                        class="h-5 w-5 fill-sky-500 stroke-sky-800 dark:fill-sky-300 dark:stroke-sky-500 transition group-hover:fill-sky-600 group-hover:stroke-sky-900 dark:group-hover:fill-sky-400 dark:group-hover:stroke-sky-600 transition hover:scale-110"
                         src='{{ "magnifying-glass" |> icon("phosphor", "duotone") }}'
                         inline
                       />

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -84,6 +84,7 @@
                 >
                 </div>
                 <nav class="pointer-events-auto hidden md:block">
+                  {{ if it.topnav.links.length }}
                   <ul
                     class="flex rounded-full bg-sky-700/90 px-3 text-sm font-medium ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:ring-white/10 divide-x-1 divide-zinc-50/50 dark:divide-zinc-200/50"
                     role="menubar"
@@ -103,7 +104,7 @@
                           <span class="sr-only"
                           >({{ item.aria_label }})</span></a>
                       </li>
-                    {{ /for -}}
+                    {{ /for -}}{{ /if }}
                   </ul>
                 </nav>
 

--- a/src/_includes/templates/top-nav1.vto
+++ b/src/_includes/templates/top-nav1.vto
@@ -48,7 +48,7 @@
           href="{{ item.href }}"
           {{ if item.target }}
             target="{{ item.target }}"{{ /if }}
-          class="text-sm/6 font-semibold text-zinc-900 dark:text-zinc-300"
+          class="text-sm/6 font-semibold text-zinc-950 dark:text-zinc-300"
         >{{ item.text }}</a>
       {{ /for -}}
     </div>
@@ -117,25 +117,25 @@
           <div class="space-y-2 py-6">
             <a
               href="#"
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-zinc-900 hover:bg-zinc-50"
+              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-zinc-950 hover:bg-zinc-50"
             >Product</a>
             <a
               href="#"
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-zinc-900 hover:bg-zinc-50"
+              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-zinc-950 hover:bg-zinc-50"
             >Features</a>
             <a
               href="#"
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-zinc-900 hover:bg-zinc-50"
+              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-zinc-950 hover:bg-zinc-50"
             >Resources</a>
             <a
               href="#"
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-zinc-900 hover:bg-zinc-50"
+              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-zinc-950 hover:bg-zinc-50"
             >Company</a>
           </div>
           <div class="py-6">
             <a
               href="#"
-              class="-mx-3 block rounded-lg px-3 py-2.5 text-base/7 font-semibold text-zinc-900 hover:bg-zinc-50"
+              class="-mx-3 block rounded-lg px-3 py-2.5 text-base/7 font-semibold text-zinc-950 hover:bg-zinc-50"
             >Log in</a>
           </div>
         </div>

--- a/src/_includes/templates/top-nav2.vto
+++ b/src/_includes/templates/top-nav2.vto
@@ -79,7 +79,7 @@
                   data-headlessui-state=""
                 >
                   <button
-                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-zinc-900 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
+                    class="group flex items-center rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-zinc-950 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10 dark:hover:ring-white/20"
                     type="button"
                     aria-expanded="false"
                     data-headlessui-state=""
@@ -107,7 +107,7 @@
                 </div>
                 <nav class="pointer-events-auto hidden md:block">
                   <ul
-                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-zinc-900 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
+                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-zinc-950 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
                   >
                     <li>
                       <a

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -2,7 +2,7 @@
 {{# <div class="bg-white py-24 sm:py-32">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
-      <h2 class="text-4xl font-semibold tracking-tight text-balance text-zinc-900 sm:text-5xl">From the blog</h2>
+      <h2 class="text-4xl font-semibold tracking-tight text-balance text-zinc-950 sm:text-5xl">From the blog</h2>
       <p class="mt-2 text-lg/8 text-zinc-600">Learn how to grow your business with our expert advice.</p>
     </div> #}}
 <div
@@ -56,12 +56,12 @@
         </div>
         <div class="group relative">
           <h3
-            class="mt-3 text-lg/6 font-semibold text-zinc-900 group-hover:text-zinc-600"
+            class="mt-3 text-lg/6 font-semibold text-zinc-950 group-hover:text-zinc-600"
           >
             <a
               href="{{ post.url }}"
               data-faid="{{ post.lang }}-{{ if post.id.length > 0 }}{{ post.id }}{{ else }}{{ loop.index }}{{ /if }}"
-              class="data-fatrigger text-zinc-900 hover:text-sky-500 dark:text-zinc-50 dark:hover:text-sky-500"
+              class="data-fatrigger text-zinc-950 hover:text-sky-500 dark:text-zinc-50 dark:hover:text-sky-500"
               {{ if post.url == url }}
                 aria-current="page"{{ /if }}
             >

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -1,10 +1,4 @@
 <!-- ===== top-post-cards1.vto TEMPLATE START ===== -->
-{{# <div class="bg-white py-24 sm:py-32">
-  <div class="mx-auto max-w-7xl px-6 lg:px-8">
-    <div class="mx-auto max-w-2xl text-center">
-      <h2 class="text-4xl font-semibold tracking-tight text-balance text-zinc-950 sm:text-5xl">From the blog</h2>
-      <p class="mt-2 text-lg/8 text-zinc-600">Learn how to grow your business with our expert advice.</p>
-    </div> #}}
 <div
   class="mx-auto mt-2 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3"
 >
@@ -80,7 +74,9 @@
     </article>
   {{ /for }}
 </div>
-{{# </div>
-</div> #}}
-
+<div class="mt-6 flex justify-left">
+  <a href="{{ i18n.archive.url }}" role="button" tabindex="0" aria-label="{{ i18n.archive.aria_label }}" class="inline-flex flex-none items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold  outline-offset-2 text-zinc-50 bg-sky-500 transition hover:bg-sky-400 active:bg-sky-600 active:text-sky-100/70 active:transition-none dark:bg-sky-700 dark:hover:bg-sky-600 dark:active:bg-sky-700 dark:active:text-sky-100/70 transform hover:scale-105 active:scale-100 focus:ring-4 focus:ring-sky-500/50">
+    {{ i18n.archive.button }}
+  </a>
+</div>
 <!-- ===== top-post-cards1.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -72,7 +72,7 @@
                 </span>{{ /if }} #}}
             </a>
           </h3>
-          <p class="mt-5 line-clamp-3 text-sm/6 text-zinc-600 dark:text-zinc-300">
+          <p class="mt-5 line-clamp-3 text-sm/6 text-zinc-900 dark:text-zinc-300">
             {{ post.excerpt |> md(true) }}
           </p>
         </div>

--- a/src/_includes/templates/top-post-list.vto
+++ b/src/_includes/templates/top-post-list.vto
@@ -13,7 +13,7 @@
       }}
     </div>
     <h2
-      class="text-base font-semibold tracking-tight text-zinc-900 dark:text-zinc-100"
+      class="text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-100"
     >
       <div
         class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-zinc-800/50"

--- a/src/_includes/templates/top-post-list3.vto
+++ b/src/_includes/templates/top-post-list3.vto
@@ -2,7 +2,7 @@
 {{# <div class="bg-white py-24 sm:py-32">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
-      <h2 class="text-4xl font-semibold tracking-tight text-balance text-zinc-900 sm:text-5xl">From the blog</h2>
+      <h2 class="text-4xl font-semibold tracking-tight text-balance text-zinc-950 sm:text-5xl">From the blog</h2>
       <p class="mt-2 text-lg/8 text-zinc-600">Learn how to grow your business with our expert advice.</p>
     </div> #}}
 <div

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -11,7 +11,7 @@
             <br class="block sm:hidden"> #}}
             <span class="subpixel-antialiased">{{ site.title }}</span>
           </h1>
-          <p class="mt-6 text-base text-zinc-900 dark:text-zinc-400">
+          <p class="mt-6 text-base text-zinc-950 dark:text-zinc-400">
             {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
           </p>
           {{# {{ include "templates/socialicons.vto" }} #}}

--- a/src/generators/archive_result.page.js
+++ b/src/generators/archive_result.page.js
@@ -8,7 +8,8 @@ export default function* ({ search, lang, i18n, featuretags, featurecats }) {
     yield {
       ...featuretags.find((item) => item.key === tag), // <- Add the id and summary etc from featuretags
       url: `/archive/${tag}/`,
-      title: `${i18n.search.by_tag}:  ${i18n.punctuation.open_quote}${tag}${i18n.punctuation.close_quote}`,
+      title: `${i18n.search.by_tag}:`,
+      subtitle: `${i18n.punctuation.open_quote}${tag}${i18n.punctuation.close_quote}`,
       type: "tag",
       search_query: `type=post lang=${lang} '${tag}'`,
       tag,
@@ -19,7 +20,8 @@ export default function* ({ search, lang, i18n, featuretags, featurecats }) {
   for (const author of search.values("author", `lang=${lang}`)) {
     yield {
       url: `/author/${author}/`,
-      title: `${i18n.search.by_author}: ${i18n.punctuation.open_quote}${author}${i18n.punctuation.close_quote}`,
+      title: `${i18n.search.by_author}:`,
+      subtitle: `${i18n.punctuation.open_quote}${author}${i18n.punctuation.close_quote}`,
       type: "author",
       search_query: `type=post lang=${lang} author='${author}'`,
       author,
@@ -31,7 +33,8 @@ export default function* ({ search, lang, i18n, featuretags, featurecats }) {
     yield {
       ...featurecats.find((item) => item.key === category), // <- Add the id and summary etc from featurecats
       url: `/category/${category}/`,
-      title: `${i18n.search.by_category}: ${i18n.punctuation.open_quote}${category}${i18n.punctuation.close_quote}`,
+      title: `${i18n.search.by_category}:`,
+      subtitle: `${i18n.punctuation.open_quote}${category}${i18n.punctuation.close_quote}`,
       type: "category",
       search_query: `type=post lang=${lang} category='${category}'`,
       category,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -149,3 +149,30 @@ document.addEventListener('keydown', function(event) {
         }
     }
 });
+
+// For TOC details opening
+// This script will automatically open the Table of Contents (ToC) on medium and larger screens
+document.addEventListener('DOMContentLoaded', () => {
+    const tocDetails = document.getElementById('toc-details');
+    if (!tocDetails) {
+        console.warn('Table of Contents details element not found!');
+        return;
+    }
+    const handleDetailsState = () => {
+        const isMediumOrLargeScreen = window.matchMedia('(min-width: 768px)').matches;
+
+        if (isMediumOrLargeScreen) {
+            // On medium and larger screens:
+            // The 'open' attribute is set in the HTML. We DO NOT modify it here.
+            // This allows the user to freely open/close the ToC, and their action will persist.
+        } else {
+            // On smaller screens:
+            // Ensure the ToC is always closed by default (remove 'open' if present).
+            tocDetails.removeAttribute('open');
+        }
+    };
+    // Set initial state on page load
+    handleDetailsState();
+    // Re-evaluate state on window resize
+    window.addEventListener('resize', handleDetailsState);
+});

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -20,14 +20,36 @@ window.addEventListener('scroll', () => {
   const topNavBG = document.getElementById('top-nav-bg');
   const scrollPosition = window.scrollY;
 
-  // Handle logo swap
-  if (scrollPosition > 10) {
-      largeLogo.classList.add('opacity-0');
-      smallLogo.classList.remove('opacity-0');
-  } else {
-      largeLogo.classList.remove('opacity-0');
-      smallLogo.classList.add('opacity-0');
+  // Check if the current screen size is 'md' (768px) or larger
+  // (Tailwind's default 'md' breakpoint is 768px)
+  const isLargeScreen = window.matchMedia('(min-width: 768px)').matches;
+
+  // --- Handle logo swap only for 'md' and larger screens ---
+  if (isLargeScreen) {
+    if (largeLogo && smallLogo) { // Defensive check
+      if (scrollPosition > 10) {
+        largeLogo.classList.remove('md:opacity-100'); // Remove large logo opacity
+        largeLogo.classList.add('opacity-0');    // Hide large logo
+        smallLogo.classList.remove('md:opacity-0'); // Show small logo
+      } else {
+        largeLogo.classList.remove('opacity-0'); // Show large logo
+        largeLogo.classList.add('md:opacity-100'); // Set large logo opacity
+        smallLogo.classList.add('md:opacity-0');    // Hide small logo
+      }
+    }
   }
+  // For small screens, the Tailwind CSS classes now handle visibility:
+  // - large-logo is `hidden` by default.
+  // - small-logo is `opacity-100` by default.
+  // So, no specific JS logic is needed for logos on small screens here.
+
+  // IMPORTANT: Keep these to ensure correct state on load and resize
+  window.addEventListener('DOMContentLoaded', () => {
+      window.dispatchEvent(new Event('scroll'));
+  });
+  window.addEventListener('resize', () => {
+      window.dispatchEvent(new Event('scroll'));
+  });
 
   // Handle nav opacity changes based on scroll position
   if (scrollPosition > 50) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,9 +18,9 @@
   }
 
   /* You could also style specific link states globally */
-  a:focus {
+  /* a:focus {
     @apply outline-none ring-2 ring-sky-700/50 ring-offset-2;
-  }
+  } */
 }
 @layer components {
   /* Apply base styles to tables with not-prose */

--- a/src/styles.css
+++ b/src/styles.css
@@ -120,7 +120,7 @@
 }
 
 body article > div > p:first-of-type {
-  @apply text-base text-lg lg:text-xl font-light leading-relaxed text-zinc-900 dark:text-zinc-200;
+  @apply text-base text-lg lg:text-xl font-light leading-relaxed text-zinc-950 dark:text-zinc-200;
 }
 
 body article > div > figure > picture > img {
@@ -129,7 +129,7 @@ body article > div > figure > picture > img {
 
 /* MDN keyboard shortcut style for kbd tag */
 kbd {
-  @apply bg-zinc-200 rounded border border-zinc-400 shadow-md text-zinc-900 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap
+  @apply bg-zinc-200 rounded border border-zinc-400 shadow-md text-zinc-950 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap
 }
 
 /*----------------------------

--- a/src/styles.css
+++ b/src/styles.css
@@ -243,4 +243,20 @@ mark {
   transform: translateX(0);
 }
 
+/* TOC */
+/* Remove default padding some browsers apply to summary */
+summary {
+  padding: 0;
+}
+
+/* Optional: Adjust spacing between summary and content when open on small screens */
+details[open] > summary {
+  margin-bottom: 0.5rem; /* Or adjust as needed for your design */
+}
+
+/* Ensure the ul within details doesn't have unwanted top margin if prose changes its default */
+#toc-details ul {
+  margin-top: 0;
+}
+
 /* lume-google-fonts-here */


### PR DESCRIPTION
20e1c17c9bc59d94952d181ecb2f98f751badf54
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue May 20 09:10:25 2025 +0900

### Refactor ToC
ToC takes up space on mobile, so I refactored into a summary / details block, using javascript to force it open on larger screens from md breakpoint and above.

Small screens - ToC is closed by default but viewer can click the exposure triangle to expand.
Large screens - ToC is open by default, but viewer can click the exposure triangle to contract.



57393158f6db54916f1393567bab8a58da7f1553
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue May 20 09:08:24 2025 +0900

### Remove a11y ring
I had added a default accessibility ring for any anchor tag, but it causes a bit of visual conflict and I need to research it more to find a better implementation. Removed for now.



02f072a7610e3d52162c2ae5b9af88fa27ff94d0
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue May 20 05:12:25 2025 +0900

### Add Responsive singleton top margin and text size
Top margin is too big on small screens, so make it more compact, and adjust text size to screen.



aed57f1e9e6f934df1ecb41159abc706771084cf
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue May 20 04:45:04 2025 +0900

### Refactor top nav
Use fixed symbol logo for mobile to md breakpoint, then switch to "fade and swap" from there. Required responsive class settings and javascript window.matchmedia

Small screens:
Fixed small logo in nav
No large logo

### Large screens:
Large logo visible at top
On scroll, fade large logo and replace with the small logo in the nav



8513ccd5333682771a3b932e528e205f070959c0
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 20:07:13 2025 +0900

### Add Archive Link under Top Cards
Add cta button for browsing archive, at the bottom of the top post card grid.

Same color and functionality as other cta buttons on top.



3741cf570bca83b5bf3e81ddee8926a8f73e58d3
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 19:48:37 2025 +0900

### Link eSolia in top copy
Removed eSolia link from nav, but it should be somewhere prominent for SEO purposes and to show this is an eSolia property. Added a link to the top marketing copy.



37d79b5a58f80c1f339d41bbdc795d99ce00e86e
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 19:41:56 2025 +0900

### Search icon to blue
Change search icon to blue, with blue hover, but leave mode switch alone



7a03e5cbfd69bff2045b82548c5707f3c1707ddf
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 18:22:20 2025 +0900

### Hide back button for mobile sizes
Mobile browsers have a back button, so the back button is not needed for small screen sizes.

Hide it until md breakpoint for page, post, archive result singleton.



98aceee6ad211d629a9b9206ee46f5fc1786002e
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 18:12:52 2025 +0900

### Archive detail page formatting
Script was producing the "title" as one long string. Broke it up into two in the generator, so that we can have title and subtitle, and format them separately.

Format the title (category, tag or author) as light font, then the actual thing as bold. This mimics the archive page, in that "archive" is light.



0422f211b74ff855c12a93e038778a82cbd44c00
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 17:54:40 2025 +0900

### Make archive main page match top
Archive main page had blog name thin, and archive thick.
Reversed it so that the blog name is more similar to top.
Word "archive" is thin and eSolia logo blue



6212a2cc239c0d0c397cbc661947ef9a691b6cab
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 17:53:28 2025 +0900

### Darken text further
Need to specify text color in prose



814f53c2e2496aed7bccb2239b9871c8c7fc347c
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 17:21:27 2025 +0900

### Darken text
Make text 950



ec9a6b836b7d28a7abf731da295a9ecd4eedc1c5
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon May 19 17:20:06 2025 +0900

### Delete eSolia link on top nav
Delete in data but make it so it can be resurrected easily. Also add conditional so that if it is blank, the nav bar does not break. Add link elsewhere for SEO.

![JRC CleanShot Polypane 2025-05-20-091418JST@2x](https://github.com/user-attachments/assets/03afd33d-685b-4f25-b2cd-0d24dc5be4c4)
![JRC CleanShot Polypane 2025-05-20-091553JST@2x](https://github.com/user-attachments/assets/b4e21f0d-4a5b-42a8-aeb0-0abea218d636)
![JRC CleanShot Polypane 2025-05-20-091722JST@2x](https://github.com/user-attachments/assets/c246e5cd-3209-4093-a8bb-ed659449e032)
![JRC CleanShot Microsoft Edge 2025-05-20-091818JST@2x](https://github.com/user-attachments/assets/a66233f4-0830-47ea-9d4b-9ff8472f2cfb)



