### PR TITLE
fix: match fonts CSS preload URL to stylesheet href; drop stray space

### DIFF
--- a/src/_includes/layouts/base.vto
+++ b/src/_includes/layouts/base.vto
@@ -21,22 +21,26 @@
 
     {{ include "templates/cdn-preconnect.vto" }}
 
-    {{ if lang === "ja" }}{{- include "templates/font-preload-ja.vto" -}}{{ /if }}
-    {{ if lang === "en" }}{{- include "templates/font-preload-en.vto" -}}{{ /if }}
+    {{ if lang === "ja" }}{{- include "templates/font-preload-ja.vto" -}}{{
+      /if
+    }}
+    {{ if lang === "en" }}{{- include "templates/font-preload-en.vto" -}}{{
+      /if
+    }}
 
-    <link 
-      rel="preload" 
-      href="/fonts-{{ lang }}.css"
+    <link
+      rel="preload"
+      href="/fonts-{{ lang }}.css?cb={{ cacheBuster }}"
       as="style"
     >
-    <link 
-      rel="stylesheet" 
+    <link
+      rel="stylesheet"
       href="/fonts-{{ lang }}.css?cb={{ cacheBuster }}"
       type="text/css"
     >
     <link
       rel="stylesheet"
-      href="/styles.css?cb={{ cacheBuster }} "
+      href="/styles.css?cb={{ cacheBuster }}"
       type="text/css"
     >
     <link
@@ -66,7 +70,9 @@
     <div class="flex w-full">
       <div class="fixed inset-0 flex justify-center sm:px-8">
         <div class="flex w-full max-w-7xl lg:px-8">
-          <div class="w-full bg-white ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-300/20">
+          <div
+            class="w-full bg-white ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-300/20"
+          >
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Preload `<link rel="preload" href="/fonts-ja.css">` did not match stylesheet `<link rel="stylesheet" href="/fonts-ja.css?cb=...">` — different URLs to the browser, so the preload was wasted and the CSS was fetched twice. Added `?cb={{ cacheBuster }}` to the preload URL.
- Removed a stray space inside the `styles.css` href (`"/styles.css?cb={{ cacheBuster }} "`).

Verified locally: console is clean (0 errors, 0 warnings), and `performance.getEntriesByType('resource')` shows a single fetch each for `fonts-ja.css` and `styles.css`.

Closes #268

## Test plan

- [x] Local build succeeds
- [x] `deno fmt` clean
- [x] Console produces no "preloaded using link preload but not used" warning
- [x] Single network request for `fonts-ja.css` (was duplicated before)
- [x] `styles.css` href has no trailing whitespace in built HTML
- [ ] Production: confirm clean console on JA and EN pages

InfoSec: no security impact — link href hygiene only