### PR TITLE
feat: add Worker cron trigger for nightly rebuild

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,119 @@
+// Cloudflare Worker entry point.
+//
+// Two responsibilities:
+//   1. fetch()     — delegate every request to the Static Assets binding so
+//                    the site is served from _site/ exactly as before.
+//   2. scheduled() — once per day, push an empty commit to main via the
+//                    GitHub API. CF Workers Builds (already connected to
+//                    eSolia/blog.esolia.pro) sees the push and rebuilds.
+//                    This refreshes time-dependent build artefacts such as
+//                    `elapseddays` per post (computed in _config.ts).
+//
+// Manual one-time setup outside this file:
+//   - Create a fine-grained GitHub PAT scoped to eSolia/blog.esolia.pro only,
+//     permission: Contents = read & write.
+//   - Bind it to the Worker:
+//       deno run -A npm:wrangler@latest secret put GITHUB_TOKEN
+//
+// Minimal Cloudflare Workers types declared inline to avoid pulling in
+// @cloudflare/workers-types and dueling tsconfigs with the Lume Deno setup.
+
+interface Fetcher {
+  fetch(request: Request): Promise<Response>;
+}
+
+interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException(): void;
+}
+
+interface ScheduledEvent {
+  cron: string;
+  scheduledTime: number;
+  type: "scheduled";
+}
+
+interface Env {
+  ASSETS: Fetcher;
+  GITHUB_TOKEN: string;
+}
+
+const REPO_OWNER = "eSolia";
+const REPO_NAME = "blog.esolia.pro";
+const REPO_BRANCH = "main";
+const USER_AGENT = "blog-esolia-pro-rebuild-cron";
+
+export default {
+  fetch(request: Request, env: Env): Promise<Response> {
+    return env.ASSETS.fetch(request);
+  },
+
+  scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext): void {
+    ctx.waitUntil(triggerRebuild(env));
+  },
+};
+
+async function triggerRebuild(env: Env): Promise<void> {
+  const ghHeaders = {
+    "Authorization": `Bearer ${env.GITHUB_TOKEN}`,
+    "User-Agent": USER_AGENT,
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const apiBase = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}`;
+
+  const refResp = await fetch(`${apiBase}/git/ref/heads/${REPO_BRANCH}`, {
+    headers: ghHeaders,
+  });
+  if (!refResp.ok) {
+    throw new Error(
+      `get ref failed: ${refResp.status} ${await refResp.text()}`,
+    );
+  }
+  const ref = (await refResp.json()) as { object: { sha: string } };
+  const parentSha = ref.object.sha;
+
+  const commitResp = await fetch(`${apiBase}/git/commits/${parentSha}`, {
+    headers: ghHeaders,
+  });
+  if (!commitResp.ok) {
+    throw new Error(
+      `get commit failed: ${commitResp.status} ${await commitResp.text()}`,
+    );
+  }
+  const parent = (await commitResp.json()) as { tree: { sha: string } };
+
+  const createResp = await fetch(`${apiBase}/git/commits`, {
+    method: "POST",
+    headers: { ...ghHeaders, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      message:
+        "chore: nightly rebuild trigger\n\nInfoSec: no security impact — empty commit fired by Worker cron to refresh time-dependent build artefacts.",
+      tree: parent.tree.sha,
+      parents: [parentSha],
+      author: {
+        name: "blog-esolia-pro-cron",
+        email: "noreply@esolia.pro",
+        date: new Date().toISOString(),
+      },
+    }),
+  });
+  if (!createResp.ok) {
+    throw new Error(
+      `create commit failed: ${createResp.status} ${await createResp.text()}`,
+    );
+  }
+  const newCommit = (await createResp.json()) as { sha: string };
+
+  const updateResp = await fetch(`${apiBase}/git/refs/heads/${REPO_BRANCH}`, {
+    method: "PATCH",
+    headers: { ...ghHeaders, "Content-Type": "application/json" },
+    body: JSON.stringify({ sha: newCommit.sha, force: false }),
+  });
+  if (!updateResp.ok) {
+    throw new Error(
+      `update ref failed: ${updateResp.status} ${await updateResp.text()}`,
+    );
+  }
+  console.log(`Triggered rebuild via empty commit ${newCommit.sha}`);
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,10 +2,15 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "account_id": "ab2ac8ca4000c79ae4a66377276585be",
   "name": "blog-esolia-pro",
+  "main": "./worker/index.ts",
   "compatibility_date": "2026-05-01",
   "assets": {
     "directory": "./_site",
+    "binding": "ASSETS",
     "not_found_handling": "404-page"
+  },
+  "triggers": {
+    "crons": ["0 17 * * *"]
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
Closes #259

## Summary

Convert the assets-only Worker into an assets+code Worker so we can register a Cron Trigger.

- New `worker/index.ts` (~110 lines, no external deps):
  - `fetch()` delegates every request to `env.ASSETS.fetch(request)` — behaviour identical to today (still serves static assets, still honours `_headers`, still uses `not_found_handling`).
  - `scheduled()` calls the GitHub API to create an empty commit on `main`. CF Workers Builds (already connected to the repo) sees the push and rebuilds + redeploys. This refreshes time-dependent build artefacts like `elapseddays` per post (computed in `_config.ts`).
- `wrangler.jsonc`: add `main`, `assets.binding: "ASSETS"` (now required since we have a script), and `triggers.crons: ["0 17 * * *"]` (02:00 JST daily).
- Cloudflare Workers types declared minimally inline — avoids dragging in `@cloudflare/workers-types` and dueling tsconfigs with the Lume Deno setup.

## Verification

Local `wrangler dev --test-scheduled`:

| Check | Result |
| --- | --- |
| `curl /` | 200 + all 8 security headers (fetch handler delegates to ASSETS correctly) |
| `curl /__scheduled` | "Ran scheduled event"; worker log shows the GH API call fired and 401'd with dummy token (expected — proves the call path works) |
| `deno fmt` / `deno lint` / `deno check` on `worker/index.ts` | clean |

## Manual one-time setup required AFTER this PR merges

The Worker will deploy with the new cron config automatically when CF Workers Builds runs. The cron will then start firing nightly — but **the first invocation will fail until you bind the `GITHUB_TOKEN` secret**.

Order of operations:

1. **Create a fine-grained PAT** on https://github.com/settings/tokens?type=beta:
   - Resource owner: `eSolia`
   - Repository access: only `eSolia/blog.esolia.pro`
   - Repository permissions → Contents: **Read and write** (everything else stays "No access")
   - Expiration: 1 year (mark calendar for rotation)
2. **Bind it to the Worker**:
   ```sh
   deno run -A npm:wrangler@latest secret put GITHUB_TOKEN
   # paste the PAT when prompted
   ```
3. **Verify**: in the CF dashboard → Worker → Triggers, you should see the cron schedule. Either wait for the next 02:00 JST run, or manually invoke from the dashboard's "Trigger" button (if available) to test.

After the first successful run you'll see an empty commit on `main` authored by `blog-esolia-pro-cron <noreply@esolia.pro>`, followed by a fresh CF build.

## Out of scope

- Decommissioning the existing external cron runner — owner handles separately.

## Notes

- **Why empty commit instead of CF API**: Workers Builds doesn't expose a documented manual-trigger API endpoint. Pushing to git is the supported trigger surface.
- **Why minimal inline types**: avoids adding npm deps and complicating Deno's typecheck. Three interface declarations (Fetcher, ExecutionContext, ScheduledEvent) cost less than wiring up `@cloudflare/workers-types`.
- **Site migration on the horizon**: per discussion, this site may eventually fold into `esolia.co.jp/blog`. The cron is single-file and easy to retire when that happens.

## Test plan

- [x] `wrangler dev --test-scheduled` smoke test (fetch + scheduled both fire correctly)
- [x] Preflight: `deno fmt`, `deno lint`, `deno check` clean on worker file
- [ ] Post-merge: CF Workers Builds builds + deploys with new config
- [ ] Post-merge: `wrangler secret put GITHUB_TOKEN` (manual, owner)
- [ ] Post-merge: first scheduled run produces visible empty commit on main and a successful follow-on build

InfoSec: PAT scope minimal (one repo, contents only). PAT stored as encrypted Worker secret, never logged. Empty commits are a benign git operation.

ISO 27001: A.8.9 (Configuration Management), A.8.32 (Change Management).