### PR TITLE
fix: pin LumeCMS dev server bind to 127.0.0.1

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -90,6 +90,10 @@ const markdown = {
 const site = lume({
   src: "./src",
   location: new URL("https://blog.esolia.pro"),
+  server: {
+    hostname: "127.0.0.1",
+    port: 3000,
+  },
 }, { markdown });
 
 // Load First, order does not matter


### PR DESCRIPTION
## Summary

- Adds explicit `server: { hostname: "127.0.0.1", port: 3000 }` to `_config.ts`
- Makes the `lume cms` subcommand bind deterministically to IPv4 loopback, sidestepping the `localhost → ::1` resolution that breaks the Hetzner VPS deployment
- Lets Caddy on the VPS use plain `reverse_proxy :3000` instead of an IPv6-literal upstream `[::1]:3000`

## Test plan

- [x] Local `deno task cms` still works on macOS (binds to 127.0.0.1:3000, CMS reachable at http://127.0.0.1:3000/admin)
- [ ] After merge + `git pull` on VPS + `sudo systemctl restart lumecms`:
  - [ ] `sudo ss -ltnp | grep :3000` shows `127.0.0.1:3000` (not `[::1]:3000`)
  - [ ] `curl -sI http://127.0.0.1:3000/admin` returns `401 realm="Secure Area"`
- [ ] Caddyfile reverted from `reverse_proxy [::1]:3000` to `reverse_proxy :3000`, `sudo systemctl reload caddy`
- [ ] `curl -sI -k https://cms.blog.esolia.pro/admin` still returns 401
- [ ] CMS dashboard loads in incognito browser

Closes #262