### PR TITLE
feat: migrate hosting to Cloudflare Workers

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -55,7 +55,12 @@ import footnotes from "https://deno.land/x/lume_markdown_plugins@v0.8.0/footnote
 import { alert } from "npm:@mdit/plugin-alert@0.17.0";
 
 // Utils
-import { cssBanner, shuffle, deferPagefind, externalLinksIcon } from "hibana/mod.ts";
+import {
+  cssBanner,
+  deferPagefind,
+  externalLinksIcon,
+  shuffle,
+} from "hibana/mod.ts";
 
 // Assets in HTML
 import icons from "lume/plugins/icons.ts";
@@ -144,7 +149,13 @@ site.use(googleFonts({
 site.use(googleFonts({
   cssFile: "fonts-en.css",
   fontsFolder: "fonts-en",
-  ignoredSubsets: ["cyrillic", "cyrillic-ext", "vietnamese", "latin-ext", "greek"],
+  ignoredSubsets: [
+    "cyrillic",
+    "cyrillic-ext",
+    "vietnamese",
+    "latin-ext",
+    "greek",
+  ],
   fonts: {
     textface:
       "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&display=swap",
@@ -395,6 +406,7 @@ site.add("manifest.json");
 site.add("uploads");
 site.add("assets");
 site.add("f36d0f5824b04fae955f338128bac96e.txt"); // indexnow
+site.add("_headers"); // Cloudflare Workers Static Assets headers config (404 handled via not_found_handling in wrangler.jsonc)
 // Mastodon comment system
 // site.add(
 //   "https://cdn.jsdelivr.net/npm/@oom/mastodon-comments@0.3.2/src/comments.js",
@@ -445,7 +457,7 @@ site.script("makeFontpathAbsoluteJa", sedFixFontpathJa);
 site.addEventListener("afterBuild", "makeFontpathAbsoluteEn");
 site.addEventListener("afterBuild", "makeFontpathAbsoluteJa");
 
-// pass the base url 
+// pass the base url
 site.process([".html"], externalLinksIcon("https://blog.esolia.pro"));
 site.process([".html"], deferPagefind());
 

--- a/src/_headers
+++ b/src/_headers
@@ -1,0 +1,18 @@
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  X-Powered-By: Lume and Deno mixed with Blood Sweat and Tears
+  X-Custom-Header: Rawr eSolia Tokyo
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Permissions-Policy: autoplay=(), camera=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), publickey-credentials-get=()
+
+/fonts-*/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/uploads/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "ab2ac8ca4000c79ae4a66377276585be",
+  "name": "blog-esolia-pro",
+  "compatibility_date": "2026-05-01",
+  "assets": {
+    "directory": "./_site",
+    "not_found_handling": "404-page"
+  },
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+      "head_sampling_rate": 1
+    },
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
+  }
+}


### PR DESCRIPTION
Closes #254

## Summary

- Add `wrangler.jsonc` configuring CF Workers Static Assets with `_site/` as the asset directory, full `observability` block, and `account_id` per global guidance.
- Add `src/_headers` ported verbatim from `netlify.toml` — preserves all security headers (HSTS preload, X-Frame-Options DENY, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-XSS-Protection, custom headers) and immutable cache rules for `/fonts-*`, `/assets/*`, `/uploads/*`.
- 404 fallback uses CF's native `not_found_handling: "404-page"` (Workers Static Assets only accepts 301/302/303/307/308 in `_redirects`, not 404 — so no `_redirects` file needed).
- One `_config.ts` change: `site.add("_headers")` so Lume copies the file into `_site/`. (`deno fmt` reformatted the `hibana/mod.ts` import block while it was at it — unrelated drive-by.)

## Verification

Deployed live to `https://blog-esolia-pro.esolia.workers.dev` from this branch and curl'd:

| Check | Result |
| --- | --- |
| `/` (ja) | 200, all 8 security headers present |
| `/en/` | 200, headers present |
| `/no-such-page` | 404, headers present, serves `404.html` |
| `/assets/blog-esolia-pro-default.png` | `cache-control: public, max-age=31536000, immutable` |

## Manual steps after merge (in order)

These are intentionally NOT done in this PR.

1. **Connect repo to CF Workers Builds** (so push to `main` auto-builds):
   - CF Dashboard → Workers & Pages → `blog-esolia-pro` → Settings → Builds → Connect repository
   - Pick `eSolia/blog.esolia.pro`, branch `main`
   - Build command: `deno task build`
   - Deploy command: `npx wrangler deploy`
   - Build directory: project root (CF auto-detects `_site/` from wrangler.jsonc)
2. **Smoke test the auto-build** by pushing a trivial commit to `main` and watching the CF build log.
3. **Custom domain cutover** (DNS):
   - CF Dashboard → Worker → Settings → Domains & Routes → Add Custom Domain → `blog.esolia.pro`
   - This automatically creates the proxied DNS record in CF (assumes the zone is already in CF — verify before clicking)
   - Verify TLS, headers, content from `https://blog.esolia.pro` once propagated
4. **Disable / delete Netlify site** (`blog-esolia-pro` on Netlify) — only after CF cutover is verified.
5. **Cleanup PR** (separate, after cutover): remove `netlify.toml`, `headers-dev`, update README badge.

## Out of scope / follow-ups

- Pre-existing `deno lint` errors in `_config.ts` (unversioned `npm:date-fns/locale/*` imports) — unchanged on this branch, exist on main. Worth fixing in a follow-up.
- `headers-dev` basic-auth for branch deploys: dropped. CF Worker preview URLs are versioned per deploy and not publicly indexed. If gated previews are needed later, Cloudflare Access can be added.
- Wrangler local-dev warning about `compatibility_date` "2026-05-01" being newer than its bundled runtime — harmless (CF will honor the date when deployed via Workers Builds, which uses a current wrangler).

## Test plan

- [x] Local `deno task build` succeeds; `_headers` lands in `_site/`
- [x] `wrangler dev` serves locally with correct headers
- [x] `wrangler deploy` succeeds; live preview responds with expected headers and 404 behaviour
- [ ] Post-merge: CF Workers Builds connected, auto-build verified
- [ ] Post-merge: `blog.esolia.pro` custom domain attached, DNS cut over
- [ ] Post-merge: Netlify site disabled
- [ ] Follow-up PR: remove `netlify.toml`, `headers-dev`, update README

InfoSec: all security headers from netlify.toml ported verbatim. No new secrets in repo. Org-level `CLOUDFLARE_API_TOKEN` already authorized for this repo (used for Workers Builds connection only — no GH Actions secret reach-through required).

ISO 27001: A.8.9 (Configuration Management), A.8.25 (Secure Development Lifecycle), A.8.32 (Change Management).