### PR TITLE
fix: wrap post tag row to prevent mobile horizontal overflow

### DIFF
--- a/src/_includes/templates/post-details.vto
+++ b/src/_includes/templates/post-details.vto
@@ -51,7 +51,7 @@
       {{ i18n.post.hot }}
     </span>{{ /if }}
 </div>
-<div class="text-xs/3 text-zinc-500 ml-4 mt-2 flex space-x-2 break-keep">
+<div class="text-xs/3 text-zinc-500 ml-4 mt-2 flex flex-wrap gap-2 break-keep">
   {{ for tag of tags }}
     {{ set page = search.page(`type=tag lang=${lang} tag="${tag}"`) }}
     {{ if page }}


### PR DESCRIPTION
## Summary

- Reported by Ena: today's post [/posts/20260514-it担当者の真価-ja/](https://blog.esolia.pro/posts/20260514-it%E6%8B%85%E5%BD%93%E8%80%85%E3%81%AE%E7%9C%9F%E4%BE%A1-ja/) (11 tags) renders broken on iPhone — content squeezed to ~40% width with blank space to the right.
- Root cause: tag container in `post-details.vto:54` used `flex space-x-2` with no `flex-wrap`. With 11 tags the row was ~1013px wide on a 390px viewport; iOS Safari shrink-to-fit then misrenders the whole page.
- Fix: switched to `flex flex-wrap gap-2`. Tags now wrap onto multiple rows. `gap-2` replaces `space-x-2` because `space-x-*` adds a stray left margin on each wrapped row's first child.

Verified with Playwright at 390×844: `document.body.scrollWidth` was 1013px before, is 390px after. Confirmed for both the JA post and the EN sibling that share this template.

Closes #264

## Test plan

- [x] Local build succeeds (`deno task build`)
- [x] `deno fmt` clean
- [x] Post page renders without horizontal overflow on 390×844 viewport
- [x] Tags wrap to multiple rows
- [x] Verified on both JA and EN versions of the post
- [ ] Production deploy confirms fix in mobile Safari

InfoSec: no security impact — presentational CSS class change only