### PR TITLE
fix: point JA font preload at existing subset buckets

### DIFF
--- a/src/_includes/templates/font-preload-ja.vto
+++ b/src/_includes/templates/font-preload-ja.vto
@@ -1,13 +1,47 @@
 <!-- ===== font-preload-ja.vto TEMPLATE START ===== -->
-{{# <link rel="preload" href="/fonts-ja/textface-normal-400-[111].woff2" as="font" type="font/woff2" crossorigin="anonymous"> #}}
-<link rel="preload" href="/fonts-ja/textface-normal-400-[115].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-400-[116].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-400-[117].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-400-[118].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-400-[119].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-600-[115].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-600-[116].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-600-[117].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-600-[118].woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-ja/textface-normal-600-[119].woff2" as="font" type="font/woff2" crossorigin="anonymous">
+{{# Subset buckets covering above-the-fold JA content (hiragana, katakana,
+    common kanji, JP punctuation, Latin). Bucket numbers track fonts-ja.css —
+    update both when the font subset bundle is regenerated. #}}
+<link
+  rel="preload"
+  href="/fonts-ja/textface-normal-400-[237].woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+>
+<link
+  rel="preload"
+  href="/fonts-ja/textface-normal-400-[238].woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+>
+<link
+  rel="preload"
+  href="/fonts-ja/textface-normal-400-[239].woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+>
+<link
+  rel="preload"
+  href="/fonts-ja/textface-normal-600-[477].woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+>
+<link
+  rel="preload"
+  href="/fonts-ja/textface-normal-600-[478].woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+>
+<link
+  rel="preload"
+  href="/fonts-ja/textface-normal-600-[479].woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+>
 <!-- ===== font-preload-ja.vto TEMPLATE END ===== -->


### PR DESCRIPTION
## Summary

- Every JA page logged 10 font 404s from `font-preload-ja.vto` referencing buckets `[115]–[119]` that no longer exist (the subset bundle now starts at `[120]`).
- Updated to the buckets that actually cover above-the-fold JA content: `[237]`/`[238]`/`[239]` (400) and `[477]`/`[478]`/`[479]` (600) — common kanji, Latin/ASCII, and hiragana + katakana + JP punctuation.
- Added a comment in the template noting that bucket numbers track `fonts-ja.css` and need refreshing when the font subset bundle is regenerated.

Verified locally: console errors 10 → 0 on the post page, all 6 preloaded buckets transfer successfully, no "preloaded but not used" warnings for fonts.

Closes #266

## Test plan

- [x] Local build succeeds (`deno task build`)
- [x] `deno fmt` clean
- [x] 0 console errors on JA post page (was 10 with 404s)
- [x] All 6 preloaded font buckets transfer with non-zero size
- [x] Homepage renders cleanly
- [ ] Production: confirm fonts load on first paint with no 404s

InfoSec: no security impact — preload hint URLs only