### PR TITLE
Test font-normal for lede in post singleton

### DIFF
--- a/src/_includes/layouts/page.vto
+++ b/src/_includes/layouts/page.vto
@@ -16,7 +16,7 @@ bodyClass: body-tag
               <article data-pagefind-body data-title="{{ title }}" data-pagefind-index-attrs="data-title">
                 <header class="flex flex-col">
                   <h1
-                    class="mt-0 text-3xl font-bold tracking-tight sm:text-4xl subpixel-antialiased xtext-shadow-xs xtext-shadow-zinc-300 bg-gradient-to-r from-esoliablue-700 via-sky-900 to-esoliablue-800 bg-clip-text text-transparent"
+                    class="mt-0 text-3xl font-bold tracking-tight sm:text-4xl subpixel-antialiased bg-gradient-to-r from-esoliablue-700 via-sky-900 to-esoliablue-800 bg-clip-text text-transparent"
                   >
                     {{ title }}
                   </h1>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,3 +1,20 @@
+// Load this first
+(function() {
+    var userAgent = navigator.userAgent || navigator.vendor || window.opera;
+
+    if (/windows phone/i.test(userAgent)) {
+        document.body.classList.add('os-windows-phone');
+    } else if (/android/i.test(userAgent)) {
+        document.body.classList.add('os-android');
+    } else if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+        document.body.classList.add('os-ios');
+    } else if (/Mac/i.test(userAgent)) {
+        document.body.classList.add('os-mac');
+    } else if (/Win/i.test(userAgent)) { // This would catch most Windows desktops/laptops
+        document.body.classList.add('os-windows');
+    }
+})();
+
 // Function to load a script from a CDN with additional attributes
 function loadVendorScript(src, attributes, callback) {
   var script = document.createElement('script');

--- a/src/styles.css
+++ b/src/styles.css
@@ -119,8 +119,22 @@
   @apply text-lg font-light leading-relaxed;
 }
 
+/* Default lede paragraph styles (Mac, Linux, etc.) */
+/* font-weight: 300; */
 body article > div > p:first-of-type {
   @apply text-base text-lg lg:text-xl font-light leading-relaxed text-zinc-950 dark:text-zinc-200;
+}
+
+/* Specific styles for Windows devices */
+/* More specific due to `body.os-windows`; overrides default */
+body.os-windows article > div > p:first-of-type {
+  /* Only override the font-weight, and it will use others*/
+  /* This is a workaround for the blurriness issue on Windows */
+  /* font-normal (font-weight: 400) */
+  @apply font-normal;
+
+  /* font-medium (font-weight: 500) */
+  /* @apply font-medium; */
 }
 
 body article > div > figure > picture > img {


### PR DESCRIPTION
f7af1f176dc3ef4743b74ec71522db4c216f2762
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue May 20 15:10:51 2025 +0900

### Test using font-normal in lede
Windows may respond better to weight 400, so start with the area on the page that Ena san specifically pointed out, the lede para.

Javascript gets the user OS, and puts it in the body tag.

The CSS will target that, so Windows will get a heavier font in the lede.

Let's see if it works.



77d66f141355e88d86483eaf08fb1853ce4b9e5a
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue May 20 15:09:18 2025 +0900

### Tidy
Removed unused classes



