### PR TITLE
Pre-launch polish

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -102,8 +102,13 @@ site.use(multilanguage({
 }));
 site.use(nav());
 site.use(pagefind({
-  element: "#search",
-  resetStyles: false,
+  ui: {
+    containerId: "search",
+    showImages: false,
+    showEmptyFilters: true,
+    resetStyles: false,
+    showSubResults: true,
+  },
 }));
 site.use(plaintext());
 site.use(prism({

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v3.0.1/",
+    "lume/": "https://deno.land/x/lume@v3.0.2/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.5/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.10/jsx-runtime.ts"
   },
@@ -28,7 +28,7 @@
       ]
     },
     "plugins": [
-      "https://deno.land/x/lume@v3.0.1/lint.ts"
+      "https://deno.land/x/lume@v3.0.2/lint.ts"
     ]
   },
   "fmt": {

--- a/src/_includes/css/alerts.css
+++ b/src/_includes/css/alerts.css
@@ -5,12 +5,16 @@ body {
   margin-block: 1.5rem;
   padding: 0.5rem 1rem;
   border-left: solid 4px var(--color);
+  border-radius: var(--radius-sm);
   background-color: var(--bgcolor);
   font: var(--font-sans);
   color: var(--color-zinc-900);
+    & li {
+      line-height: 0.5rem;
+    }
 
     & :last-child {
-      margin-bottom: 0;
+      margin-bottom: 0.25rem;
     }
   }
 

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -8,7 +8,7 @@ script: /js/fathom-post-list-event.js
   <div class="mt-16 sm:mt-32 sm:px-8">
     <div class="mx-auto w-full max-w-full lg:px-8">
       <div class="relative px-4 sm:px-8 lg:px-12">
-        <div class="mx-auto max-w-2xl lg:max-w-5xl">
+        <div id="archive" class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl">
             <h1
               class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl tracking-tight text-zinc-950 dark:text-zinc-100"

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -15,7 +15,7 @@
     >
     <meta
       name="theme-color"
-      content="hsl(237.79 38% 28.000000000000004%)"
+      content="hsl(200, 98%, 39%)"
       media="(prefers-color-scheme: dark)"
     >
 

--- a/src/_includes/layouts/page.vto
+++ b/src/_includes/layouts/page.vto
@@ -13,7 +13,7 @@ bodyClass: body-tag
               <div class="hidden md:block"><a type="button" href="/{{ if lang === "en"}}en{{/if}}" aria-label="{{ i18n.nav.return_home }}" class="btn group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1  ring-zinc-900/5 transition lg:absolute lg:-left-5 lg:-mt-2 lg:mb-0 xl:-top-1.5 xl:left-0 xl:mt-0 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
               <img class="size-6 stroke-zinc-300 transition group-hover:stroke-zinc-700 dark:stroke-zinc-500 dark:group-hover:stroke-zinc-400" src="{{ "arrow-left" |> icon("phosphor", "duotone") }}" inline />
               </a></div>
-              <article data-pagefind-body data-title="{{ title }}" data-pagefind-index-attrs="data-title">
+              <article id="page" data-pagefind-body data-title="{{ title }}" data-pagefind-index-attrs="data-title">
                 <header class="flex flex-col">
                   <h1
                     class="mt-0 text-3xl font-bold tracking-tight sm:text-4xl subpixel-antialiased bg-gradient-to-r from-esoliablue-700 via-sky-900 to-esoliablue-800 bg-clip-text text-transparent"

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -26,7 +26,7 @@ bodyClass: body-post
                   {{ /if }}
                 </header>
                 <div
-                  class="prose max-w-[70ch] prose-zinc text-zinc-950 sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
+                  class="prose max-w-[70ch] prose-zinc text-zinc-950 dark:text-zinc-100 sm:prose-sm md:prose-base lg:prose-lg dark:prose-invert prose-a:underline prose-a:decoration-1 prose-a:transition mt-8"
                   data-mdx-content="true"
                 >
                 {{ content }}

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -13,7 +13,7 @@ bodyClass: body-post
               <div class="hidden md:block"><a type="button" href="/{{ if lang === "en"}}en{{/if}}" aria-label="{{ i18n.nav.return_home }}" class="btn group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1  ring-zinc-900/5 transition lg:absolute lg:-left-5  lg:-mt-0 lg:mb-0 xl:-top-0 xl:left-0 xl:-mt-0 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
               <img class="size-6 stroke-zinc-300 transition group-hover:stroke-zinc-700 dark:stroke-zinc-500 dark:group-hover:stroke-zinc-400" src="{{ "arrow-left" |> icon("phosphor", "duotone") }}" inline />
               </a></div>
-              <article data-pagefind-body data-title="{{ title }}" data-pagefind-index-attrs="data-title">
+              <article id="post" data-pagefind-body data-title="{{ title }}" data-pagefind-index-attrs="data-title">
                 <header class="flex flex-col -top-4">
                   {{# {{ include "templates/post-details.vto" { elapsed: elapseddays } }} #}}
                   <h1

--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -35,7 +35,7 @@
       </nav>
     </div>
     <div
-      class="flex flex-col items-center border-t border-slate-400/10 py-10 sm:flex-row-reverse sm:justify-between no-external-icon"
+      class="flex flex-col items-center border-t border-zinc-400/10 py-10 sm:flex-row-reverse sm:justify-between no-external-icon"
     >
       <div class="mt-6 flex flex-wrap gap-6">
         <a

--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -1,5 +1,5 @@
 <!-- ===== footer.vto TEMPLATE START ===== -->
-<footer class="mt-32 flex-none bg-zinc-100 dark:bg-zinc-800">
+<footer id="footer" class="mt-32 flex-none bg-zinc-100 dark:bg-zinc-800">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="py-16">
       <a

--- a/src/_includes/templates/page-toc.vto
+++ b/src/_includes/templates/page-toc.vto
@@ -1,5 +1,5 @@
 <!-- ===== page-toc.vto TEMPLATE START ===== -->
-<nav class="max-w-2xl mt-6 mr-auto bg-zinc-50 prose prose-zinc prose-a:font-light prose-a:text-zinc-900 prose-a:opacity-100 prose-a:hover:bg-white prose-a:transition prose-a:hover:text-sky-600 prose-a:hover:font-semibold dark:prose-a:text-zinc-200 dark:prose-a:hover:text-esoliaamber-600 dark:prose-invert dark:bg-zinc-800 p-2 pr-8 md:p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5">
+<nav id="page-toc" class="max-w-2xl mt-6 mr-auto bg-zinc-50 prose prose-zinc prose-a:font-light prose-a:text-zinc-900 prose-a:opacity-100 prose-a:hover:bg-white prose-a:transition prose-a:hover:text-sky-600 prose-a:hover:font-semibold dark:prose-a:text-zinc-200 dark:prose-a:hover:text-esoliaamber-600 dark:prose-invert dark:bg-zinc-800 p-2 pr-8 md:p-6 rounded-lg shadow-md ring-1 ring-zinc-900/5">
   <details id="toc-details" class="block" open>
     <summary class="cursor-pointer md:cursor-default p-0">
       <h2 class="text-base md:text-xl -mt-4 -mb-2 p-0 font-light inline-block">{{ i18n.nav.toc }}</h2>

--- a/src/_includes/templates/panel-categories.vto
+++ b/src/_includes/templates/panel-categories.vto
@@ -1,5 +1,5 @@
 <!-- ===== panel-categories.vto TEMPLATE START ===== -->
-<div class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
+<div id="panel-categories" class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
   <h2 class="flex text-sm font-semibold text-zinc-950 dark:text-zinc-100">
     <img
       alt=""

--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -1,5 +1,5 @@
 <!-- ===== panel-cta.vto TEMPLATE START ===== -->
-<div class="flex flex-col lg:flex-row lg:space-x-4">
+<div id="panel-cta" class="flex flex-col lg:flex-row lg:space-x-4">
   <form
     class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40 group"
     name="frm"

--- a/src/_includes/templates/post-details.vto
+++ b/src/_includes/templates/post-details.vto
@@ -1,5 +1,5 @@
 <!-- ===== post-details.vto TEMPLATE START ===== -->
-<div class="mt-2 flex flex-wrap items-center gap-x-4 text-xs">
+<div id="post-details" class="mt-2 flex flex-wrap items-center gap-x-4 text-xs">
   {{ if date !== "hide" }}
     <time
       datetime="{{ date }}"

--- a/src/_includes/templates/post-image.vto
+++ b/src/_includes/templates/post-image.vto
@@ -1,3 +1,3 @@
 <!-- ===== post-image.vto TEMPLATE START ===== -->
-<div class="w-full mt-20"><img class="opacity-90 rounded-md cover" src="{{ image }}" alt="Description of image"></div>
+<div id="post-image" class="w-full mt-20"><img class="opacity-90 rounded-md cover" src="{{ image }}" alt="Description of image"></div>
 <!-- ===== post-image.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/post-list.vto
+++ b/src/_includes/templates/post-list.vto
@@ -1,6 +1,6 @@
 <!-- ===== post-list.vto TEMPLATE START ===== -->
 {{ for post of postslist }}
-  <article class="md:grid md:grid-cols-4 md:items-baseline">
+  <article id="post-list" class="md:grid md:grid-cols-4 md:items-baseline">
     <div class="group relative flex flex-col items-start md:col-span-3">
       <h2
         class="text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-100"

--- a/src/_includes/templates/post-share.vto
+++ b/src/_includes/templates/post-share.vto
@@ -1,6 +1,6 @@
 <!-- ===== post-share.vto TEMPLATE START ===== -->
 <div
-  class="mx-auto my-16 max-w-sm overflow-hidden rounded-full shadow-md ring-1 ring-zinc-900/5 px-4 py-4 sm:py-2 lg:px-6 bg-zinc-50 dark:bg-zinc-800"
+  id="post-share" class="mx-auto my-16 max-w-sm overflow-hidden rounded-full shadow-md ring-1 ring-zinc-900/5 px-4 py-4 sm:py-2 lg:px-6 bg-zinc-50 dark:bg-zinc-800"
 >
   <div class="flex flex-wrap justify-center text-md p-1">
     <p

--- a/src/_includes/templates/post-share.vto
+++ b/src/_includes/templates/post-share.vto
@@ -4,7 +4,7 @@
 >
   <div class="flex flex-wrap justify-center text-md p-1">
     <p
-      class="text-zinc-600 text-center"
+      class="text-zinc-600 dark:text-zinc-200 text-center"
     >
       <span class="font-bold">{{ i18n.social.share_ask }}</span><br>
       <span class="font-base">{{ i18n.social.share_title }}</span>

--- a/src/_includes/templates/skiplink.vto
+++ b/src/_includes/templates/skiplink.vto
@@ -1,6 +1,6 @@
 <!-- ===== skiplink.vto TEMPLATE START ===== -->
 <a href="#main-content" 
-  class="absolute top-0 left-0 transform -translate-x-full z-[9999] focus-visible:translate-x-0 focus-visible:p-4 focus-visible:bg-sky-600 focus-visible:text-white focus-visible:border-2 focus-visible:border-sky-800 focus-visible:rounded-md focus-visible:underline focus-visible:font-semibold focus-visible:transition-all focus-visible:duration-300 focus-visible:ease-in-out focus:outline-none"
+  class="absolute top-0 left-0 transform -translate-x-full z-[9999] focus-visible:translate-x-0 focus-visible:p-4 focus-visible:bg-sky-600 focus-visible:text-white focus-visible:border-2 focus-visible:border-sky-800 focus-visible:rounded-md focus-visible:underline focus-visible:font-semibold focus-visible:transition-all focus-visible:duration-300 focus-visible:ease-in-out focus:outline-none sr-only"
   id="skip-to-content"
   role="link"
   aria-label="{{ i18n.home.skip_to_main_content_aria }}"

--- a/src/_includes/templates/skiplink.vto
+++ b/src/_includes/templates/skiplink.vto
@@ -1,5 +1,5 @@
 <!-- ===== skiplink.vto TEMPLATE START ===== -->
-<a href="#main-content" 
+<a id="skiplink" href="#main-content" 
   class="absolute top-0 left-0 transform -translate-x-full z-[9999] focus-visible:translate-x-0 focus-visible:p-4 focus-visible:bg-sky-600 focus-visible:text-white focus-visible:border-2 focus-visible:border-sky-800 focus-visible:rounded-md focus-visible:underline focus-visible:font-semibold focus-visible:transition-all focus-visible:duration-300 focus-visible:ease-in-out focus:outline-none sr-only"
   id="skip-to-content"
   role="link"

--- a/src/_includes/templates/social-icons.vto
+++ b/src/_includes/templates/social-icons.vto
@@ -1,5 +1,5 @@
 <!-- ===== socialicons.vto TEMPLATE START ===== -->
-<div class="mt-6 flex gap-6 no-external-icon">
+<div id="socialicons" class="mt-6 flex gap-6 no-external-icon">
   <a
     class="group -m-1 p-1"
     aria-label="{{ i18n.social.linkedin_label }}"

--- a/src/_includes/templates/top-lead.vto
+++ b/src/_includes/templates/top-lead.vto
@@ -1,5 +1,5 @@
 <!-- Hero section -->
-<div class="relative isolate -z-10">
+<div id="top-lead" class="relative isolate -z-10">
   <svg
     class="absolute inset-x-0 top-0 -z-10 h-[64rem] w-full stroke-zinc-200 [mask-image:radial-gradient(32rem_32rem_at_center,white,transparent)]"
     aria-hidden="true"

--- a/src/_includes/templates/top-main-cats1.vto
+++ b/src/_includes/templates/top-main-cats1.vto
@@ -1,5 +1,5 @@
-<!-- ===== top-main-tags1.vto TEMPLATE START ===== -->
-<div class="flex space-x-2 bg-zinc-100 dark:bg-zinc-700 p-2 rounded-md">
+<!-- ===== top-main-cats1.vto TEMPLATE START ===== -->
+<div id="top-main-cats" class="flex space-x-2 bg-zinc-100 dark:bg-zinc-700 p-2 rounded-md">
   {{# <span class="inline-flex items-center rounded-full bg-zinc-50 px-2 py-1 text-xs font-medium text-zinc-600 ring-1 ring-zinc-500/10 ring-inset">M365</span> #}}
   {{
     set pageCats = search.pages(`type=category lang=${lang}`, "category=desc-locale")
@@ -21,4 +21,4 @@
     </div>
   {{ /if }}
 </div>
-<!-- ===== top-main-tags1.vto TEMPLATE END ===== -->
+<!-- ===== top-main-cats1.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/top-nav.vto
+++ b/src/_includes/templates/top-nav.vto
@@ -1,5 +1,5 @@
 <!-- ===== top-nav.vto TEMPLATE START ===== -->
-<header class="pointer-events-none relative z-50 flex flex-none flex-col">
+<header id="top-nav" class="pointer-events-none relative z-50 flex flex-none flex-col">
   <div class="order-last mt-[calc(--spacing(16)-(--spacing(3)))]"></div>
   <div class="top-0 order-last -mb-3 pt-3 sm:px-8">
     <div class="mx-auto w-full max-w-7xl lg:px-8">

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -1,6 +1,6 @@
 <!-- ===== top-post-cards1.vto TEMPLATE START ===== -->
 <div
-  class="mx-auto mt-2 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3"
+  id="top-post-cards" class="mx-auto mt-2 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3"
 >
   {{ for post of search.pages(`type=post lang=${lang}`, "date=desc", 6) }}
     <!-- == CARD == -->

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -4,7 +4,7 @@
 >
   {{ for post of search.pages(`type=post lang=${lang}`, "date=desc", 6) }}
     <!-- == CARD == -->
-    <article class="flex flex-col items-start">
+    <article class="flex flex-col items-start group">
       <div class="relative w-full">
         {{
           set catColor = featurecats.find((item) => item.key === post.category)?.color
@@ -24,7 +24,7 @@
           {{# src="{{ if catImage }}{{ catImage }}{{ else }}/assets/cat0-bg.jpg{{ /if }}" #}}
           src="{{ if post.image_top }}{{ post.image_top }}{{ else }}/assets/blog-esolia-pro-default-top.png{{ /if }}"
           alt=""
-          class="aspect-video w-full rounded-2xl bg-blend-overlay object-cover sm:aspect-2/1 lg:aspect-3/2 transition-opacity duration-300 mix-blend-normal dark:mix-blend-luminosity"
+          class="aspect-video w-full rounded-2xl bg-blend-overlay object-cover sm:aspect-2/1 lg:aspect-3/2 transition-all delay-50 duration-50 mix-blend-normal dark:mix-blend-luminosity group-hover:opacity-99"
           loading="lazy"
           fetchpriority="high"
           decoding="async"
@@ -55,7 +55,7 @@
             <a
               href="{{ post.url }}"
               data-faid="{{ post.lang }}-{{ if post.id.length > 0 }}{{ post.id }}{{ else }}{{ loop.index }}{{ /if }}"
-              class="data-fatrigger text-zinc-950 hover:text-sky-500 dark:text-zinc-50 dark:hover:text-sky-500"
+              class="data-fatrigger text-zinc-950 group-hover:text-sky-500 dark:text-zinc-50 dark:group-hover:text-sky-500 transition-all delay-0 duration-50"
               {{ if post.url == url }}
                 aria-current="page"{{ /if }}
             >

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -2,7 +2,7 @@
 <div
   class="mx-auto mt-2 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3"
 >
-  {{ for post of search.pages(`type=post lang=${lang}`, "date=desc", 10) }}
+  {{ for post of search.pages(`type=post lang=${lang}`, "date=desc", 6) }}
     <!-- == CARD == -->
     <article class="flex flex-col items-start">
       <div class="relative w-full">

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -1,5 +1,5 @@
 <!-- ===== top-welcome-header.vto TEMPLATE START ===== -->
-<div class="mt-6 sm:px-8">
+<div id="top-welcome-header" class="mt-6 sm:px-8">
   <div class="mx-auto w-full max-w-7xl lg:px-8">
     <div class="relative px-4 sm:px-8 lg:px-12">
       <div class="mx-auto max-w-2xl lg:max-w-5xl">

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "short_name": "ETIEB",
   "name": "eSolia Tech It Easy Blog",
   "start_url": "/",
-  "background_color": "#2d2f63",
+  "background_color": "#0284c7",
   "theme_color": "#ffbc68",
   "display": "standalone",
   "icons": [


### PR DESCRIPTION
Polishes site by upgrading lume to latest, limiting top cards to 6, correcting color in dark mode, improving styling for alert cards, increasing the hover and click target for top cards, correcting search settings.

7617c514278f272a60d8799deee13c5abfb241fa
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 29 06:10:51 2025 +0900

### Improves click target for top cards
Top cards could only be clicked on their title previously. Improves by adding "group" and "group-hover" to the elements as appropriate, increasing the size of the click target to the card's size, and causes a subtle visual transition when viewer hovers anywhere on the card.

A bonus is, you can still click the category if you focus your mouse on it.



cd6783bc6afb7e1dfec71146b87ca02512a1141b
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 29 05:34:50 2025 +0900

### Improves styling for alert callouts
Adds slight border radius, reduces leading for li elements, adds slight margin on bottom.



9b07f795143bc4ccb95fc3e93b74427c88e0e634
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 29 05:33:35 2025 +0900

### Fixes dark mode contrast
The post paragraphs and post share section were low-to-no contrast in dark mode. Fix by specifying color for dark:.



fd59d7ed5466e7b0a9f752fd0b5e602fb46d8207
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 29 05:16:15 2025 +0900

### Adds id's to all sections
Having an id on all major elements makes it easier to target style in css, when needed.



711caf5b5e93cb50a89fa6e43e13d5795beb5d9f
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Thu May 29 05:15:33 2025 +0900

### Sets app background to sky
App background does not look great if it's navy, so set it to sky, which goes well with amber. It is nicely visible on iPhone at night as this setting colors the top of the UI. It changes to Amber in the day.



235aaa52dc3ed33ddac83cd2d0019dfa91b52d05
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 28 21:07:14 2025 +0900

### Fixes small color error
Standard for this site is the gray color "zinc", not slate.



26138a8511c2c4274c10c343b0dbf5e1dcea07b6
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 28 21:04:25 2025 +0900

### Hides skiplink for sighted users
Set skiplink to be visible for screen reader users only. Will research and reenable when we understand how to control it better, as it is useful for keyboard users.



ef185f8aa4f4cbcaca03cd4f19defc6b446ebcbf
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 28 21:01:42 2025 +0900

### Limits top cards grid to 6 cards
Top card grid uses vento query to limit the number of cards, and the agreed number is six, so set it to that.



2caf075aa650e8be7d9d96872b05fd09aed3c04d
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 28 20:57:42 2025 +0900

### Corrects pagefind settings
Pagefind has its settings as an object under the ui key, so change to that, and enable sub results.



c413e0eaa1bf311b2c187ca79521a1ecc7e85252
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Wed May 28 20:56:38 2025 +0900

### Upgrades to Lume 3.0.2
More bug fixes after major release



