### PR TITLE
Moves activityhub hub and rel self link to head

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,7 +32,6 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
     Permissions-Policy = "autoplay=(), camera=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=()"
-    Link = "<https://pubsubhubbub.superfeedr.com/>; rel=hub"
 
 [[redirects]]
 from = "/en/*"

--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -37,6 +37,9 @@
       title="{{ site.title }}"
     >
     <link rel="canonical" href="{{ url |> url(true) }}">
+    <link rel="self" href="{{ url |> url(true) }}">
+    <link rel="hub" href="https://pubsubhubbub.superfeedr.com/">
+    
     {{# Various js, such as Alpine and Fathom and the theme toggle script #}}
     <script src="/js/main.js?cb={{ cacheBuster }}" type="module" defer></script>
     <link rel="manifest" href="/manifest.json" crossorigin="use-credentials">


### PR DESCRIPTION
4a06f78aee6322d0a54e1e97056dd432f6329459
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Mon Jun 2 08:33:21 2025 +0900

### Moves activityhub hub and rel self link to head
Had pubsubhubbub hub link in headers, but there were some errors so we will do the alternative of putting it in the <head> section.




