### PR TITLE
Upgrades to lume 3.0.3

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@dbf4c9cd7f4e5e2155ff45c15922fd82e280ada8/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@a134eae6e5dc0c2f6910702f68321d7d89532c9e/",
+    "lume/": "https://deno.land/x/lume@v3.0.3/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.12.0/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.10/jsx-runtime.ts"
   },
   "tasks": {
@@ -28,7 +28,7 @@
       ]
     },
     "plugins": [
-      "https://cdn.jsdelivr.net/gh/lumeland/lume@dbf4c9cd7f4e5e2155ff45c15922fd82e280ada8/lint.ts"
+      "https://deno.land/x/lume@v3.0.3/lint.ts"
     ]
   },
   "fmt": {


### PR DESCRIPTION
4f667d78d818e37ac9eb9294fdc999169f795468
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Fri Jun 13 05:41:32 2025 +0900

### Upgrades to lume 3.0.3
Best with deno 2.3.5. Latest deno 2.3.6 will break if you use prism!




