### PR TITLE
fix(content): normalize PC performance tag (fixes archive collision behind the CMS 502s)

### DIFF
--- a/src/posts/20260522-copilot-pc-performance-en.md
+++ b/src/posts/20260522-copilot-pc-performance-en.md
@@ -18,7 +18,7 @@ author: K.Y.
 category: Windows
 tags:
   - Copilot
-  - PC performance
+  - PC Performance
 comments: {}
 ---
 More and more people are using MS Copilot as a standard AI assistant tool for Windows PC. However, Copilot itself can sometimes slow down PC performance. Based on actual cases reported to IT help desk, we'll introduce the examples. Please check your company PC as well. 


### PR DESCRIPTION
## Summary

Fixes the recurring `same output path "/en/archive/PC Performance/index.html"` build error, which is the likely trigger of the intermittent **502 Bad Gateway** ("Host Error") your staff saw on `cms.blog.esolia.pro`.

### Root cause
- `20260522-copilot-pc-performance-en.md` tagged `PC performance` (lowercase p)
- `20260528-restarting-your-pc-en.md` tagged `PC Performance` (uppercase P)
- The archive generator maps both to `/en/archive/PC Performance/` → duplicate output path.
- A **full build** only logs a warning, but the same collision can **throw during `lume --serve`'s incremental rebuild**, crashing the process. systemd (`Restart=always`) restarts it, and the ~80s startup rebuild is the window where `cloudflared` gets "connection refused" → Cloudflare returns 502. Confirmed the 502 timestamp matched a service restart exactly.

### Fix
Normalize the lowercase tag to `PC Performance` (Title Case, consistent with the other post).

## Test plan
- [x] `deno task lume` builds clean — **zero** "same output path" errors (was logging it every build)
- [x] Archive page `/en/archive/PC Performance/` resolves to a single source

### Deploy note
Takes effect on the CMS after the VPS pulls + restarts (`git pull && sudo systemctl restart lumecms`). That restart itself is one ~80s rebuild window; best done when staff aren't mid-edit.

InfoSec: content metadata only; no security impact.