### PR TITLE
chore(ci): chain lint + fmt-check into Cloudflare Workers Build

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,6 +8,7 @@
   "tasks": {
     "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",
     "build": "deno task lume",
+    "build:cloudflare": "deno lint && deno fmt --check && deno task lume",
     "serve": "deno task lume -s",
     "update-deps": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.8/cli.ts' update plugins.ts deno.json",
     "cms": "deno task lume cms"


### PR DESCRIPTION
## Summary

Add a chained `build:cloudflare` task to `deno.json` so Cloudflare Workers
Builds enforces lint + format-check + site build in one pass:

```
deno lint && deno fmt --check && deno task lume
```

End-to-end timing: ~81s locally (lint+fmt ≈ 10s, site build ≈ 64s, 2613
files generated). Matches the chained pattern from the rest of the
eSolia fleet — see devkit `docs/deployment-strategy.md` (PR #174).

After merge, the `blog-esolia-pro` Worker Build trigger is patched via
the Workers Builds API to invoke `deno task build:cloudflare`.

## Prerequisite

Builds on #270 (deno fmt + lint cleanup) so the gate is clean from PR 1.

## Test plan

- [x] `deno task build:cloudflare` runs clean locally
- [ ] After merge: trigger CF Build, confirm green, confirm site
      deploys to `https://blog.esolia.pro`

InfoSec: no security impact — CI configuration only.
