### PR TITLE
Upgrade lume/cms to 0.15.5 (Lume 3.2.5 compat) + move CMS auth to Cloudflare Access

### DIFF
--- a/_cms.ts
+++ b/_cms.ts
@@ -1,8 +1,4 @@
 import lumeCMS from "lume/cms/mod.ts";
-import { Field } from "lume/cms/types.ts";
-
-const _username = Deno.env.get("ESBLOG_U1")!;
-const _password = Deno.env.get("ESBLOG_P1")!;
 
 const cms = lumeCMS({
   site: {
@@ -13,25 +9,12 @@ const cms = lumeCMS({
     <p>This is the CMS for eSolia's bilingual blog site, with posts in Japanese and English.</p>
     `,
   },
-  log: {
-    filename: "errors.log",
-  },
 });
 
-// Enable basicauth
-// cms.auth({
-//   method: "basic",
-//   users: {
-//     // foo: "bar",
-//     lume: "iscool",
-//     [username]: password,
-//   },
-// });
-
-// Enable basicauth
-cms.auth({
-  eSolia: "GoodStories!",
-});
+// Auth is enforced at the edge (Cloudflare Access on cms.blog.esolia.pro), NOT
+// in the CMS. Under Lume 3.2 the CMS only runs via `lume --serve`, whose
+// `isProduction` gate is always false, so the plugin never applies cms.auth().
+// Do not add cms.auth() here expecting it to protect the CMS — it does nothing.
 
 // Configure upload storage
 cms.upload({
@@ -50,27 +33,6 @@ cms.upload({
 
 // Configure git
 cms.git();
-
-const _url: Field = {
-  name: "url",
-  type: "text",
-  description: "The public URL of the page. Leave empty to use the file path.",
-  transform(value) {
-    if (!value) {
-      return;
-    }
-
-    if (!value.endsWith("/")) {
-      value += "/";
-    }
-    if (!value.startsWith("/")) {
-      value = "/" + value;
-    }
-
-    return value;
-  },
-};
-// Note: _url field defined for future use; prefix with `_` satisfies no-unused-vars.
 
 cms.document({
   name: "featurecats-ja",
@@ -301,7 +263,7 @@ cms.collection({
         "変更前のurlや、ショートurl。最初と最後に英数半角スラッシュを忘れず。<br>The page url or urls before they changed, or an url intended to be used as a short url. Ensure there is a forward slash before and after",
       view: "Show Overrides",
       transform(value) {
-        return value?.map((redirect) => redirect.trim()); // Trim whitespace
+        return value?.map((redirect: string) => redirect.trim()); // Trim whitespace
       },
     },
     {
@@ -345,7 +307,7 @@ cms.collection({
       label: "作成日 Created Date",
       description: "作成された日付<br>The date the page was posted",
       init(field) {
-        field.value = new Date().toISOString();
+        field.value = new Date();
       },
       attributes: {
         required: true,
@@ -402,7 +364,7 @@ cms.collection({
       transform(value) {
         return value?.trim(); // rem whitespace at ends
       },
-      uploads: "uploads",
+      upload: "uploads",
       attributes: {
         accept: "image/*",
       },
@@ -417,7 +379,7 @@ cms.collection({
       transform(value) {
         return value?.trim(); // rem whitespace at ends
       },
-      uploads: "uploads",
+      upload: "uploads",
       attributes: {
         accept: "image/*",
       },
@@ -438,10 +400,12 @@ cms.collection({
       label: "カテゴリー Category",
       description:
         "ページのカテゴリ（例：セキュリティ、クラウド など）。ページの言語で入力してください。<br>The page category (e.g. Security, Cloud, etc), in the language of the page",
+      // Populated dynamically in init(); 0.15.5 requires options to be present.
+      options: [],
       init(field, { data }, docData) {
         const site = data.site;
-        let allCats = [];
-        const staticCategoriesByLang = {
+        let allCats: string[] = [];
+        const staticCategoriesByLang: Record<string, string[]> = {
           ja: [
             "Microsoft-365",
             "セキュリティ",
@@ -490,15 +454,15 @@ cms.collection({
       description:
         "ページのタグ。ページの言語で入力してください。<br>The page tags, in the language of the page",
       transform(value) {
-        return value?.map((tag) => tag.trim()); // Trim whitespace
+        return value?.map((tag: string) => tag.trim()); // Trim whitespace
       },
       init(field, { data }, docData) {
         const site = data.site;
         // console.log("data:", data);
         // console.log("docData:", docData);
         // console.log("site:", site);
-        let allTags = [];
-        const staticTagsByLang = {
+        let allTags: string[] = [];
+        const staticTagsByLang: Record<string, string[]> = {
           ja: [
             "JIS-Q-27001",
           ],

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "lume/": "https://deno.land/x/lume@v3.2.5/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.12.5/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.15.5/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.12/jsx-runtime.ts",
     "hibana/": "https://deno.land/x/hibana@v1.0.18/"
   },
@@ -11,7 +11,7 @@
     "build:cloudflare": "deno lint && deno fmt --check && deno task lume",
     "serve": "deno task lume -s",
     "update-deps": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.8/cli.ts' update plugins.ts deno.json",
-    "cms": "deno task lume cms"
+    "cms": "deno task lume -s"
   },
   "compilerOptions": {
     "types": [


### PR DESCRIPTION
Closes #274

## Summary

Completes the deferred CMS half of the Lume 3.2.5 upgrade (see #273). Bumps `lume/cms` `0.12.5 → 0.15.5` (the version Lume 3.2.5 pins) and migrates `_cms.ts` to the 0.15.5 API. Restores local `deno task serve`/`cms`, which were crashing on the missing `Fs` export.

### `_cms.ts` migration (14 type errors → 0)
- Removed the dropped `log` CMS option
- **Fixed two latent bugs**: `uploads:` → `upload:` on the `image` / `image_top` fields — the wrong key meant those fields never actually bound to the uploads store
- Added the now-required static `options: []` to the `category` select field (still populated dynamically in `init()`)
- datetime `init` now assigns a `Date` (0.15.5 types `field.value` as `Date`)
- Typed the `init()` / `transform()` callbacks; removed dead `_url` const + `Field` import

### Build / task fixes
- `cms` task: the `lume cms` **subcommand was removed in 3.2.5** — the CMS now runs inside `lume --serve`. Task is now `deno task lume -s` (binds to 127.0.0.1:3000 via `_config.ts`).

### Auth moves to the edge (security)
Removed `cms.auth()` and the dead `ESBLOG_U1/P1` env reads. Under Lume 3.2.5 the CMS only runs via `lume --serve`, whose `isProduction` gate is always false, so the plugin **never applied `cms.auth()`** (verified empirically — `/admin` served with no challenge even with a production `--location`). Authentication for `cms.blog.esolia.pro` is now enforced at the **Cloudflare Access** edge instead. A code comment documents this so nobody re-adds an inert `cms.auth()`.

## Test plan
- [x] `deno fmt --check`, `deno lint`, `deno check _config.ts _cms.ts _md5_shim.ts` — clean
- [x] `deno task lume` — full build, 2673 files (build loads no CMS; unaffected)
- [x] `deno task serve` boots; CMS loads at `/admin` (previously crashed on `Fs`)
- [x] `_cms.ts` typechecks against 0.15.5

## Remaining manual steps (not in this repo)
- **Cloudflare Access**: app created on `cms.blog.esolia.pro/*` with an ALLOW policy ✅ (done in dashboard). Verify the policy include rule is scoped to eSolia identities (not "Everyone").
- **Origin lockdown**: prevent Access bypass via the VPS IP — `cloudflared` tunnel (preferred) or firewall to Cloudflare IP ranges. Required before exposing the CMS.
- **VPS redeploy**: only after the above — `git pull && sudo systemctl restart lumecms` on Hetzner. The VPS must stay on its pre-#273 commit until then.

InfoSec: removes a plaintext credential from the working tree; CMS auth moves to Cloudflare Access. The old password remains in git history and is defunct — rotate if reused elsewhere. No PII changes.