### PR TITLE
Upgrade to lume 3 dev and latest deno, minify css, balance table

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -260,7 +260,9 @@ site.use(googleFonts({
       "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@100;200;300;400;500;600;700&display=swap",
   },
 }));
-site.use(tailwindcss());
+site.use(tailwindcss({
+  minify: true
+}));
 site.use(source_maps());
 
 // Modify URLs

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v3.0.2/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.5/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@c8e5609d81c42347078db2759b3cc75dfb4c6ae8/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@a134eae6e5dc0c2f6910702f68321d7d89532c9e/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.10/jsx-runtime.ts"
   },
   "tasks": {
@@ -28,7 +28,7 @@
       ]
     },
     "plugins": [
-      "https://deno.land/x/lume@v3.0.2/lint.ts"
+      "https://cdn.jsdelivr.net/gh/lumeland/lume@c8e5609d81c42347078db2759b3cc75dfb4c6ae8/lint.ts"
     ]
   },
   "fmt": {

--- a/src/posts/20250602-microsoft-copilotってなに-ja.md
+++ b/src/posts/20250602-microsoft-copilotってなに-ja.md
@@ -7,7 +7,7 @@ oldUrl:
 lang: ja
 id: 202504e-what-is-copilot
 date: 2025-06-02T05:00:35.603Z
-last_modified: 2025-06-02T17:39:00.000Z
+last_modified: 2025-06-02T22:40:00.000Z
 title: Microsoft Copilotってなに？
 description: Microsoft Copilotとは？WordやExcelなどで業務効率を上げるAI機能を、わかりやすく解説します。
 image: /uploads/blog-esolia-pro-default.png
@@ -51,7 +51,7 @@ Microsoft Copilot (コパイロット)は、AIによる情報の検索や文書�
   </thead>
   <tbody>
     <tr>
-      <td class="whitespace-nowrap"><strong>月額料金</strong></td>
+      <td><strong>月額料金</strong></td>
       <td>無料</td>
       <td>¥3,200（税抜、ユーザー／月）</td>
       <td>¥4,497（税抜、ユーザー／月、年契約）</td>
@@ -80,7 +80,7 @@ Microsoft Copilot (コパイロット)は、AIによる情報の検索や文書�
       <td>優先アクセス</td>
     </tr>
     <tr>
-      <td><strong>AI画像生成（ブースト）</strong></td>
+      <td class="whitespace-nowrap"><strong>AI画像生成（ブースト）</strong></td>
       <td>15ブースト／日</td>
       <td>100ブースト／日</td>
       <td>100ブースト／日</td>


### PR DESCRIPTION
80c9356c78da89141d37d7ec939cc98f42d5ab23
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue Jun 3 07:46:36 2025 +0900

### Styles to balance table better
Moved the whitespace-nowrap class to another cell, which makes the table balance better.



2c0f99eabf2a7b40281abc126e7b1cf4c47b7235
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue Jun 3 07:46:00 2025 +0900

### Upgrades to lume 3 dev, to get tailwind minification
Tailwind minify option added, so use that right away. Had to delete _site and _cache to get this working on localhost.


![image](https://github.com/user-attachments/assets/9ab9dc6f-fd5c-4d5e-8743-163d669ac438)
![JRC CleanShot Code - Insiders 2025-06-03-074942JST@2x](https://github.com/user-attachments/assets/16b06675-418e-4052-8a1d-148cccd2fa50)

