### PR TITLE
TOC and alert contrast, 3x variant for grid photos, meta entities link bug fix

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -14,6 +14,7 @@ import metas from "lume/plugins/metas.ts";
 import multilanguage from "lume/plugins/multilanguage.ts";
 import nav from "lume/plugins/nav.ts";
 import pagefind from "lume/plugins/pagefind.ts";
+import plaintext from "lume/plugins/plaintext.ts";
 import prism from "lume/plugins/prism.ts";
 import "npm:prismjs@1.29.0/components/prism-git.js";
 import "npm:prismjs@1.29.0/components/prism-json.js";
@@ -104,6 +105,7 @@ site.use(pagefind({
   element: "#search",
   resetStyles: false,
 }));
+site.use(plaintext());
 site.use(prism({
   theme: [
     {

--- a/_config.ts
+++ b/_config.ts
@@ -69,7 +69,7 @@ import sitemap from "lume/plugins/sitemap.ts";
 // import seo from "https://raw.githubusercontent.com/timthepost/cushytext/refs/heads/main/src/_plugins/seo/mod.ts";
 
 // Final minification and compression 
-import minify_html from "lume/plugins/minify_html.ts";
+// import minify_html from "lume/plugins/minify_html.ts";
 import brotli from "lume/plugins/brotli.ts";
 
 
@@ -388,7 +388,7 @@ site.use(sitemap({
 // );
 
 // Optimize HTML
-site.use(minify_html());
+// site.use(minify_html());
 site.use(brotli());
 
 

--- a/src/_includes/css/alerts.css
+++ b/src/_includes/css/alerts.css
@@ -7,7 +7,7 @@ body {
   border-left: solid 4px var(--color);
   background-color: var(--bgcolor);
   font: var(--font-sans);
-  color: var(--color-zinc-500);
+  color: var(--color-zinc-900);
 
     & :last-child {
       margin-bottom: 0;
@@ -15,7 +15,7 @@ body {
   }
 
   .markdown-alert-title {
-    color: var(--color-zinc-800);
+    color: var(--color-zinc-950);
     font: var(--font-sans);
     margin: 0;
     display: flex;

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -5,7 +5,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ it.title || metas.title }} - {{ site.title }}</title>
+    <title>{{ title |> plaintext }} - {{ site.title }}</title>
 
     <meta name="supported-color-schemes" content="light dark">
     <meta

--- a/src/_includes/layouts/page.vto
+++ b/src/_includes/layouts/page.vto
@@ -20,27 +20,8 @@ bodyClass: body-tag
                   >
                     {{ title }}
                   </h1>
-
                   {{# {{ if toc.length }}
-                    <nav class="max-w-2xl mt-4 mr-auto bg-white prose dark:prose-invert dark:bg-zinc-800 p-6 rounded-lg shadow-md">
-                      <h2 class="mb-1 font-light">{{ i18n.nav.toc }}</h2>
-                      <ul class="list-disc list-inside space-y-2 text-sm font-light">
-                        {{ for item of toc }}
-                        <li class="font-light">
-                          <a class="text-zinc-500 hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
-                          {{ if item.children.length }}
-                          <ul>
-                            {{ for child of item.children }}
-                            <li>
-                              <a href="#{{ child.slug }}">{{ child.text }}</a>
-                            </li>
-                            {{ /for }}
-                          </ul>
-                          {{ /if }}
-                        </li>
-                        {{ /for }}
-                      </ol>
-                    </nav>
+                    {{ include "templates/page-toc.vto" }}
                   {{ /if }} #}}
                 </header>
                 <div

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -21,31 +21,8 @@ bodyClass: body-post
                   >
                     {{ title }}
                   </h1>
-
                   {{ if toc.length }}
-                    <nav class="max-w-2xl mt-6 mr-auto bg-zinc-50 prose prose-zinc dark:prose-invert dark:bg-zinc-800 p-2 pr-8 md:p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5 prose-a:transition">
-                      <details id="toc-details" class="block" open>
-                        <summary class="cursor-pointer md:cursor-default p-0">
-                          <h2 class="text-base md:text-xl -mt-4 -mb-2 p-0 font-light inline-block">{{ i18n.nav.toc }}</h2>
-                        </summary>
-                        <ul class="list-disc list-inside space-y-2 text-sm">
-                          {{ for item of toc }}
-                          <li class="">
-                            <a class="font-light text-zinc-700 hover:text-sky-600 dark:text-zinc-200 dark:hover:text-sky-500" href="#{{ item.slug }}">{{ item.text }}</a>
-                            {{ if item.children.length }}
-                            <ul>
-                              {{ for child of item.children }}
-                              <li>
-                                <a class="font-light text-zinc-700 hover:text-sky-600 dark:text-zinc-200 dark:hover:text-sky-500" href="#{{ child.slug }}">{{ child.text }}</a>
-                              </li>
-                              {{ /for }}
-                            </ul>
-                            {{ /if }}
-                          </li>
-                          {{ /for }}
-                        </ol>
-                      </details>
-                    </nav>
+                    {{ include "templates/page-toc.vto" }}
                   {{ /if }}
                 </header>
                 <div

--- a/src/_includes/templates/page-toc.vto
+++ b/src/_includes/templates/page-toc.vto
@@ -1,0 +1,25 @@
+<!-- ===== page-toc.vto TEMPLATE START ===== -->
+<nav class="max-w-2xl mt-6 mr-auto bg-zinc-50 prose prose-zinc prose-a:font-light prose-a:text-zinc-900 prose-a:opacity-100 prose-a:hover:bg-white prose-a:transition prose-a:hover:text-sky-600 prose-a:hover:font-semibold dark:prose-a:text-zinc-200 dark:prose-a:hover:text-esoliaamber-600 dark:prose-invert dark:bg-zinc-800 p-2 pr-8 md:p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5">
+  <details id="toc-details" class="block" open>
+    <summary class="cursor-pointer md:cursor-default p-0">
+      <h2 class="text-base md:text-xl -mt-4 -mb-2 p-0 font-light inline-block">{{ i18n.nav.toc }}</h2>
+    </summary>
+    <ul class="list-disc list-inside space-y-2 text-sm">
+      {{ for item of toc }}
+      <li class="">
+        <a class="" href="#{{ item.slug }}">{{ item.text }}</a>
+        {{ if item.children.length }}
+        <ul>
+          {{ for child of item.children }}
+          <li>
+            <a class="" href="#{{ child.slug }}">{{ child.text }}</a>
+          </li>
+          {{ /for }}
+        </ul>
+        {{ /if }}
+      </li>
+      {{ /for }}
+    </ol>
+  </details>
+</nav>
+<!-- ===== page-toc.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -28,7 +28,7 @@
           loading="lazy"
           fetchpriority="high"
           decoding="async"
-          transform-images="avif webp jpg 600@2"
+          transform-images="avif webp jpg 600@2 600@3"
         >
         <div
           class="absolute inset-0 rounded-2xl ring-1 ring-zinc-900/10 ring-inset"

--- a/src/styles.css
+++ b/src/styles.css
@@ -137,6 +137,10 @@ body.os-windows article > div > p:first-of-type {
   /* @apply font-medium; */
 }
 
+body.os-windows header > nav {
+  @apply prose-a:font-normal;
+}
+
 body article > div > figure > picture > img {
   @apply shadow-md rounded-md;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -49,7 +49,7 @@
   }
     /* Override the prose <a> tag hover classes */
   .prose :where(a) {
-    @apply hover:opacity-60;
+    @apply hover:opacity-70;
   }
 
   .prose figure + p {


### PR DESCRIPTION
9e4a949b6be6c1d8efb38b281c8276077e7b4d18
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 09:03:17 2025 +0900

### Refactor toc and alert css
TOC is moved to partial and conditionally pulled into page or post templates, if there is a TOC.

Partial page-toc.vto is refactored, so it remains as prose for the good formatting as base, but also has a lot of exception processing using prose-a:blahblah. Now the a tags look sharp.

A windows-specific css class targets the TOC's nav specifically, increasing font weight a notch for windows users.

Also alert callout text is not so gray.

Fixes: #227



3eb2d1bfed7c4d073d7ae909c272b597c9b43b58
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 08:57:56 2025 +0900

### Add 3x variant to top page photos
For super high resolution monitors, added a 3x variant. Measured the screen pix for the images and it's about 300, so the plugin is generating 600@2 and 600@3 in avif, webp, jpeg, for browsers to pick from.



420fdc0eb210b77fd372b3e4e358b9dc87f49787
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 08:55:42 2025 +0900

### Adjust anchor tag hover opacity
Make the opacity change less pronounced



e4a102a3f145a9afff0167b52e8b5450b901ae94
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 21 08:54:05 2025 +0900

### Fix html entities leaking into metadata
Noticed a br tag as entities in the browser tab, so figured out how to filter it out using the plaintext plugin.

Also removed reference to metas.title since that does not work in this context.

Fixes: #224



