### PR TITLE
perf(cms): shrink CMS rebuild window ~53s → ~13s (skip search/feeds/sitemap/archives under LUME_CMS)

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -100,6 +100,14 @@ const site = lume({
   },
 }, { markdown });
 
+// When Lume serves the CMS (`lume --serve` with _cms.ts), it sets LUME_CMS=true.
+// The CMS rebuilds the whole site on each save-triggered reload, and that ~50-80s
+// window is when cms.blog.esolia.pro briefly 502s. Search index, feeds, and the
+// sitemap are irrelevant to the editor preview, so skip them under the CMS to
+// shrink the rebuild. The production Cloudflare build (no LUME_CMS) still emits
+// everything.
+const isCms = Deno.env.get("LUME_CMS") === "true";
+
 // Load First, order does not matter
 site.use(attributes());
 site.use(date({ locales: { enUS, ja } }));
@@ -110,15 +118,17 @@ site.use(multilanguage({
   defaultLanguage: "ja",
 }));
 site.use(nav());
-site.use(pagefind({
-  ui: {
-    containerId: "search",
-    showImages: false,
-    showEmptyFilters: true,
-    resetStyles: false,
-    showSubResults: true,
-  },
-}));
+if (!isCms) {
+  site.use(pagefind({
+    ui: {
+      containerId: "search",
+      showImages: false,
+      showEmptyFilters: true,
+      resetStyles: false,
+      showSubResults: true,
+    },
+  }));
+}
 site.use(plaintext());
 site.use(redirects());
 site.use(prism({
@@ -251,112 +261,114 @@ site.use(icons());
 site.use(inline());
 
 // Generate files with URLs
-site.use(feed({
-  output: ["/feed.ja.xml", "/feed.ja.json"],
-  query: "type=post lang=ja",
-  sort: "date=desc",
-  limit: 0,
-  info: {
-    title: "=site.title",
-    description: "=site.description",
-    published: new Date(),
-    lang: "ja",
-    hubs: undefined,
-    generator: true,
-    authorName: "=site.author",
-  },
-  items: {
-    title: "=title",
-    description: "=description",
-    published: "=date",
-    updated: "=last_modified",
-    lang: "ja",
-    image: "=image",
-    authorName: "=author",
-  },
-}));
-site.use(feed({
-  output: ["/feed.en.xml", "/feed.en.json"],
-  query: "type=post lang=en",
-  sort: "date=desc",
-  limit: 0,
-  info: {
-    title: "=en.site.title",
-    description: "=en.site.description",
-    published: new Date(),
-    lang: "en",
-    hubs: undefined,
-    generator: true,
-    authorName: "=en.site.author",
-  },
-  items: {
-    title: "=title",
-    description: "=description",
-    published: "=date",
-    updated: "=last_modified",
-    lang: "en",
-    image: "=image",
-    authorName: "=author",
-  },
-}));
+if (!isCms) {
+  site.use(feed({
+    output: ["/feed.ja.xml", "/feed.ja.json"],
+    query: "type=post lang=ja",
+    sort: "date=desc",
+    limit: 0,
+    info: {
+      title: "=site.title",
+      description: "=site.description",
+      published: new Date(),
+      lang: "ja",
+      hubs: undefined,
+      generator: true,
+      authorName: "=site.author",
+    },
+    items: {
+      title: "=title",
+      description: "=description",
+      published: "=date",
+      updated: "=last_modified",
+      lang: "ja",
+      image: "=image",
+      authorName: "=author",
+    },
+  }));
+  site.use(feed({
+    output: ["/feed.en.xml", "/feed.en.json"],
+    query: "type=post lang=en",
+    sort: "date=desc",
+    limit: 0,
+    info: {
+      title: "=en.site.title",
+      description: "=en.site.description",
+      published: new Date(),
+      lang: "en",
+      hubs: undefined,
+      generator: true,
+      authorName: "=en.site.author",
+    },
+    items: {
+      title: "=title",
+      description: "=description",
+      published: "=date",
+      updated: "=last_modified",
+      lang: "en",
+      image: "=image",
+      authorName: "=author",
+    },
+  }));
 
-// Enrich JSON feeds with tags and summary from post metadata
-// (The feed plugin doesn't support custom fields, so we post-process)
-site.process(function enrichFeedJson() {
-  // Build lookup of post metadata keyed by full URL
-  const postMeta = new Map<
-    string,
-    { category: string; tags: string[]; description: string }
-  >();
+  // Enrich JSON feeds with tags and summary from post metadata
+  // (The feed plugin doesn't support custom fields, so we post-process)
+  site.process(function enrichFeedJson() {
+    // Build lookup of post metadata keyed by full URL
+    const postMeta = new Map<
+      string,
+      { category: string; tags: string[]; description: string }
+    >();
 
-  for (const data of site.search.pages("type=post")) {
-    const fullUrl = site.url(data.url as string, true);
-    postMeta.set(fullUrl, {
-      category: (data.category as string) || "",
-      tags: (data.tags as string[]) || [],
-      description: (data.description as string) || "",
-    });
-  }
+    for (const data of site.search.pages("type=post")) {
+      const fullUrl = site.url(data.url as string, true);
+      postMeta.set(fullUrl, {
+        category: (data.category as string) || "",
+        tags: (data.tags as string[]) || [],
+        description: (data.description as string) || "",
+      });
+    }
 
-  // Find and enrich JSON feed pages
-  for (const page of site.pages) {
-    const pageUrl = page.data.url as string;
-    if (pageUrl?.endsWith(".json") && pageUrl?.includes("feed")) {
-      try {
-        const content = page.content as string;
-        const feedJson = JSON.parse(content);
-        if (feedJson.items) {
-          for (const item of feedJson.items) {
-            const meta = postMeta.get(item.url);
-            if (meta) {
-              item.tags = meta.category
-                ? [meta.category, ...meta.tags]
-                : [...meta.tags];
-              if (meta.description) {
-                item.summary = meta.description;
+    // Find and enrich JSON feed pages
+    for (const page of site.pages) {
+      const pageUrl = page.data.url as string;
+      if (pageUrl?.endsWith(".json") && pageUrl?.includes("feed")) {
+        try {
+          const content = page.content as string;
+          const feedJson = JSON.parse(content);
+          if (feedJson.items) {
+            for (const item of feedJson.items) {
+              const meta = postMeta.get(item.url);
+              if (meta) {
+                item.tags = meta.category
+                  ? [meta.category, ...meta.tags]
+                  : [...meta.tags];
+                if (meta.description) {
+                  item.summary = meta.description;
+                }
               }
             }
+            page.content = JSON.stringify(feedJson);
           }
-          page.content = JSON.stringify(feedJson);
+        } catch {
+          // Skip pages with non-parseable content
         }
-      } catch {
-        // Skip pages with non-parseable content
       }
     }
-  }
-});
-site.use(sitemap({
-  // query: "external_link=undefined",
-  filename: "sitemap.xml",
-  sort: "lastmod=desc",
-  // lastmod/priority moved under `items` in Lume 3.2's sitemap plugin, which
-  // now requires a leading `=` to reference a page-data field (a bare string is
-  // treated as a literal). `lastmod` is the git-modified date set above.
-  items: {
-    lastmod: "=lastmod",
-    priority: "=priority",
-  },
-}));
+  });
+  site.use(sitemap({
+    // query: "external_link=undefined",
+    filename: "sitemap.xml",
+    sort: "lastmod=desc",
+    // lastmod/priority moved under `items` in Lume 3.2's sitemap plugin, which
+    // now requires a leading `=` to reference a page-data field (a bare string is
+    // treated as a literal). `lastmod` is the git-modified date set above.
+    items: {
+      lastmod: "=lastmod",
+      priority: "=priority",
+    },
+  }));
+}
 
 // Checks
 // site.use(
@@ -475,7 +487,9 @@ site.addEventListener("afterBuild", "makeFontpathAbsoluteJa");
 
 // pass the base url
 site.process([".html"], externalLinksIcon("https://blog.esolia.pro"));
-site.process([".html"], deferPagefind());
+if (!isCms) {
+  site.process([".html"], deferPagefind());
+}
 
 // site.filter("tdate", (value: string | undefined, locale: string, timezone: string) => {
 //   if (!value) {

--- a/src/generators/archive.page.js
+++ b/src/generators/archive.page.js
@@ -2,6 +2,10 @@ export const layout = "layouts/archive.vto";
 export const lang = ["ja", "en"];
 
 export default function* ({ search, paginate, lang, i18n }) {
+  // Paginated archive listing isn't needed for the CMS editor preview. Skip it
+  // under the CMS (LUME_CMS=true) to shrink the rebuild window; the public
+  // Cloudflare build still generates it.
+  if (Deno.env.get("LUME_CMS") === "true") return;
   const posts = search.pages(`type=post lang=${lang}`, "date=desc");
 
   // Moved inside the default function to use the `lang` variable passed.

--- a/src/generators/archive_result.page.js
+++ b/src/generators/archive_result.page.js
@@ -3,6 +3,10 @@ export const lang = ["ja", "en"];
 // export const id = "archiveresult";
 
 export default function* ({ search, lang, i18n, featuretags, featurecats }) {
+  // Per-tag/category archive pages (~68% of all pages) aren't needed for the CMS
+  // editor preview. Skip them under the CMS (LUME_CMS=true) to shrink the
+  // rebuild window; the public Cloudflare build still generates them.
+  if (Deno.env.get("LUME_CMS") === "true") return;
   // Generate a page for each tag
   for (const tag of search.values("tags", `lang=${lang}`)) {
     yield {


### PR DESCRIPTION
## Summary

Shrinks the CMS rebuild window — the cause of the intermittent **502 "Host Error"** your staff saw on `cms.blog.esolia.pro`.

### Background
LumeCMS triggers a full process reload after certain saves (`X-Lume-CMS: reload` → `Deno.exit(0)` → systemd restart). The new process cold-rebuilds the whole site (~53s) before it listens, and during that window `cloudflared` gets connection-refused → Cloudflare shows 502. (Inherent to LumeCMS + systemd; the official Caddy `cms-deploy` behaves the same.)

### Change
Lume sets `LUME_CMS=true` only when serving the CMS. None of these outputs are needed for the **editor preview**, so they're now gated on `!isCms` and skipped under the CMS only:
- pagefind search index (+ `deferPagefind` processor)
- JA/EN feeds (+ feed-JSON enrichment)
- sitemap
- **archive generators** (`archive.page.js` + `archive_result.page.js`) — the dominant cost: **256 of 378** HTML pages, each running search queries

### Measured (local, Deno)
| Build | Files | Time |
|---|---|---|
| CMS-mode (`LUME_CMS=true`) | 1960 | **~13s** (was ~53s) |
| Production (no `LUME_CMS`) | 2673 | ~57s (unchanged) |

The CMS reload→rebuild window — and thus the 502 duration — drops ~4×.

## Test plan
- [x] Production build unchanged: 2673 files, all **256 archives** + pagefind + feeds + sitemap present
- [x] CMS-mode build: posts still render (sample post present); archives/search/feeds/sitemap correctly absent
- [x] `deno fmt --check`, `deno lint`, `deno check` pass
- [ ] Post-deploy: confirm shorter restart window on the VPS

Trade-off: in the CMS preview only, the search box, archive pages, and feeds aren't generated (tag links would 404 in-preview). Cosmetic and editor-only; the public site is unaffected.

InfoSec: no security impact — build-scope change gated on an env flag.