### PR TITLE
chore: pre-CI-shift deno fmt + lint cleanup

### DIFF
--- a/_cms.ts
+++ b/_cms.ts
@@ -1,8 +1,8 @@
 import lumeCMS from "lume/cms/mod.ts";
 import { Field } from "lume/cms/types.ts";
 
-const username = Deno.env.get("ESBLOG_U1")!;
-const password = Deno.env.get("ESBLOG_P1")!;
+const _username = Deno.env.get("ESBLOG_U1")!;
+const _password = Deno.env.get("ESBLOG_P1")!;
 
 const cms = lumeCMS({
   site: {
@@ -51,7 +51,7 @@ cms.upload({
 // Configure git
 cms.git();
 
-const url: Field = {
+const _url: Field = {
   name: "url",
   type: "text",
   description: "The public URL of the page. Leave empty to use the file path.",
@@ -70,6 +70,7 @@ const url: Field = {
     return value;
   },
 };
+// Note: _url field defined for future use; prefix with `_` satisfies no-unused-vars.
 
 cms.document({
   name: "featurecats-ja",

--- a/_config.ts
+++ b/_config.ts
@@ -3,8 +3,8 @@ import lume from "lume/mod.ts";
 // Load First, order does not matter
 import attributes from "lume/plugins/attributes.ts";
 import date from "lume/plugins/date.ts";
-import { enUS } from "npm:date-fns/locale/en-US";
-import { ja } from "npm:date-fns/locale/ja";
+import { enUS } from "npm:date-fns@^4.1.0/locale/en-US";
+import { ja } from "npm:date-fns@^4.1.0/locale/ja";
 import { getGitDate } from "lume/core/utils/date.ts";
 // import { time } from "node:console";
 // import { getCurrentVersion } from "lume/core/utils/lume_version.ts";

--- a/deno.json
+++ b/deno.json
@@ -37,7 +37,16 @@
   },
   "fmt": {
     "exclude": [
-      "./_site"
+      "./_site",
+      "./src/posts",
+      "./src/uploads",
+      "./src/assets",
+      "./src/keep-archive",
+      "./src/favicon.svg",
+      "./README.md",
+      "./src/_includes/css/typography.css",
+      "./src/_includes/templates/page-toc.vto",
+      "./src/_includes/templates/top-nav.vto"
     ]
   },
   "unstable": [

--- a/src/_components/icon.vto
+++ b/src/_components/icon.vto
@@ -2,4 +2,8 @@
 {{ comp.icon({ name: "lightbulb", size: 6, color: "esoliaamber" }) }}
 #}}
 
-<img class="size-{{ size }} fill-{{ color }}-400 inline-block align-[-0.1em] mr-1" src="{{ name |> icon("phosphor", "duotone") }}" inline>
+<img
+  class="size-{{ size }} fill-{{ color }}-400 inline-block align-[-0.1em] mr-1"
+  src='{{ name |> icon("phosphor", "duotone") }}'
+  inline
+>

--- a/src/_includes/css/overrides.css
+++ b/src/_includes/css/overrides.css
@@ -48,9 +48,20 @@
 
   /* Fonts */
   --font-family-code:
-    Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console",
-    "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono",
-    "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+    Consolas,
+    Menlo,
+    Monaco,
+    "Andale Mono WT",
+    "Andale Mono",
+    "Lucida Console",
+    "Lucida Sans Typewriter",
+    "DejaVu Sans Mono",
+    "Bitstream Vera Sans Mono",
+    "Liberation Mono",
+    "Nimbus Mono L",
+    "Courier New",
+    Courier,
+    monospace;
   /* --font-family-ui: -apple-system, system-ui, sans-serif; */
   --font-family-ui: "textface", -apple-system, system-ui, sans-serif;
   /* --font-family-display: var(--font-family-ui); */

--- a/src/_includes/layouts/archive.vto
+++ b/src/_includes/layouts/archive.vto
@@ -10,7 +10,9 @@ script: /js/fathom-post-list-event.js
       <div class="relative px-4 sm:px-8 lg:px-12">
         <div id="archive" class="mx-auto max-w-2xl lg:max-w-5xl">
           <header class="max-w-2xl">
-            <h1 class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl tracking-tight text-zinc-950 dark:text-zinc-100">
+            <h1
+              class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl tracking-tight text-zinc-950 dark:text-zinc-100"
+            >
               <span class="font-semibold subpixel-antialiased">{{
                 site.title
               }}</span>
@@ -85,7 +87,9 @@ script: /js/fathom-post-list-event.js
           </header>
 
           <div class="mt-16 sm:mt-20">
-            <div class="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
+            <div
+              class="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40"
+            >
               <div class="flex max-w-3xl flex-col space-y-16">
                 {{ include "templates/post-list.vto" { postslist: results } }}
 

--- a/src/_includes/layouts/archive_result.vto
+++ b/src/_includes/layouts/archive_result.vto
@@ -12,7 +12,9 @@ bodyClass: body-tag
             <div class="hidden md:block">
               <a href="/archive/">{{ i18n.nav.back }}</a>
             </div>
-            <h1 class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl tracking-tight text-zinc-950 dark:text-zinc-100 subpixel-antialiased">
+            <h1
+              class="text-2xl 2xs:text-3xl sm:text-4xl lg:text-5xl tracking-tight text-zinc-950 dark:text-zinc-100 subpixel-antialiased"
+            >
               <span
                 class="font-extralight text-esoliablue-800 dark:text-esoliablue-600"
               >{{ title }}</span>

--- a/src/_includes/layouts/page.vto
+++ b/src/_includes/layouts/page.vto
@@ -31,7 +31,9 @@ bodyClass: body-tag
                 data-pagefind-index-attrs="data-title"
               >
                 <header class="flex flex-col">
-                  <h1 class="mt-0 text-3xl font-semibold tracking-tight sm:text-4xl subpixel-antialiased bg-gradient-to-r from-esoliablue-700 via-sky-900 to-esoliablue-800 bg-clip-text text-transparent">
+                  <h1
+                    class="mt-0 text-3xl font-semibold tracking-tight sm:text-4xl subpixel-antialiased bg-gradient-to-r from-esoliablue-700 via-sky-900 to-esoliablue-800 bg-clip-text text-transparent"
+                  >
                     {{ title }}
                   </h1>
                   {{# {{ if toc.length }}

--- a/src/_includes/layouts/post.vto
+++ b/src/_includes/layouts/post.vto
@@ -32,7 +32,9 @@ bodyClass: body-post
               >
                 <header class="flex flex-col -top-4">
                   {{# {{ include "templates/post-details.vto" { elapsed: elapseddays } }} #}}
-                  <h1 class="mt-1 text-xl sm:text-2xl lg:text-3xl 2xl:text-4xl 3xl:text-5xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-100 subpixel-antialiased">
+                  <h1
+                    class="mt-1 text-xl sm:text-2xl lg:text-3xl 2xl:text-4xl 3xl:text-5xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-100 subpixel-antialiased"
+                  >
                     {{ title }}
                   </h1>
                   {{ if toc.length }}

--- a/src/_includes/templates/featured1.vto
+++ b/src/_includes/templates/featured1.vto
@@ -1,7 +1,9 @@
 <!-- ===== featured1.vto TEMPLATE START ===== -->
 <ol class="mt-6 flex flex-wrap space-y-4">
   <li class="flex gap-4 w-48">
-    <div class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+    <div
+      class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0"
+    >
       <img
         alt=""
         loading="lazy"
@@ -13,7 +15,9 @@
     </div>
     <dl class="flex flex-auto flex-wrap gap-x-2">
       <dt class="sr-only">Blog Post Title</dt>
-      <dd class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal">
+      <dd
+        class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal"
+      >
         Featured post title number 1
       </dd>
       <dt class="sr-only">Role</dt>
@@ -32,7 +36,9 @@
     </dl>
   </li>
   <li class="flex gap-4 w-48">
-    <div class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+    <div
+      class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0"
+    >
       <img
         alt=""
         loading="lazy"
@@ -44,7 +50,9 @@
     </div>
     <dl class="flex flex-auto flex-wrap gap-x-2">
       <dt class="sr-only">Blog Post Title</dt>
-      <dd class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal">
+      <dd
+        class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal"
+      >
         Featured post title number 2
       </dd>
       <dt class="sr-only">Role</dt>
@@ -54,7 +62,9 @@
     </dl>
   </li>
   <li class="flex gap-4 w-48">
-    <div class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+    <div
+      class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0"
+    >
       <img
         alt=""
         loading="lazy"
@@ -66,7 +76,9 @@
     </div>
     <dl class="flex flex-auto flex-wrap gap-x-2">
       <dt class="sr-only">Blog Post Title</dt>
-      <dd class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal">
+      <dd
+        class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100 whitespace-normal"
+      >
         Featured post title number 3
       </dd>
       <dt class="sr-only">Role</dt>

--- a/src/_includes/templates/font-preload-en.vto
+++ b/src/_includes/templates/font-preload-en.vto
@@ -1,4 +1,16 @@
 <!-- ===== font-preload-en.vto TEMPLATE START ===== -->
-<link rel="preload" href="/fonts-en/textface-100-normal-100-700-latin.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="/fonts-en/textface-100-italic-100-700-latin.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link
+  rel="preload"
+  href="/fonts-en/textface-100-normal-100-700-latin.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+>
+<link
+  rel="preload"
+  href="/fonts-en/textface-100-italic-100-700-latin.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+>
 <!-- ===== font-preload-en.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/footer.vto
+++ b/src/_includes/templates/footer.vto
@@ -27,7 +27,7 @@
               aria_label="{{ item.aria_label }}"
               title="{{ item.title }}"
               {{- if item.target }}target="{{ item.target }}"{{ /if }}
-              {{- if item.target === '_blank' }}rel="noopener"{{ /if -}}
+              {{- if item.target === "_blank" }}rel="noopener"{{ /if -}}
               role="menuitem"
             >
               {{ item.text }}
@@ -36,7 +36,9 @@
         </div>
       </nav>
     </div>
-    <div class="flex flex-col items-center border-t border-zinc-400/10 py-10 sm:flex-row-reverse sm:justify-between no-external-icon">
+    <div
+      class="flex flex-col items-center border-t border-zinc-400/10 py-10 sm:flex-row-reverse sm:justify-between no-external-icon"
+    >
       <div class="mt-6 flex flex-wrap gap-6">
         <a
           class="group -m-1 p-1"

--- a/src/_includes/templates/footer2.vto
+++ b/src/_includes/templates/footer2.vto
@@ -4,8 +4,12 @@
       <div class="border-t border-zinc-100 pt-10 pb-16 dark:border-zinc-700/40">
         <div class="relative px-4 sm:px-8 lg:px-12">
           <div class="mx-auto max-w-2xl lg:max-w-5xl">
-            <div class="flex flex-col items-center justify-between gap-6 md:flex-row">
-              <div class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-zinc-950 dark:text-zinc-200">
+            <div
+              class="flex flex-col items-center justify-between gap-6 md:flex-row"
+            >
+              <div
+                class="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-zinc-950 dark:text-zinc-200"
+              >
                 {{- for item of it.footernav.links }}
                   <a
                     class="whitespace-nowrap transition hover:text-teal-500 dark:hover:text-teal-400"

--- a/src/_includes/templates/panel-categories.vto
+++ b/src/_includes/templates/panel-categories.vto
@@ -16,7 +16,9 @@
   </h2>
   <ol class="mt-6 space-y-4">
     <li class="flex gap-4">
-      <div class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+      <div
+        class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0"
+      >
         <img
           alt=""
           loading="lazy"
@@ -28,7 +30,9 @@
       </div>
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
-        <dd class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100">
+        <dd
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100"
+        >
           Stories
         </dd>
         <dt class="sr-only">Role</dt>
@@ -47,7 +51,9 @@
       </dl>
     </li>
     <li class="flex gap-4">
-      <div class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+      <div
+        class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0"
+      >
         <img
           alt=""
           loading="lazy"
@@ -59,7 +65,9 @@
       </div>
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
-        <dd class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100">
+        <dd
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100"
+        >
           Tips
         </dd>
         <dt class="sr-only">Role</dt>
@@ -78,7 +86,9 @@
       </dl>
     </li>
     <li class="flex gap-4">
-      <div class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+      <div
+        class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0"
+      >
         <img
           alt=""
           loading="lazy"
@@ -90,7 +100,9 @@
       </div>
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
-        <dd class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100">
+        <dd
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100"
+        >
           Tutorials
         </dd>
         <dt class="sr-only">Role</dt>
@@ -109,7 +121,9 @@
       </dl>
     </li>
     <li class="flex gap-4">
-      <div class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+      <div
+        class="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full ring-1 shadow-md shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0"
+      >
         <img
           alt=""
           loading="lazy"
@@ -121,7 +135,9 @@
       </div>
       <dl class="flex flex-auto flex-wrap gap-x-2">
         <dt class="sr-only">The Category</dt>
-        <dd class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100">
+        <dd
+          class="w-full flex-none text-sm font-medium text-zinc-950 dark:text-zinc-100"
+        >
           Announcements
         </dd>
         <dt class="sr-only">Role</dt>

--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -62,7 +62,9 @@
       </button>
     </div>
   </form>
-  <div class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40 mt-6 lg:mt-0">
+  <div
+    class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40 mt-6 lg:mt-0"
+  >
     <h2 class="flex text-sm font-semibold text-zinc-950 dark:text-zinc-100">
       <img
         alt=""

--- a/src/_includes/templates/photo-obi.vto
+++ b/src/_includes/templates/photo-obi.vto
@@ -1,7 +1,9 @@
 <!-- ===== photo-obi.vto TEMPLATE START ===== -->
 <div class="mt-16 sm:mt-20">
   <div class="-my-4 flex justify-center gap-5 overflow-hidden py-4 sm:gap-8">
-    <div class="relative aspect-9/10 w-44 flex-none rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800">
+    <div
+      class="relative aspect-9/10 w-44 flex-none rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800"
+    >
       <img
         alt="Photo by Erik Eastman on Unsplash photo-of-people-crossing-road-4HG5hlhmZg8"
         loading="lazy"
@@ -14,7 +16,9 @@
         transform-images="avif webp jpg 640@2 1080@2"
       >
     </div>
-    <div class="relative aspect-9/10 w-44 flex-none -rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800">
+    <div
+      class="relative aspect-9/10 w-44 flex-none -rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800"
+    >
       <img
         alt="Photo by Vista Wei on Unsplash red-staircase-bar-handle-OiERUvVrioU"
         loading="lazy"
@@ -27,7 +31,9 @@
         transform-images="avif webp jpg 640@2 1080@2"
       >
     </div>
-    <div class="relative aspect-9/10 w-44 flex-none rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800">
+    <div
+      class="relative aspect-9/10 w-44 flex-none rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800"
+    >
       <img
         alt="Photo by Derch on Unsplash vehicles-on-roadway-between-lighted-buildings-at-night-4CMq1GxDSPA"
         loading="lazy"
@@ -40,7 +46,9 @@
         transform-images="avif webp jpg 640@2 1080@2"
       >
     </div>
-    <div class="relative aspect-9/10 w-44 flex-none rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800">
+    <div
+      class="relative aspect-9/10 w-44 flex-none rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800"
+    >
       <img
         alt="Photo by Ryoji Iwata on Unsplash red-and-white-tower-in-the-middle-of-an-urban-city-T1FvAeD59o0"
         loading="lazy"
@@ -53,7 +61,9 @@
         transform-images="avif webp jpg 640@2 1080@2"
       >
     </div>
-    <div class="relative aspect-9/10 w-44 flex-none -rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800">
+    <div
+      class="relative aspect-9/10 w-44 flex-none -rotate-2 overflow-hidden rounded-xl bg-zinc-100 sm:w-72 sm:rounded-2xl dark:bg-zinc-800"
+    >
       <img
         alt="Photo by Denys Nevozhai on Unsplash lantern-on-the-street-at-nighttime--F3wMFrZ7z0"
         loading="lazy"

--- a/src/_includes/templates/post-list.vto
+++ b/src/_includes/templates/post-list.vto
@@ -2,8 +2,12 @@
 {{ for post of postslist }}
   <article id="post-list" class="md:grid md:grid-cols-4 md:items-baseline">
     <div class="group relative flex flex-col items-start md:col-span-3">
-      <h2 class="text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-100">
-        <div class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-zinc-800/50">
+      <h2
+        class="text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-100"
+      >
+        <div
+          class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-zinc-800/50"
+        >
         </div>
         <a
           href="{{ post.url }}"
@@ -32,7 +36,9 @@
         ><span
             class="h-4 w-0.5 rounded-full bg-zinc-200 dark:bg-zinc-500"
           ></span></span>{{ post.date |> date("DATE") }}</time>
-      <div class="relative z-10 mt-2 text-sm/7 text-zinc-600 dark:text-zinc-200 truncate w-full">
+      <div
+        class="relative z-10 mt-2 text-sm/7 text-zinc-600 dark:text-zinc-200 truncate w-full"
+      >
         {{ post.excerpt |> md(true) }}
       </div>
 

--- a/src/_includes/templates/search-modal.vto
+++ b/src/_includes/templates/search-modal.vto
@@ -3,7 +3,9 @@
   id="searchModal"
   class="fixed top-0 left-0 z-1000 w-full h-full overflow-auto hidden"
 >
-  <div class="relative w-3/4 h-3/4 mx-auto mt-24 overflow-auto p-5 bg-white/95 dark:bg-zinc-800/95 border border-zinc-100 dark:border-zinc-700/40 rounded-lg shadow-md">
+  <div
+    class="relative w-3/4 h-3/4 mx-auto mt-24 overflow-auto p-5 bg-white/95 dark:bg-zinc-800/95 border border-zinc-100 dark:border-zinc-700/40 rounded-lg shadow-md"
+  >
     <div class="block text-right items-right font-semibold text-sm">
       <a id="modal-close" href="#">{{ i18n.search.close_link }}</a>
       <div id="search" class="text-left mt-6" tabindex="0"></div>

--- a/src/_includes/templates/slider1.vto
+++ b/src/_includes/templates/slider1.vto
@@ -6,7 +6,9 @@
         <ul class="splide__list rounded-t-2xl">
           <!-- Start slides loop -->
           {{
-            for post of search.pages(`type=post lang=${lang} featured=true`, "date=desc")
+            for 
+            post of search.pages(`type=post lang=${lang} featured=true`, "date=desc")
+
           }}
             {{
               set catColor = featurecats.find((item) => item.key === post.category)
@@ -33,7 +35,9 @@
                 {{ if post.url == url }}
                   aria-current="page"{{ /if }}
               >
-                <div class="absolute top-1/4 left-1/2 transform -translate-x-1/2 text-zinc-50 bg-{{ if catColor }}{{ catColor }}-500/40{{ else }}white/60{{ /if }} transition delay-150 duration-300 ease-in-out hover:bg-{{ if catColor }}{{ catColor }}-600/40{{ else }}white/40{{ /if }} hover:scale-102 hover:grayscale hover:invert dark:hover:invert-0 p-5 rounded-lg w-2/3">
+                <div
+                  class="absolute top-1/4 left-1/2 transform -translate-x-1/2 text-zinc-50 bg-{{ if catColor }}{{ catColor }}-500/40{{ else }}white/60{{ /if }} transition delay-150 duration-300 ease-in-out hover:bg-{{ if catColor }}{{ catColor }}-600/40{{ else }}white/40{{ /if }} hover:scale-102 hover:grayscale hover:invert dark:hover:invert-0 p-5 rounded-lg w-2/3"
+                >
                   <h2 class="text-3xl mb-4">{{ post.title }}</h2>
                   <p class="text-sm">{{ post.excerpt |> md(true) }}</p>
                 </div>
@@ -44,10 +48,14 @@
         </ul>
       </div>
       <!-- Left fade overlay -->
-      <div class="absolute top-0 left-0 h-full w-16 bg-gradient-to-r from-zinc-100 to-transparent dark:from-zinc-900 dark:to-transparent pointer-events-none">
+      <div
+        class="absolute top-0 left-0 h-full w-16 bg-gradient-to-r from-zinc-100 to-transparent dark:from-zinc-900 dark:to-transparent pointer-events-none"
+      >
       </div>
       <!-- Right fade overlay -->
-      <div class="absolute top-0 right-0 h-full w-16 bg-gradient-to-l from-zinc-100 to-transparent dark:from-zinc-900 dark:to-transparent pointer-events-none">
+      <div
+        class="absolute top-0 right-0 h-full w-16 bg-gradient-to-l from-zinc-100 to-transparent dark:from-zinc-900 dark:to-transparent pointer-events-none"
+      >
       </div>
     </div>
   </div>

--- a/src/_includes/templates/top-lead.vto
+++ b/src/_includes/templates/top-lead.vto
@@ -41,12 +41,18 @@
   </div>
   <div class="overflow-hidden">
     <div class="mx-auto max-w-7xl px-6 pt-36 pb-32 sm:pt-60 lg:px-8 lg:pt-32">
-      <div class="mx-auto max-w-2xl gap-x-14 lg:mx-0 lg:flex lg:max-w-none lg:items-center">
+      <div
+        class="mx-auto max-w-2xl gap-x-14 lg:mx-0 lg:flex lg:max-w-none lg:items-center"
+      >
         <div class="relative w-full lg:max-w-xl lg:shrink-0 xl:max-w-2xl">
-          <h1 class="text-5xl font-extralight tracking-tight text-pretty text-zinc-950 sm:text-7xl">
+          <h1
+            class="text-5xl font-extralight tracking-tight text-pretty text-zinc-950 sm:text-7xl"
+          >
             私達、<br>株式会社イソリアは、御社が経験しているITを変更して行きます
           </h1>
-          <p class="mt-8 text-lg font-medium text-pretty text-zinc-500 sm:max-w-md sm:text-xl/8 lg:max-w-none">
+          <p
+            class="mt-8 text-lg font-medium text-pretty text-zinc-500 sm:max-w-md sm:text-xl/8 lg:max-w-none"
+          >
             Cupidatat minim id magna ipsum sint dolor qui. Sunt sit in quis
             cupidatat mollit aute velit. Et labore commodo nulla aliqua proident
             mollit ullamco exercitation tempor. Sint aliqua anim nulla sunt
@@ -54,26 +60,36 @@
             minim amet fugiat veniam occaecat aliqua.
           </p>
         </div>
-        <div class="mt-14 flex justify-end gap-8 sm:-mt-44 sm:justify-start sm:pl-20 lg:mt-0 lg:pl-0">
-          <div class="ml-auto w-44 flex-none space-y-8 pt-32 sm:ml-0 sm:pt-80 lg:order-last lg:pt-36 xl:order-none xl:pt-80">
+        <div
+          class="mt-14 flex justify-end gap-8 sm:-mt-44 sm:justify-start sm:pl-20 lg:mt-0 lg:pl-0"
+        >
+          <div
+            class="ml-auto w-44 flex-none space-y-8 pt-32 sm:ml-0 sm:pt-80 lg:order-last lg:pt-36 xl:order-none xl:pt-80"
+          >
             <div class="relative">
               <img
                 src="https://images.unsplash.com/photo-1557804506-669a67965ba0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&h=528&q=80"
                 alt=""
                 class="aspect-2/3 w-full rounded-xl bg-zinc-900/5 object-cover shadow-lg"
               >
-              <div class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset">
+              <div
+                class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset"
+              >
               </div>
             </div>
           </div>
-          <div class="mr-auto w-44 flex-none space-y-8 sm:mr-0 sm:pt-52 lg:pt-36">
+          <div
+            class="mr-auto w-44 flex-none space-y-8 sm:mr-0 sm:pt-52 lg:pt-36"
+          >
             <div class="relative">
               <img
                 src="https://images.unsplash.com/photo-1485217988980-11786ced9454?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&h=528&q=80"
                 alt=""
                 class="aspect-2/3 w-full rounded-xl bg-zinc-900/5 object-cover shadow-lg"
               >
-              <div class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset">
+              <div
+                class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset"
+              >
               </div>
             </div>
             <div class="relative">
@@ -82,7 +98,9 @@
                 alt=""
                 class="aspect-2/3 w-full rounded-xl bg-zinc-900/5 object-cover shadow-lg"
               >
-              <div class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset">
+              <div
+                class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset"
+              >
               </div>
             </div>
           </div>
@@ -93,7 +111,9 @@
                 alt=""
                 class="aspect-2/3 w-full rounded-xl bg-zinc-900/5 object-cover shadow-lg"
               >
-              <div class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset">
+              <div
+                class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset"
+              >
               </div>
             </div>
             <div class="relative">
@@ -102,7 +122,9 @@
                 alt=""
                 class="aspect-2/3 w-full rounded-xl bg-zinc-900/5 object-cover shadow-lg"
               >
-              <div class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset">
+              <div
+                class="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-zinc-900/10 ring-inset"
+              >
               </div>
             </div>
           </div>

--- a/src/_includes/templates/top-nav1.vto
+++ b/src/_includes/templates/top-nav1.vto
@@ -56,21 +56,21 @@
     <div class="hidden lg:flex lg:flex-1 lg:justify-end">
       <script>
         // Check and apply the user's stored preference or the system preference on page load
-      if (
-        localStorage.theme === "dark" ||
-        (!("theme" in localStorage) &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches)
-      ) {
-        document.documentElement.classList.add("dark");
-      } else {
-        document.documentElement.classList.remove("dark");
-      }
+        if (
+          localStorage.theme === "dark" ||
+          (!("theme" in localStorage) &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches)
+        ) {
+          document.documentElement.classList.add("dark");
+        } else {
+          document.documentElement.classList.remove("dark");
+        }
 
-      // User actions to explicitly choose themes
-      function toggleTheme(isDark) {
-        localStorage.theme = isDark ? "dark" : "light"; // Save preference
-        document.documentElement.classList.toggle("dark", isDark);
-      }
+        // User actions to explicitly choose themes
+        function toggleTheme(isDark) {
+          localStorage.theme = isDark ? "dark" : "light"; // Save preference
+          document.documentElement.classList.toggle("dark", isDark);
+        }
       </script>
       <button class="button" onclick="toggleTheme()">
         <span class="icon text-sm/6 text-red-900">◐</span>
@@ -81,7 +81,9 @@
   <div class="lg:hidden" role="dialog" aria-modal="true">
     <!-- Background backdrop, show/hide based on slide-over state. -->
     <div class="fixed inset-0 z-50"></div>
-    <div class="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-zinc-900/10">
+    <div
+      class="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-zinc-900/10"
+    >
       <div class="flex items-center justify-between">
         <a href="#" class="-m-1.5 p-1.5">
           <span class="sr-only">eSolia Inc.</span>

--- a/src/_includes/templates/top-nav2.vto
+++ b/src/_includes/templates/top-nav2.vto
@@ -106,7 +106,9 @@
                 >
                 </div>
                 <nav class="pointer-events-auto hidden md:block">
-                  <ul class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-zinc-950 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10">
+                  <ul
+                    class="flex rounded-full bg-white/90 px-3 text-sm font-medium text-zinc-950 ring-1 shadow-lg shadow-zinc-800/5 ring-zinc-900/5 backdrop-blur-sm dark:bg-zinc-800/90 dark:text-zinc-200 dark:ring-white/10"
+                  >
                     <li>
                       <a
                         class="relative block px-3 py-2 transition hover:text-teal-500 dark:hover:text-teal-400"
@@ -155,7 +157,9 @@
                       aria-hidden="true"
                       class="h-6 w-6 fill-zinc-100 stroke-zinc-500 transition group-hover:fill-zinc-200 group-hover:stroke-zinc-700 dark:hidden [@media(prefers-color-scheme:dark)]:fill-teal-50 [@media(prefers-color-scheme:dark)]:stroke-teal-500 [@media(prefers-color-scheme:dark)]:group-hover:fill-teal-50 [@media(prefers-color-scheme:dark)]:group-hover:stroke-teal-600"
                     >
-                      <path d="M8 12.25A4.25 4.25 0 0 1 12.25 8v0a4.25 4.25 0 0 1 4.25 4.25v0a4.25 4.25 0 0 1-4.25 4.25v0A4.25 4.25 0 0 1 8 12.25v0Z">
+                      <path
+                        d="M8 12.25A4.25 4.25 0 0 1 12.25 8v0a4.25 4.25 0 0 1 4.25 4.25v0a4.25 4.25 0 0 1-4.25 4.25v0A4.25 4.25 0 0 1 8 12.25v0Z"
+                      >
                       </path>
                       <path
                         d="M12.25 3v1.5M21.5 12.25H20M18.791 18.791l-1.06-1.06M18.791 5.709l-1.06 1.06M12.25 20v1.5M4.5 12.25H3M6.77 6.77 5.709 5.709M6.77 17.73l-1.061 1.061"

--- a/src/_includes/templates/top-post-cards1.vto
+++ b/src/_includes/templates/top-post-cards1.vto
@@ -18,7 +18,9 @@
           class="absolute inset-0 bg-{{ if catColor }}{{ catColor }}{{ else }}zinc{{ /if }}-500 opacity-80 rounded-2xl transition-opacity duration-300 mix-blend-color"
         >
         </div> #}}
-        <div class="absolute inset-0 bg-white/10 dark:bg-zinc-800/60 rounded-2xl mix-blend-luminosity dark:mix-blend-color">
+        <div
+          class="absolute inset-0 bg-white/10 dark:bg-zinc-800/60 rounded-2xl mix-blend-luminosity dark:mix-blend-color"
+        >
         </div>
         <img
           {{# src="{{ if catImage }}{{ catImage }}{{ else }}/assets/cat0-bg.jpg{{ /if }}" #}}
@@ -36,7 +38,9 @@
           transform-images="avif webp png jpeg 384@2 600@2 768@2 960@2 1152@2 1344@2 1440@2 1800@2 2016@2"
           sizes="(max-width: 672px) 100vw, 384px"
         >
-        <div class="absolute inset-0 rounded-2xl ring-1 ring-zinc-900/10 ring-inset">
+        <div
+          class="absolute inset-0 rounded-2xl ring-1 ring-zinc-900/10 ring-inset"
+        >
         </div>
       </div>
       <div class="max-w-xl">
@@ -53,7 +57,9 @@
           }}
         </div>
         <div class="group relative">
-          <h3 class="mt-3 text-lg/6 font-semibold text-zinc-950 group-hover:text-zinc-600">
+          <h3
+            class="mt-3 text-lg/6 font-semibold text-zinc-950 group-hover:text-zinc-600"
+          >
             <a
               href="{{ post.url }}"
               data-faid="{{ post.lang }}-{{ if post.id.length > 0 }}{{ post.id }}{{ else }}{{ loop.index }}{{ /if }}"
@@ -68,7 +74,9 @@
                 </span>{{ /if }} #}}
             </a>
           </h3>
-          <p class="mt-5 line-clamp-3 text-sm/6 text-zinc-900 dark:text-zinc-300">
+          <p
+            class="mt-5 line-clamp-3 text-sm/6 text-zinc-900 dark:text-zinc-300"
+          >
             {{ post.excerpt |> md(true) }}
           </p>
         </div>

--- a/src/_includes/templates/top-post-list.vto
+++ b/src/_includes/templates/top-post-list.vto
@@ -12,8 +12,12 @@
         }
       }}
     </div>
-    <h2 class="text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-100">
-      <div class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-zinc-800/50">
+    <h2
+      class="text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-100"
+    >
+      <div
+        class="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-50 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 sm:rounded-2xl dark:bg-zinc-800/50"
+      >
       </div>
       <a
         href="{{ post.url }}"

--- a/src/_includes/templates/top-post-list3.vto
+++ b/src/_includes/templates/top-post-list3.vto
@@ -5,20 +5,30 @@
       <h2 class="text-4xl font-semibold tracking-tight text-balance text-zinc-950 sm:text-5xl">From the blog</h2>
       <p class="mt-2 text-lg/8 text-zinc-600">Learn how to grow your business with our expert advice.</p>
     </div> #}}
-<div class="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-  <article class="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-zinc-900 px-8 pt-80 pb-8 sm:pt-48 lg:pt-80">
+<div
+  class="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3"
+>
+  <article
+    class="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-zinc-900 px-8 pt-80 pb-8 sm:pt-48 lg:pt-80"
+  >
     <div class="absolute inset-0 bg-emerald-500 opacity-80 rounded-2xl"></div>
     <img
       src="https://images.unsplash.com/photo-1496128858413-b36217c2ce36?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3603&q=80"
       alt=""
       class="absolute inset-0 -z-10 size-full object-cover"
     >
-    <div class="absolute inset-0 -z-10 bg-linear-to-t from-zinc-900 via-zinc-900/40">
+    <div
+      class="absolute inset-0 -z-10 bg-linear-to-t from-zinc-900 via-zinc-900/40"
+    >
     </div>
-    <div class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-zinc-900/10 ring-inset">
+    <div
+      class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-zinc-900/10 ring-inset"
+    >
     </div>
 
-    <div class="flex flex-wrap items-center gap-y-1 overflow-hidden text-sm/6 text-zinc-300 z-50">
+    <div
+      class="flex flex-wrap items-center gap-y-1 overflow-hidden text-sm/6 text-zinc-300 z-50"
+    >
       <time datetime="2020-03-16" class="mr-8">Mar 16, 2020</time>
       <div class="-ml-4 flex items-center gap-x-4">
         <svg viewBox="0 0 2 2" class="-ml-0.5 size-0.5 flex-none fill-white/50">
@@ -41,18 +51,26 @@
       </a>
     </h3>
   </article>
-  <article class="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-zinc-900 px-8 pt-80 pb-8 sm:pt-48 lg:pt-80">
+  <article
+    class="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-zinc-900 px-8 pt-80 pb-8 sm:pt-48 lg:pt-80"
+  >
     <img
       src="https://images.unsplash.com/photo-1496128858413-b36217c2ce36?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3603&q=80"
       alt=""
       class="absolute inset-0 -z-10 size-full object-cover"
     >
-    <div class="absolute inset-0 -z-10 bg-linear-to-t from-zinc-900 via-zinc-900/40">
+    <div
+      class="absolute inset-0 -z-10 bg-linear-to-t from-zinc-900 via-zinc-900/40"
+    >
     </div>
-    <div class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-zinc-900/10 ring-inset">
+    <div
+      class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-zinc-900/10 ring-inset"
+    >
     </div>
 
-    <div class="flex flex-wrap items-center gap-y-1 overflow-hidden text-sm/6 text-zinc-300">
+    <div
+      class="flex flex-wrap items-center gap-y-1 overflow-hidden text-sm/6 text-zinc-300"
+    >
       <time datetime="2020-03-16" class="mr-8">Mar 16, 2020</time>
       <div class="-ml-4 flex items-center gap-x-4">
         <svg viewBox="0 0 2 2" class="-ml-0.5 size-0.5 flex-none fill-white/50">
@@ -75,18 +93,26 @@
       </a>
     </h3>
   </article>
-  <article class="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-zinc-900 px-8 pt-80 pb-8 sm:pt-48 lg:pt-80">
+  <article
+    class="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-zinc-900 px-8 pt-80 pb-8 sm:pt-48 lg:pt-80"
+  >
     <img
       src="https://images.unsplash.com/photo-1496128858413-b36217c2ce36?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3603&q=80"
       alt=""
       class="absolute inset-0 -z-10 size-full object-cover"
     >
-    <div class="absolute inset-0 -z-10 bg-linear-to-t from-zinc-900 via-zinc-900/40">
+    <div
+      class="absolute inset-0 -z-10 bg-linear-to-t from-zinc-900 via-zinc-900/40"
+    >
     </div>
-    <div class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-zinc-900/10 ring-inset">
+    <div
+      class="absolute inset-0 -z-10 rounded-2xl ring-1 ring-zinc-900/10 ring-inset"
+    >
     </div>
 
-    <div class="flex flex-wrap items-center gap-y-1 overflow-hidden text-sm/6 text-zinc-300">
+    <div
+      class="flex flex-wrap items-center gap-y-1 overflow-hidden text-sm/6 text-zinc-300"
+    >
       <time datetime="2020-03-16" class="mr-8">Mar 16, 2020</time>
       <div class="-ml-4 flex items-center gap-x-4">
         <svg viewBox="0 0 2 2" class="-ml-0.5 size-0.5 flex-none fill-white/50">

--- a/src/_includes/templates/top-welcome-header.vto
+++ b/src/_includes/templates/top-welcome-header.vto
@@ -12,7 +12,10 @@
             <span class="subpixel-antialiased">{{ site.title }}</span>
           </h1>
           <p class="mt-6 text-base text-zinc-950 dark:text-zinc-400">
-            {{ i18n.home.welcome |> replace("YEARS_IN_BUSINESS", (new Date().getFullYear() - 1999)) }}
+            {{
+              i18n.home.welcome
+              |> replace("YEARS_IN_BUSINESS", new Date().getFullYear() - 1999)
+            }}
           </p>
           {{# {{ include "templates/socialicons.vto" }} #}}
           {{# {{ include "templates/featured1.vto" }} #}}

--- a/src/index.vto
+++ b/src/index.vto
@@ -15,7 +15,9 @@ script: /js/fathom-post-list-event.js
     <div class="mx-auto w-full max-w-7xl lg:px-8">
       <div class="relative px-4 sm:px-8 lg:px-12">
         <div class="mx-auto max-w-2xl lg:max-w-5xl">
-          <div class="mx-auto grid max-w-xl grid-cols-1 gap-y-20 lg:max-w-none lg:grid-cols-1">
+          <div
+            class="mx-auto grid max-w-xl grid-cols-1 gap-y-20 lg:max-w-none lg:grid-cols-1"
+          >
             <div class="flex flex-col gap-6">
               {{ include "templates/top-main-cats1.vto" }}
               {{ include "templates/top-post-cards1.vto" }}

--- a/src/js/fathom-post-list-event.js
+++ b/src/js/fathom-post-list-event.js
@@ -7,10 +7,10 @@
 //   });
 // });
 
-window.addEventListener("load", () => {
+globalThis.addEventListener("load", () => {
   document.querySelectorAll(".data-fatrigger").forEach((item) => {
-    item.addEventListener("click", (event) => {
-      let postId = item.getAttribute("data-faid");
+    item.addEventListener("click", () => {
+      const postId = item.getAttribute("data-faid");
       if (typeof fathom !== "undefined") {
         fathom.trackEvent(`post link click: ${postId}`);
       } else {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -2,13 +2,13 @@ import { loadVendorScript } from "hibana/utils/dom_utils.ts";
 
 // Load this first
 (function () {
-  var userAgent = navigator.userAgent || navigator.vendor || window.opera;
+  const userAgent = navigator.userAgent || navigator.vendor || globalThis.opera;
 
   if (/windows phone/i.test(userAgent)) {
     document.body.classList.add("os-windows-phone");
   } else if (/android/i.test(userAgent)) {
     document.body.classList.add("os-android");
-  } else if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+  } else if (/iPad|iPhone|iPod/.test(userAgent) && !globalThis.MSStream) {
     document.body.classList.add("os-ios");
   } else if (/Mac/i.test(userAgent)) {
     document.body.classList.add("os-mac");
@@ -18,15 +18,15 @@ import { loadVendorScript } from "hibana/utils/dom_utils.ts";
 })();
 
 // Swap logo on scroll and make nav bg more opaque
-window.addEventListener("scroll", () => {
+globalThis.addEventListener("scroll", () => {
   const largeLogo = document.getElementById("large-logo");
   const smallLogo = document.getElementById("small-logo");
   const topNavBG = document.getElementById("top-nav-bg");
-  const scrollPosition = window.scrollY;
+  const scrollPosition = globalThis.scrollY;
 
   // Check if the current screen size is 'md' (768px) or larger
   // (Tailwind's default 'md' breakpoint is 768px)
-  const isLargeScreen = window.matchMedia("(min-width: 768px)").matches;
+  const isLargeScreen = globalThis.matchMedia("(min-width: 768px)").matches;
 
   // --- Handle logo swap only for 'md' and larger screens ---
   if (isLargeScreen) {
@@ -48,11 +48,11 @@ window.addEventListener("scroll", () => {
   // So, no specific JS logic is needed for logos on small screens here.
 
   // IMPORTANT: Keep these to ensure correct state on load and resize
-  window.addEventListener("DOMContentLoaded", () => {
-    window.dispatchEvent(new Event("scroll"));
+  globalThis.addEventListener("DOMContentLoaded", () => {
+    globalThis.dispatchEvent(new Event("scroll"));
   });
-  window.addEventListener("resize", () => {
-    window.dispatchEvent(new Event("scroll"));
+  globalThis.addEventListener("resize", () => {
+    globalThis.dispatchEvent(new Event("scroll"));
   });
 
   // Handle nav opacity changes based on scroll position
@@ -153,7 +153,7 @@ searchButton.onclick = function () { // Change the event listener target to the 
 close.onclick = function () {
   modal.style.display = "none";
 };
-window.onclick = function (event) {
+globalThis.onclick = function (event) {
   if (event.target == modal) {
     modal.style.display = "none";
   }
@@ -191,7 +191,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
   const handleDetailsState = () => {
     const isMediumOrLargeScreen =
-      window.matchMedia("(min-width: 768px)").matches;
+      globalThis.matchMedia("(min-width: 768px)").matches;
 
     if (isMediumOrLargeScreen) {
       // On medium and larger screens:
@@ -206,5 +206,5 @@ document.addEventListener("DOMContentLoaded", () => {
   // Set initial state on page load
   handleDetailsState();
   // Re-evaluate state on window resize
-  window.addEventListener("resize", handleDetailsState);
+  globalThis.addEventListener("resize", handleDetailsState);
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -14,7 +14,7 @@
     @apply text-zinc-500 dark:text-zinc-100 hover:text-sky-600 dark:hover:text-sky-400; /* Example base link styles */
     transition: color 0.15s ease-in-out;
     text-decoration-thickness: 1px; /* Set your desired default thickness here as well */
-    text-decoration-color: theme('colors.zinc.500'); /* Match the text color */
+    text-decoration-color: theme("colors.zinc.500"); /* Match the text color */
   }
 
   /* You could also style specific link states globally */
@@ -25,7 +25,7 @@
 @layer components {
   /* Apply base styles to tables with not-prose */
   table not-prose {
-    @apply table-fixed w-full text-left text-sm; 
+    @apply table-fixed w-full text-left text-sm;
   }
 
   table.not-prose thead {
@@ -47,7 +47,7 @@
   table.not-prose caption {
     @apply caption-bottom text-left p-2 text-xs text-zinc-400;
   }
-    /* Override the prose <a> tag hover classes */
+  /* Override the prose <a> tag hover classes */
   .prose :where(a) {
     @apply hover:opacity-70;
   }
@@ -71,12 +71,38 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  --default-font-feature-settings: "kern" 1, "liga" 1, "clig" 1, "calt" 1, "palt" 0, "zero" 1, "sups" 0, "frac" 0, "ordn" 0;
+  --default-font-feature-settings:
+    "kern" 1,
+    "liga" 1,
+    "clig" 1,
+    "calt" 1,
+    "palt" 0,
+    "zero" 1,
+    "sups" 0,
+    "frac" 0,
+    "ordn" 0;
   --default-font-variant-ligatures: common-ligatures;
   --header-top: 1rem;
-  --font-sans: textface, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans:
+    textface,
+    ui-sans-serif,
+    system-ui,
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji";
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-  --font-mono: codeface, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-mono:
+    codeface,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace;
   /* eSolia Yellow Logo Color #FFBC68 is 500 */
   --color-esoliaamber-50: oklch(98.69% 0.021 95.28);
   --color-esoliaamber-100: oklch(97.31% 0.037 91.69);
@@ -147,12 +173,12 @@ body article > div > figure > picture > img {
 
 /* MDN keyboard shortcut style for kbd tag */
 kbd {
-  @apply bg-zinc-200 rounded border border-zinc-400 shadow-md text-zinc-950 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap
+  @apply bg-zinc-200 rounded border border-zinc-400 shadow-md text-zinc-950 inline-block text-[0.85em] font-semibold leading-none px-1 py-0.5 whitespace-nowrap;
 }
 
 /*----------------------------
-* 検索ボックス via Lume Pagefind
-*----------------------------*/
+ * 検索ボックス via Lume Pagefind
+ *----------------------------*/
 :root {
   --pagefind-ui-scale: 1;
   --pagefind-ui-primary: var(--color-sky-500);
@@ -164,7 +190,15 @@ kbd {
   --pagefind-ui-border-radius: 8px;
   --pagefind-ui-image-border-radius: 8px;
   --pagefind-ui-image-box-ratio: 3 / 2;
-  --pagefind-ui-font: textface, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --pagefind-ui-font:
+    textface,
+    ui-sans-serif,
+    system-ui,
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji";
   .dark {
     --pagefind-ui-primary: var(--color-sky-500);
     --pagefind-ui-text: var(--color-zinc-200);
@@ -178,18 +212,18 @@ kbd {
 }
 
 /*----------------------------
-* テキスト選択ハイライト
-*----------------------------*/
+ * テキスト選択ハイライト
+ *----------------------------*/
 mark {
   background-color: var(--color-sky-300);
 }
 :root {
   ::selection {
     background-color: var(--color-sky-300);
-    color: var(--color-zinc-900); 
+    color: var(--color-zinc-900);
   }
-  
-/* light-theme-here */
+
+  /* light-theme-here */
 
   .dark {
     ::selection {
@@ -197,15 +231,13 @@ mark {
       color: var(--color-zinc-900);
     }
 
-/* dark-theme-here */
-
+    /* dark-theme-here */
   }
 }
 
-
 /*----------------------------
-* Hamburger 開閉ボタン
-*----------------------------*/
+ * Hamburger 開閉ボタン
+ *----------------------------*/
 .mobile-menu-btn {
   position: fixed;
   top: 20px;
@@ -222,8 +254,8 @@ mark {
 }
 
 /*----------------------------
-* Hamburger Menu 本体
-*----------------------------*/
+ * Hamburger Menu 本体
+ *----------------------------*/
 .mobile-menu {
   position: fixed;
   top: 0;
@@ -236,25 +268,30 @@ mark {
   align-items: center;
   justify-content: center;
   background: #808080;
-  background-color: rgba(85, 85, 85, 0.7); /* Gray background with 70% opacity */
+  background-color: rgba(
+    85,
+    85,
+    85,
+    0.7
+  ); /* Gray background with 70% opacity */
 }
-.mobile-menu__item{
+.mobile-menu__item {
   width: 100%;
   height: auto;
-  padding: .5em 1em;
+  padding: 0.5em 1em;
   text-align: center;
   color: #fff;
   box-sizing: border-box;
 }
 
 /*----------------------------
-* Hamburger アニメーション部分
-*----------------------------*/
+ * Hamburger アニメーション部分
+ *----------------------------*/
 
 /* Hamburger アニメーション前のメニューの状態 */
 .mobile-menu {
   transform: translateX(100vw);
-  transition: all .3s linear;
+  transition: all 0.3s linear;
 }
 /* Hamburger アニメーション後のメニューの状態 */
 .mobile-menu.is-active {


### PR DESCRIPTION
## Summary

Apply `deno fmt` and resolve all `deno lint` errors on the code/template
paths so the tree is gate-ready before a follow-up PR adds a chained
`build:cloudflare` task to Cloudflare Workers Builds.

### Scope of changes

- **Format**: 23 Vento templates, 2 CSS files, 2 JS files, `_cms.ts`,
  `_config.ts` (30 files total)
- **Lint fixes**:
  - `_username` / `_password` / `_url` underscore prefix in `_cms.ts`
    (no-unused-vars)
  - `var` → `const` in `src/js/main.js` (no-var)
  - `let` → `const` and dropped unused `(event)` param in
    `src/js/fathom-post-list-event.js` (prefer-const, no-unused-vars)
  - Pin `npm:date-fns@^4.1.0` in `_config.ts` (no-unversioned-import) —
    resolved version already locked in `deno.lock`
- **Config**: Expand `fmt.exclude` in `deno.json` to keep content out of
  fmt: `src/posts`, `src/uploads`, `src/assets`, `src/keep-archive`,
  `src/favicon.svg`, `README.md`; plus 3 template/CSS files that
  `deno fmt`'s parser can't handle
  (`typography.css` uses Tailwind directives, `page-toc.vto` and
  `top-nav.vto` contain nested template syntax `deno fmt` mis-parses)

### What was deliberately *not* touched

- All markdown posts under `src/posts/` (44 EN + 43 JA) — `deno fmt`
  rewraps prose, which is risky for bilingual content
- SVG and PNG assets under `src/uploads` and `src/assets`
- `src/keep-archive/` sample drafts
- `README.md`

### Why now

A follow-up PR will add a chained `build:cloudflare` task to `deno.json`
(`deno lint && deno fmt --check && deno task lume`) so Cloudflare Workers
Builds enforces the same quality gates the rest of our worker fleet runs.
Without this cleanup, the chain would fail on the first push.

## Test plan

- [x] `deno lint` — clean (0 errors across 8 source files)
- [x] `deno fmt --check` — clean (81 files checked)
- [ ] After merge: confirm nightly rebuild still produces the same site
      output (no visible diffs on the live blog)

InfoSec: no security impact — formatting and unused-var underscore
prefixes only. Commented-out basic-auth credentials in `_cms.ts` remain
commented out.
