### PR TITLE
Adds alt tags for top grid images

### DIFF
--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -6,6 +6,7 @@ home:
   company_address: Shiodome City Center 5F (Work Styling), 1-5-2 Higashi-Shimbashi, Minato-ku, Tokyo, Japan, 105-7105
   skip_to_main_content_label: Skip to main content
   skip_to_main_content_aria: Skip to main content skip link
+  top_card_image_alt: Image selected to represent post
 archive: 
   title: Archive
   description: Browse our archive of past articles. Use categories and tags to quickly find the topics that interest you, or search from the magnifying glass icon in the navigation bar at the top of the page.

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -6,6 +6,7 @@ home:
   company_address: 〒105-7105 東京都港区東新橋1-5-2 汐留シティセンター5F（ワークスタイリング）
   skip_to_main_content_label: メインコンテンツへスキップ
   skip_to_main_content_aria: メインコンテンツへスキップするためのリンク
+  top_card_image_alt: 次のポストを表す選択画像
 archive: 
   title: アーカイブ
   description: 過去の記事を一覧でご紹介しています。カテゴリやタグを活用して、興味のある情報にすばやくアクセスできます。または、ページ上部のナビゲーションバーにある虫眼鏡アイコンから検索してください。

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -23,7 +23,7 @@
         <img
           {{# src="{{ if catImage }}{{ catImage }}{{ else }}/assets/cat0-bg.jpg{{ /if }}" #}}
           src="{{ if post.image_top }}{{ post.image_top }}{{ else }}/assets/blog-esolia-pro-default-top.png{{ /if }}"
-          alt=""
+          alt="{{ i18n.home.top_card_image_alt }} - {{ post.title }}"
           class="aspect-video w-full rounded-2xl bg-blend-overlay object-cover sm:aspect-2/1 lg:aspect-3/2 transition-all duration-300 ease-in-out mix-blend-normal dark:mix-blend-luminosity group-hover:opacity-90"
           loading="lazy"
           fetchpriority="high"


### PR DESCRIPTION
f2b063860c95754f10712855117d7ca7b37dc955
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Tue Jun 3 09:41:55 2025 +0900

### Adds alt tags for top grid images
Google and bing pointed out that the top page images don't have alt tags, so added them. All I can say is something like "this image was selected to describe the following post" and show the title. Unless we want to write a specific alt for each post.




