### PR TITLE
Add Cloudflare Access + Tunnel runbook posts (EN/JA, draft)

### DIFF
--- a/src/posts/20260623-cloudflare-access-tunnel-en.md
+++ b/src/posts/20260623-cloudflare-access-tunnel-en.md
@@ -1,0 +1,189 @@
+---
+draft: true
+hot: false
+featured: false
+oldUrl: []
+lang: en
+id: 202606-cf-access-tunnel
+date: 2026-06-23T11:31:05.000Z
+last_modified: 2026-06-23T11:31:05.000Z
+title: 'Replace Basic Auth with Cloudflare Access and a Tunnel on a VPS'
+description: >-
+  A practical runbook for putting a self-hosted app behind Cloudflare Access for
+  per-user SSO, and reaching it through a Cloudflare Tunnel so the VPS exposes no
+  public web ports at all. We use a headless CMS as the worked example.
+image: /uploads/blog-esolia-pro-default.png
+image_top: /uploads/blog-esolia-pro-default-top.png
+author: RC
+category: Security
+tags:
+  - Cloudflare
+  - ZeroTrust
+  - CloudflareTunnel
+  - VPS
+comments: {}
+---
+If you run a small admin app on a VPS and protect it with a single shared password, you can do a lot better: this guide replaces app-level basic auth with **Cloudflare Access** for proper per-user sign-in, and puts the app behind a **Cloudflare Tunnel** so the server stops listening on any public web port at all. We use a self-hosted CMS editor as the worked example, but the pattern fits any internal web app.
+
+<!--more-->
+
+## Why bother
+
+A shared password baked into an app has three problems: everyone uses the same one, it tends to end up in a config file (or a git repo), and the server is still sitting on a public port waiting to be scanned. Moving authentication to the edge fixes all three.
+
+| Before | After |
+| --- | --- |
+| One shared app password | Per-user sign-in (SSO / one-time PIN), scoped to your company domain |
+| Public `:443` on the VPS, reachable by IP | No public web ports; origin reachable only through Cloudflare |
+| Password lives in the app/repo | No secret in the app at all |
+| Direct hop to a far-away datacenter | Terminates at the nearest Cloudflare edge, so it is faster too |
+
+There is also a subtle trap worth calling out: some frameworks only apply their own auth in "production" mode and silently skip it when run as a dev/serve process. If your app is served that way, its built-in auth may be doing nothing. Moving auth to the edge sidesteps that entirely.
+
+## The shape of it
+
+```mermaid
+%%{init: {'flowchart': {'nodeSpacing': 20, 'rankSpacing': 30, 'padding': 4}}}%%
+flowchart LR
+    U[Editor browser] --> E[Cloudflare edge<br/>cms.example.com]
+    E --> A{Access policy<br/>company domain?}
+    A -->|deny| L[Access login / blocked]
+    A -->|allow + JWT| T[Cloudflare Tunnel]
+    T --> C[cloudflared on VPS]
+    C --> S[app on 127.0.0.1:3000]
+```
+
+The only inbound port the VPS keeps open to the internet is **SSH**. `cloudflared` makes an **outbound** connection to Cloudflare, so there is no inbound tunnel port to attack. Access authenticates at the edge, and the tunnel also validates the Access token before any traffic reaches your app.
+
+## What you need
+
+- Your domain's zone on Cloudflare.
+- **Cloudflare Zero Trust** enabled (the free tier covers up to 50 users).
+- A VPS running the app, with SSH access.
+- The app able to bind to `127.0.0.1` (loopback only).
+
+## Step 1: bind the app to loopback only
+
+Once we close the public ports, only `cloudflared` (running on the same box) should be able to reach the app, so the app must listen on the loopback interface.
+
+**The single most important gotcha:** use `127.0.0.1`, never `localhost`. On many Linux setups `localhost` resolves to IPv6 `[::1]` first. If your app binds to IPv4 `127.0.0.1` but you point the tunnel at `localhost`, the tunnel dials `[::1]:3000` and gets "connection refused". Pin IPv4 explicitly on both sides.
+
+For our CMS the server config was:
+
+```ts
+server: { hostname: "127.0.0.1", port: 3000 }
+```
+
+Confirm it is listening on loopback, not on all interfaces:
+
+```bash
+ss -ltnp | grep :3000      # want 127.0.0.1:3000, NOT 0.0.0.0 or :::3000
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/   # 200
+```
+
+While you are here, remove the app's own basic auth if it is now redundant. A plaintext password should not live in your repo, and the edge is doing the work now.
+
+## Step 2: create the Access application
+
+In the **Zero Trust dashboard**, go to **Access controls → Applications → Add an application → Self-hosted**:
+
+1. Name it (e.g. `cms`).
+2. Set the public hostname to your app's hostname (e.g. subdomain `cms`, domain `example.com`), and leave **Path blank** to protect the whole host.
+3. Add a policy: action **Allow**, with an include rule of **Emails ending in** `@yourcompany.com`. Do not use "Everyone" here, or anyone who can complete a login gets in.
+4. Choose login methods (one-time PIN by email, or Google / your SSO).
+5. Save.
+
+One thing to understand: Access only evaluates traffic that actually flows **through** Cloudflare, meaning a **proxied** (orange-cloud) hostname. A DNS-only (grey-cloud) record points straight at your server and bypasses Access completely. The tunnel in the next step gives you a proxied hostname automatically.
+
+## Step 3: create the tunnel and install the connector
+
+In **Zero Trust → Networks → Tunnels → Create a tunnel**, choose the **Cloudflared** connector and name it. The dashboard then shows an install command containing a **connector token**. Treat that token like a password.
+
+On the VPS, add Cloudflare's package repo and install the connector:
+
+```bash
+sudo mkdir -p --mode=0755 /usr/share/keyrings
+curl -fsSL https://pkg.cloudflare.com/cloudflare-public-v2.gpg \
+  | sudo tee /usr/share/keyrings/cloudflare-public-v2.gpg >/dev/null
+echo 'deb [signed-by=/usr/share/keyrings/cloudflare-public-v2.gpg] https://pkg.cloudflare.com/cloudflared any main' \
+  | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt-get update && sudo apt-get install -y cloudflared
+
+# install + start the connector as a service (token from the dashboard)
+sudo cloudflared service install <CONNECTOR_TOKEN>
+```
+
+Confirm it connected (you should see several "Registered tunnel connection" lines):
+
+```bash
+systemctl is-active cloudflared
+journalctl -u cloudflared -n 20 --no-pager | grep -i "Registered tunnel connection"
+```
+
+## Step 4: route the hostname to the local app
+
+Back in the tunnel's configuration, add a **public hostname**:
+
+- Subdomain `cms`, domain `example.com`, **path blank**.
+- Service type **HTTP**, URL **`127.0.0.1:3000`** (again: not `localhost`).
+
+Saving this **auto-creates a proxied CNAME** for your hostname. That is what makes Access take effect.
+
+Then, while you are in that route's advanced settings, expand **Access** and turn on **Enforce Access JSON Web Token (JWT) validation**, selecting the application you created. Now the tunnel itself rejects any request that does not carry a valid Access token, so even a misconfigured edge binding cannot expose the app. This matters because the app does no authentication of its own anymore.
+
+## Step 5: clean up DNS
+
+If the hostname previously had **A / AAAA** records pointing at your VPS IP, delete them. The tunnel's proxied CNAME replaces them. (If creating the public hostname complained about an existing record, that conflict is why; delete the A/AAAA, then re-save.)
+
+## Step 6: lock down the origin
+
+Now close the public web ports on the VPS, keeping only SSH:
+
+```bash
+sudo ufw --force delete allow 80
+sudo ufw --force delete allow 443
+sudo ufw status      # expect ONLY 22/tcp
+```
+
+If you had a reverse proxy (such as Caddy or nginx) only to serve this app, you can retire it now; the tunnel goes straight to `127.0.0.1:3000`:
+
+```bash
+sudo systemctl disable --now caddy
+```
+
+A final check should show only SSH and your loopback app listening:
+
+```bash
+ss -ltnp | grep -E ':22 |:443|:80 |:3000'
+# expect 127.0.0.1:3000 (app) and :22 (sshd); nothing on 80/443
+```
+
+## Step 7: verify, all three ways
+
+```bash
+# Authenticated (from a signed-in / device-enrolled company user):
+curl -s -o /dev/null -w '%{http_code}\n' https://cms.example.com/   # 200
+
+# Origin bypass is dead (force a connection straight to the VPS IP):
+curl --resolve cms.example.com:443:YOUR.VPS.IP -s -o /dev/null \
+  -w '%{http_code}\n' --max-time 8 https://cms.example.com/         # 000
+```
+
+And the one you must do by hand: open the hostname in an **incognito window, signed out** (and with any device VPN/agent paused), and confirm you hit the **Cloudflare Access login** and are **denied** without a company identity. If your own machine is enrolled in your Zero Trust org, it will sail through automatically, so "it works for me" is not a test of the gate. Always check the deny path from the outside.
+
+## Living with it
+
+- **Add or remove who can edit:** change the Access policy in the dashboard. No server change.
+- **Deploy or update the app:** SSH in, pull, restart the service. The lockdown is permanent, so no firewall or DNS steps again.
+- **The connector token is a secret:** rotate it by recreating the tunnel if it ever leaks.
+- **Cost:** the Cloudflare Zero Trust free tier (up to 50 users) covers this comfortably.
+
+## The short list of traps
+
+- Use `127.0.0.1`, not `localhost`, in the tunnel's service URL.
+- Access only works on a **proxied** hostname; the tunnel provides that.
+- Scope the Access policy to your domain, not "Everyone".
+- Turn on tunnel JWT validation when the app has no auth of its own.
+- Your own enrolled devices auto-authenticate, so always test the deny path from incognito.
+
+That is the whole pattern: strong per-user auth at the edge, zero public web ports on the origin, and a faster path for your users. Once it clicks, you will want every internal app behind it.

--- a/src/posts/20260623-cloudflare-access-tunnel-ja.md
+++ b/src/posts/20260623-cloudflare-access-tunnel-ja.md
@@ -1,0 +1,208 @@
+---
+draft: true
+hot: false
+featured: false
+oldUrl: []
+lang: ja
+id: 202606-cf-access-tunnel
+date: 2026-06-23T11:31:05.000Z
+last_modified: 2026-06-23T11:31:05.000Z
+title: VPSアプリのBasic認証をCloudflare AccessとTunnelに置き換える
+description: >-
+  自前でホスティングしているアプリをCloudflare Accessでユーザーごとに認証し、Cloudflare
+  Tunnel経由で公開して、VPSのWeb公開ポートを一切なくすための実践的な手順書です。ヘッドレスCMSを例に解説します。
+image: /uploads/blog-esolia-pro-default.png
+image_top: /uploads/blog-esolia-pro-default-top.png
+author: RC
+category: セキュリティ
+tags:
+  - Cloudflare
+  - ゼロトラスト
+  - CloudflareTunnel
+  - VPS
+comments: {}
+---
+VPS上で動かしている管理用アプリを共有パスワード1つで守っているなら、もっと良い方法があります。この記事では、アプリ側のBasic認証を**Cloudflare Access**によるユーザーごとのサインインに置き換え、さらに**Cloudflare Tunnel**の背後にアプリを置くことで、サーバーがWeb公開ポートを一切リッスンしない構成にする手順を解説します。例として自前ホスティングのCMSエディターを使いますが、このパターンはあらゆる社内向けWebアプリに応用できます。
+
+<!--more-->
+
+## なぜやるのか
+
+アプリに共有パスワードを1つ埋め込む方式には、3つの問題があります。全員が同じパスワードを使うこと、設定ファイル（やgitリポジトリ）に残りがちなこと、そしてサーバーが公開ポートでスキャンされ続けることです。認証をエッジに移すと、この3つすべてが解決します。
+
+<table class="not-prose w-full text-sm">
+  <thead>
+    <tr>
+      <th>これまで</th>
+      <th>これから</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>共有パスワード1つ</td>
+      <td>ユーザーごとのサインイン（SSO / ワンタイムPIN）、自社ドメインに限定</td>
+    </tr>
+    <tr>
+      <td>VPSの公開ポート443にIPで到達できる</td>
+      <td>Web公開ポートなし。オリジンにはCloudflare経由でしか到達できない</td>
+    </tr>
+    <tr>
+      <td>パスワードがアプリやリポジトリに存在する</td>
+      <td>アプリ側に秘密情報を一切持たない</td>
+    </tr>
+    <tr>
+      <td>遠方のデータセンターへ直接接続</td>
+      <td>最寄りのCloudflareエッジで終端するため高速</td>
+    </tr>
+  </tbody>
+</table>
+
+もう1つ、見落としがちな落とし穴があります。フレームワークによっては、自前の認証を「本番モード」のときだけ適用し、開発用のサーブプロセスとして起動すると黙ってスキップする場合があります。アプリをそのように起動している場合、組み込みの認証は何も働いていないかもしれません。認証をエッジに移せば、この問題も完全に回避できます。
+
+## 全体像
+
+```mermaid
+%%{init: {'flowchart': {'nodeSpacing': 20, 'rankSpacing': 30, 'padding': 4}}}%%
+flowchart LR
+    U[編集者のブラウザ] --> E[Cloudflareエッジ<br/>cms.example.com]
+    E --> A{Accessポリシー<br/>自社ドメイン?}
+    A -->|拒否| L[Accessログイン / ブロック]
+    A -->|許可 + JWT| T[Cloudflare Tunnel]
+    T --> C[VPS上のcloudflared]
+    C --> S[アプリ 127.0.0.1:3000]
+```
+
+VPSがインターネットに開けたままにする受信ポートは**SSHだけ**です。`cloudflared`はCloudflareへ**外向き**に接続するため、攻撃対象となる受信用のトンネルポートは存在しません。Accessがエッジで認証し、トンネル側もAccessトークンを検証してから、トラフィックがアプリに届きます。
+
+## 必要なもの
+
+- ドメインのゾーンがCloudflareにあること。
+- **Cloudflare Zero Trust**が有効であること（無料枠で50ユーザーまで対応）。
+- アプリが動作しているVPSと、SSHアクセス。
+- アプリを`127.0.0.1`（ループバックのみ）にバインドできること。
+
+## ステップ1：アプリをループバックのみにバインドする
+
+公開ポートを閉じたあとは、同じサーバー上で動く`cloudflared`だけがアプリに到達できる状態にしたいので、アプリはループバックインターフェースでリッスンする必要があります。
+
+**最も重要な落とし穴は、`localhost`ではなく`127.0.0.1`を使うことです。** 多くのLinux環境では`localhost`がIPv6の`[::1]`に先に解決されます。アプリをIPv4の`127.0.0.1`にバインドしているのにトンネル側で`localhost`を指定すると、トンネルは`[::1]:3000`へ接続しようとして「connection refused」になります。両側で明示的にIPv4を指定してください。
+
+今回のCMSではサーバー設定は次のとおりでした。
+
+```ts
+server: { hostname: "127.0.0.1", port: 3000 }
+```
+
+全インターフェースではなくループバックでリッスンしていることを確認します。
+
+```bash
+ss -ltnp | grep :3000      # 127.0.0.1:3000 であること。0.0.0.0 や :::3000 ではない
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/   # 200
+```
+
+このタイミングで、不要になったアプリ側のBasic認証は削除しておきましょう。平文のパスワードをリポジトリに置くべきではありませんし、認証はエッジが担うようになります。
+
+## ステップ2：Accessアプリケーションを作成する
+
+**Zero Trustダッシュボード**で、**Access controls → Applications → Add an application → Self-hosted**へ進みます。
+
+1. 名前を付けます（例：`cms`）。
+2. 公開ホスト名をアプリのホスト名に設定し（例：サブドメイン`cms`、ドメイン`example.com`）、ホスト全体を保護するために**パスは空欄**のままにします。
+3. ポリシーを追加します。アクションは**Allow**、include条件は**Emails ending in**で`@yourcompany.com`を指定します。ここで「Everyone」を使ってはいけません。ログインを完了できる人なら誰でも入れてしまいます。
+4. ログイン方法を選びます（メールのワンタイムPIN、またはGoogleや自社のSSO）。
+5. 保存します。
+
+ここで理解しておきたい点があります。Accessが評価するのは、実際にCloudflareを**経由する**トラフィック、つまり**プロキシ済み（オレンジクラウド）**のホスト名だけです。DNSのみ（グレークラウド）のレコードはサーバーへ直接向くため、Accessを完全に迂回してしまいます。次のステップのトンネルが、このプロキシ済みホスト名を自動的に用意してくれます。
+
+## ステップ3：トンネルを作成しコネクターをインストールする
+
+**Zero Trust → Networks → Tunnels → Create a tunnel**で、**Cloudflared**コネクターを選んで名前を付けます。するとダッシュボードに、**コネクタートークン**を含むインストールコマンドが表示されます。このトークンはパスワードと同じように扱ってください。
+
+VPS上で、Cloudflareのパッケージリポジトリを追加してコネクターをインストールします。
+
+```bash
+sudo mkdir -p --mode=0755 /usr/share/keyrings
+curl -fsSL https://pkg.cloudflare.com/cloudflare-public-v2.gpg \
+  | sudo tee /usr/share/keyrings/cloudflare-public-v2.gpg >/dev/null
+echo 'deb [signed-by=/usr/share/keyrings/cloudflare-public-v2.gpg] https://pkg.cloudflare.com/cloudflared any main' \
+  | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt-get update && sudo apt-get install -y cloudflared
+
+# コネクターをサービスとしてインストールし起動する（トークンはダッシュボードから）
+sudo cloudflared service install <CONNECTOR_TOKEN>
+```
+
+接続できたことを確認します（「Registered tunnel connection」の行がいくつか表示されるはずです）。
+
+```bash
+systemctl is-active cloudflared
+journalctl -u cloudflared -n 20 --no-pager | grep -i "Registered tunnel connection"
+```
+
+## ステップ4：ホスト名をローカルアプリにルーティングする
+
+トンネルの設定に戻り、**公開ホスト名（public hostname）**を追加します。
+
+- サブドメイン`cms`、ドメイン`example.com`、**パスは空欄**。
+- サービスタイプは**HTTP**、URLは**`127.0.0.1:3000`**（ここでも`localhost`は不可）。
+
+これを保存すると、ホスト名の**プロキシ済みCNAMEが自動的に作成**されます。これによってAccessが有効に機能します。
+
+続けて、そのルートの詳細設定（advanced settings）で**Access**を展開し、**Enforce Access JSON Web Token (JWT) validation**をオンにして、作成したアプリケーションを選択します。これでトンネル自身が、有効なAccessトークンを持たないリクエストを拒否するようになり、エッジ側の設定に万一不備があってもアプリが露出しません。アプリ自身はもう認証をしないので、この設定が重要です。
+
+## ステップ5：DNSを整理する
+
+ホスト名にVPSのIPを指す**A / AAAA**レコードが以前からある場合は、削除します。トンネルのプロキシ済みCNAMEが置き換えになります。（公開ホスト名の作成時に既存レコードとの競合を警告された場合は、これが原因です。A / AAAAを削除してから保存し直してください。）
+
+## ステップ6：オリジンをロックダウンする
+
+VPSのWeb公開ポートを閉じ、SSHだけを残します。
+
+```bash
+sudo ufw --force delete allow 80
+sudo ufw --force delete allow 443
+sudo ufw status      # 22/tcp だけになっていること
+```
+
+このアプリを配信するためだけにリバースプロキシ（Caddyやnginxなど）を立てていたなら、ここで停止できます。トンネルは`127.0.0.1:3000`へ直接つながります。
+
+```bash
+sudo systemctl disable --now caddy
+```
+
+最後の確認では、SSHとループバックのアプリだけがリッスンしている状態になっているはずです。
+
+```bash
+ss -ltnp | grep -E ':22 |:443|:80 |:3000'
+# 127.0.0.1:3000（アプリ）と :22（sshd）のみ。80/443 には何もない
+```
+
+## ステップ7：3つの方法で検証する
+
+```bash
+# 認証済みの経路（サインイン済み・デバイス登録済みの自社ユーザーから）：
+curl -s -o /dev/null -w '%{http_code}\n' https://cms.example.com/   # 200
+
+# オリジンへの迂回が塞がれていること（VPSのIPへ直接接続を強制）：
+curl --resolve cms.example.com:443:YOUR.VPS.IP -s -o /dev/null \
+  -w '%{http_code}\n' --max-time 8 https://cms.example.com/         # 000
+```
+
+そして必ず手動で行うべき確認があります。**サインアウトしたシークレットウィンドウ**で（端末のVPNやエージェントは一時停止して）ホスト名を開き、**Cloudflare Accessのログイン**が表示され、自社のIDがなければ**拒否される**ことを確認してください。自分のマシンがZero Trust組織に登録されていると自動的に通過してしまうため、「自分の環境では動く」はゲートの検証になりません。拒否経路は必ず外側から確認しましょう。
+
+## 運用について
+
+- **編集できる人の追加・削除**：ダッシュボードでAccessポリシーを変更するだけです。サーバー側の変更は不要です。
+- **アプリのデプロイ・更新**：SSHで入り、pullしてサービスを再起動します。ロックダウンは恒久的なので、ファイアウォールやDNSの作業は二度と発生しません。
+- **コネクタートークンは秘密情報**：万一漏れた場合は、トンネルを作り直してローテーションします。
+- **コスト**：Cloudflare Zero Trustの無料枠（50ユーザーまで）で十分まかなえます。
+
+## 落とし穴の短いリスト
+
+- トンネルのサービスURLには`localhost`ではなく`127.0.0.1`を使う。
+- Accessが効くのは**プロキシ済み**ホスト名だけ。それはトンネルが用意する。
+- Accessポリシーは「Everyone」ではなく自社ドメインに限定する。
+- アプリ自身に認証がない場合は、トンネルのJWT検証をオンにする。
+- 自分の登録済み端末は自動で認証を通過するので、拒否経路は必ずシークレットウィンドウで確認する。
+
+これがパターンの全体です。エッジでの強力なユーザーごとの認証、オリジンのWeb公開ポートはゼロ、そしてユーザーにとってより速い経路。一度仕組みが腑に落ちると、社内のあらゆるアプリをこの背後に置きたくなるはずです。


### PR DESCRIPTION
## Summary

Adds a bilingual how-to documenting the pattern we just implemented for the CMS: replace app-level basic auth with **Cloudflare Access** (per-user SSO) and reach the app through a **Cloudflare Tunnel**, so the VPS exposes no public web ports.

- `src/posts/20260623-cloudflare-access-tunnel-en.md`
- `src/posts/20260623-cloudflare-access-tunnel-ja.md`
- Shared `id: 202606-cf-access-tunnel` (translation pair)
- **`draft: true`** — staged for review/editing in the CMS; nothing goes live on merge

### Sanitized for a public repo
Written **generically** — `cms.example.com`, placeholder IP/account/tunnel IDs, no SSH key names. No real eSolia infrastructure identifiers, since this repo is public. The full-detail version with real values stays in the assistant's private project memory + the team's internal notes.

### Content
Covers: why move auth to the edge, the request-flow diagram, binding the app to `127.0.0.1` (the IPv4-vs-`localhost` trap), creating the Access app + policy, installing the `cloudflared` connector, routing the public hostname, enabling tunnel JWT validation, DNS cleanup, ufw lockdown, and a three-way verification (authenticated / origin-bypass-dead / deny-path).

## Test plan
- [x] `deno task lume` builds clean (2673 files; drafts correctly excluded)
- [x] Frontmatter matches the posts schema; both share the translation `id`
- [ ] Reviewer: preview rendering (table + mermaid) via the CMS or `deno task serve`, then flip `draft: false` to publish when ready

Quality: follows eSolia writing standards (JA in です/ます, no em dashes).
InfoSec: no secrets or real infrastructure identifiers in content — documents a hardening pattern only.