### PR TITLE
feat(newsletter): gate signup with Turnstile and authenticated Worker proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ deno.lock
 _seo_report_en.json
 _seo_report_ja.json
 errors.log
+.dev.vars

--- a/src/_data.yml
+++ b/src/_data.yml
@@ -1,6 +1,11 @@
 logo: /assets/logo_horiz_darkblue_bgtransparent.svg
 extra_head: []
 lang: ja
+# Cloudflare Turnstile sitekey for the newsletter signup (public value).
+# Inherited by the en: subtree below, so one entry covers both locales.
+# TODO: replace placeholder with the real sitekey from the Turnstile dashboard
+# widget "blog-esolia-pro-newsletter" before deploying.
+turnstile_sitekey: "0x4AAAAAABhkr_JNco-SeAbS"
 site:
   author: "イソリア"
   title: "Tech It Easy Blog"

--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -6,7 +6,7 @@
     method="post"
     id="newsletter"
     role="form"
-    action="https://pro.dbflex.net/secure/gateway.aspx?action=WebToRecord&amp;app=15331&amp;table=1510483"
+    action="/api/newsletter"
   >
     <h2 class="flex text-sm font-semibold text-zinc-950 dark:text-zinc-100">
       <img
@@ -22,26 +22,26 @@
     <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
       {{ i18n.newsletter.description }}
     </p>
+    {{# Locale tells the Worker which thank-you/reference/home URLs to use. #}}
+    <input type="hidden" name="locale" value="{{ lang }}" />
+    {{# Honeypot: hidden from users; bots that fill it are silently dropped. #}}
+    <input
+      type="text"
+      name="website"
+      tabindex="-1"
+      autocomplete="off"
+      aria-hidden="true"
+      class="hidden"
+    />
+    {{# Time trap: stamped with Date.now() on load by the script below. #}}
+    <input type="hidden" name="ts" value="" />
     <div class="mt-6 flex">
-      <input
-        type="hidden"
-        name="retURL"
-        value="{{ i18n.newsletter.thanks_url }}"
-      />
-      <input
-        type="hidden"
-        id="f_64244810_ID0EBB"
-        name="f_64244810"
-        type="text"
-        value="{{ i18n.newsletter.reference }}"
-        maxlength="1000"
-      >
       <label for="f_64244897_ID0ES" class="sr-only">{{
         i18n.newsletter.placeholder
       }}</label>
       <input
         id="f_64244897_ID0ES"
-        name="f_64244897"
+        name="email"
         value=""
         type="email"
         placeholder="{{ i18n.newsletter.placeholder }}"
@@ -61,6 +61,25 @@
         {{ i18n.newsletter.button }}
       </button>
     </div>
+    {{# Turnstile widget. interaction-only: invisible for normal visitors, only
+        challenges suspected bots, so the slim row above is untouched. Inside a
+        <form> it auto-injects the hidden cf-turnstile-response field. #}}
+    <div
+      class="cf-turnstile mt-3"
+      data-sitekey="{{ turnstile_sitekey }}"
+      data-appearance="interaction-only"
+      data-theme="auto"
+      data-size="flexible"
+      data-action="newsletter"
+    ></div>
+    {{# Shown when the Worker redirects back with ?newsletter=error. #}}
+    <p
+      id="newsletter-error"
+      class="mt-3 hidden text-sm text-red-500"
+      role="alert"
+    >
+      {{ i18n.newsletter.error }}
+    </p>
   </form>
   <div
     class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40 mt-6 lg:mt-0"
@@ -94,4 +113,23 @@
     </div>
   </div>
 </div>
+<script
+  src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+  async
+  defer
+></script>
+<script>
+(function () {
+  // Stamp the time-trap field so the Worker can reject impossibly fast bots.
+  var ts = document.querySelector('#newsletter input[name="ts"]');
+  if (ts) ts.value = String(Date.now());
+  // Reveal the error message when the Worker bounced us back with an error.
+  if (
+    new URLSearchParams(window.location.search).get("newsletter") === "error"
+  ) {
+    var err = document.getElementById("newsletter-error");
+    if (err) err.classList.remove("hidden");
+  }
+})();
+</script>
 <!-- ===== panel-cta.vto TEMPLATE END ===== -->

--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -71,7 +71,8 @@
       data-theme="auto"
       data-size="flexible"
       data-action="newsletter"
-    ></div>
+    >
+    </div>
     {{# Shown when the Worker redirects back with ?newsletter=error. #}}
     <p
       id="newsletter-error"
@@ -119,17 +120,17 @@
   defer
 ></script>
 <script>
-(function () {
-  // Stamp the time-trap field so the Worker can reject impossibly fast bots.
-  var ts = document.querySelector('#newsletter input[name="ts"]');
-  if (ts) ts.value = String(Date.now());
-  // Reveal the error message when the Worker bounced us back with an error.
-  if (
-    new URLSearchParams(window.location.search).get("newsletter") === "error"
-  ) {
-    var err = document.getElementById("newsletter-error");
-    if (err) err.classList.remove("hidden");
-  }
-})();
+  (function () {
+    // Stamp the time-trap field so the Worker can reject impossibly fast bots.
+    var ts = document.querySelector('#newsletter input[name="ts"]');
+    if (ts) ts.value = String(Date.now());
+    // Reveal the error message when the Worker bounced us back with an error.
+    if (
+      new URLSearchParams(window.location.search).get("newsletter") === "error"
+    ) {
+      var err = document.getElementById("newsletter-error");
+      if (err) err.classList.remove("hidden");
+    }
+  })();
 </script>
 <!-- ===== panel-cta.vto TEMPLATE END ===== -->

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,8 +1,10 @@
 // Cloudflare Worker entry point.
 //
-// Two responsibilities:
-//   1. fetch()     — delegate every request to the Static Assets binding so
-//                    the site is served from _site/ exactly as before.
+// Three responsibilities:
+//   1. fetch()     — route POST /api/newsletter to the newsletter handler
+//                    (Turnstile-gated signup); delegate everything else to the
+//                    Static Assets binding so the site is served from _site/
+//                    exactly as before.
 //   2. scheduled() — once per day, push an empty commit to main via the
 //                    GitHub API. CF Workers Builds (already connected to
 //                    eSolia/blog.esolia.pro) sees the push and rebuilds.
@@ -14,6 +16,11 @@
 //     permission: Contents = read & write.
 //   - Bind it to the Worker:
 //       deno run -A npm:wrangler@latest secret put GITHUB_TOKEN
+//   - Create a Turnstile widget (Managed) for blog.esolia.pro and bind:
+//       deno run -A npm:wrangler@latest secret put TURNSTILE_SECRET_KEY
+//   - Bind the PROdb (dbFlex) API token — same value as the esolia-2025
+//     contact-form Worker (shared appId 15331):
+//       deno run -A npm:wrangler@latest secret put DBFLEX_API_KEY_01
 //
 // Minimal Cloudflare Workers types declared inline to avoid pulling in
 // @cloudflare/workers-types and dueling tsconfigs with the Lume Deno setup.
@@ -33,9 +40,17 @@ interface ScheduledEvent {
   type: "scheduled";
 }
 
+// Native rate-limit binding (configured in wrangler.jsonc).
+interface RateLimiter {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
 interface Env {
   ASSETS: Fetcher;
   GITHUB_TOKEN: string;
+  TURNSTILE_SECRET_KEY: string;
+  DBFLEX_API_KEY_01: string;
+  NEWSLETTER_LIMIT: RateLimiter;
 }
 
 const REPO_OWNER = "eSolia";
@@ -45,6 +60,12 @@ const USER_AGENT = "blog-esolia-pro-rebuild-cron";
 
 export default {
   fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/api/newsletter") {
+      return request.method === "POST"
+        ? handleNewsletter(request, env)
+        : Promise.resolve(new Response("Method Not Allowed", { status: 405 }));
+    }
     return env.ASSETS.fetch(request);
   },
 
@@ -52,6 +73,181 @@ export default {
     ctx.waitUntil(triggerRebuild(env));
   },
 };
+
+// ---------------------------------------------------------------------------
+// Newsletter signup handler
+//
+// InfoSec: Defense-in-depth gate on the "Stay Informed" signup. In order:
+// origin allowlist, per-IP rate limit, honeypot + time-trap, Cloudflare
+// Turnstile siteverify, then server-side email validation. Only then does it
+// write to PROdb (dbFlex) via the AUTHENTICATED TeamDesk API v2 — not the old
+// public WebToRecord gateway. Every redirect target and the stored reference
+// URL are constructed server-side from a fixed allowlist, never read from the
+// request, so a caller cannot use this endpoint as an open redirect or inject
+// an arbitrary reference. Mirrors ~/dev/esolia-2025 workers/contact-form.
+// ---------------------------------------------------------------------------
+
+const DBFLEX_API = "https://pro.dbflex.net/secure/api/v2/15331";
+const NEWSLETTER_TABLE = "Email Newsletter Subscriber";
+const EMAIL_FIELD = "f_64244897";
+const REFERENCE_FIELD = "f_64244810";
+
+// InfoSec: Stricter email regex — rejects consecutive dots, leading hyphens,
+// etc. (shared with the esolia-2025 contact-form Worker).
+const EMAIL_REGEX =
+  /^(?!.*\.\.)(?!.*\.-)[a-zA-Z0-9][a-zA-Z0-9._%+-]*@[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}$/;
+
+// Reject obvious throwaway inboxes before they reach PROdb.
+const DISPOSABLE_DOMAINS = new Set([
+  "mailinator.com",
+  "guerrillamail.com",
+  "10minutemail.com",
+  "yopmail.com",
+  "tempmail.com",
+  "temp-mail.org",
+  "throwawaymail.com",
+  "trashmail.com",
+  "getnada.com",
+  "sharklasers.com",
+]);
+
+const LOCALES = {
+  ja: {
+    reference: "https://blog.esolia.pro",
+    thanks: "https://blog.esolia.pro/thank-you/",
+    home: "https://blog.esolia.pro/",
+  },
+  en: {
+    reference: "https://blog.esolia.pro/en/",
+    thanks: "https://blog.esolia.pro/en/thank-you/",
+    home: "https://blog.esolia.pro/en/",
+  },
+} as const;
+
+// InfoSec: Only accept form posts originating from our own site.
+const ALLOWED_ORIGINS = new Set(["https://blog.esolia.pro"]);
+
+interface TurnstileResponse {
+  success: boolean;
+  "error-codes"?: string[];
+}
+
+function redirect(location: string): Response {
+  return new Response(null, { status: 303, headers: { Location: location } });
+}
+
+async function handleNewsletter(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  // 1. Origin allowlist.
+  const origin = request.headers.get("Origin");
+  if (!origin || !ALLOWED_ORIGINS.has(origin)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  // 2. Per-IP rate limit (native binding).
+  const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
+  const rl = await env.NEWSLETTER_LIMIT.limit({ key: clientIp });
+  if (!rl.success) {
+    return new Response("Too many requests. Please try again later.", {
+      status: 429,
+    });
+  }
+
+  // 3. Parse the form and resolve locale (never trusted for redirects below —
+  //    only used to select from the fixed LOCALES table).
+  const form = await request.formData();
+  const locale = form.get("locale") === "en" ? "en" : "ja";
+  const l = LOCALES[locale];
+
+  // 4. Honeypot — a hidden field only bots fill in. Respond as if successful so
+  //    the bot gets no signal; store nothing.
+  if (String(form.get("website") ?? "").trim() !== "") {
+    console.log("newsletter honeypot triggered", { locale });
+    return redirect(l.thanks);
+  }
+
+  // 5. Time trap — the form stamps `ts` (ms epoch) on page load. Reject submits
+  //    that are impossibly fast (<2s) or from a stale page (>24h).
+  const ts = Number(form.get("ts"));
+  const age = Date.now() - ts;
+  if (!Number.isFinite(ts) || age < 2000 || age > 86_400_000) {
+    console.log("newsletter time trap triggered", { locale, age });
+    return redirect(l.home + "?newsletter=error#panel-cta");
+  }
+
+  // 6. Turnstile verification.
+  const token = form.get("cf-turnstile-response");
+  if (!token) {
+    return redirect(l.home + "?newsletter=error#panel-cta");
+  }
+  const verify = await fetch(
+    "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        secret: env.TURNSTILE_SECRET_KEY,
+        response: token,
+        remoteip: clientIp,
+      }),
+    },
+  );
+  const outcome = (await verify.json()) as TurnstileResponse;
+  if (!outcome.success) {
+    console.log("newsletter turnstile failed", {
+      locale,
+      errors: outcome["error-codes"],
+    });
+    return redirect(l.home + "?newsletter=error#panel-cta");
+  }
+
+  // 7. Server-side email sanity check.
+  const email = String(form.get("email") ?? "").trim();
+  const domain = email.slice(email.lastIndexOf("@") + 1).toLowerCase();
+  if (
+    email.length === 0 || email.length > 254 || !EMAIL_REGEX.test(email) ||
+    DISPOSABLE_DOMAINS.has(domain)
+  ) {
+    console.log("newsletter email rejected", { locale });
+    return redirect(l.home + "?newsletter=error#panel-cta");
+  }
+
+  // 8. Upsert to PROdb via the authenticated API. Matching on the email field
+  //    dedupes repeat signups. `reference` comes from the fixed LOCALES table.
+  const upsertUrl =
+    `${DBFLEX_API}/${encodeURIComponent(NEWSLETTER_TABLE)}/upsert.json` +
+    `?match=${EMAIL_FIELD}&workflow=1`;
+  try {
+    const resp = await fetch(upsertUrl, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${env.DBFLEX_API_KEY_01}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { [EMAIL_FIELD]: email, [REFERENCE_FIELD]: l.reference },
+      ]),
+    });
+    if (!resp.ok) {
+      console.error("newsletter dbFlex upsert failed", {
+        locale,
+        status: resp.status,
+      });
+      return redirect(l.home + "?newsletter=error#panel-cta");
+    }
+  } catch (error) {
+    console.error(
+      "newsletter dbFlex upsert error",
+      error instanceof Error ? error.message : "unknown",
+    );
+    return redirect(l.home + "?newsletter=error#panel-cta");
+  }
+
+  // 9. Success — full-page redirect to the existing thank-you page.
+  return redirect(l.thanks);
+}
 
 async function triggerRebuild(env: Env): Promise<void> {
   const ghHeaders = {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,16 +17,13 @@
     "crons": ["0 17 * * *"]
   },
   // Per-IP rate limit for the newsletter endpoint: 5 requests / 60s.
-  "unsafe": {
-    "bindings": [
-      {
-        "name": "NEWSLETTER_LIMIT",
-        "type": "ratelimit",
-        "namespace_id": "1001",
-        "simple": { "limit": 5, "period": 60 }
-      }
-    ]
-  },
+  "ratelimits": [
+    {
+      "name": "NEWSLETTER_LIMIT",
+      "namespace_id": "1001",
+      "simple": { "limit": 5, "period": 60 }
+    }
+  ],
   "observability": {
     "enabled": true,
     "logs": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,10 +7,25 @@
   "assets": {
     "directory": "./_site",
     "binding": "ASSETS",
-    "not_found_handling": "404-page"
+    "not_found_handling": "404-page",
+    // Run the Worker before serving assets for API routes. Without this, a form
+    // POST carrying Sec-Fetch-Mode: navigate would be served the 404 asset
+    // instead of invoking the newsletter handler.
+    "run_worker_first": ["/api/*"]
   },
   "triggers": {
     "crons": ["0 17 * * *"]
+  },
+  // Per-IP rate limit for the newsletter endpoint: 5 requests / 60s.
+  "unsafe": {
+    "bindings": [
+      {
+        "name": "NEWSLETTER_LIMIT",
+        "type": "ratelimit",
+        "namespace_id": "1001",
+        "simple": { "limit": 5, "period": 60 }
+      }
+    ]
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
Closes #282. Follow-up: #283 (retire the public dbFlex gateway).

## Summary

The "Stay Informed" newsletter signup posted a plain HTML form directly to a public dbFlex WebToRecord gateway, with no bot check — a steady source of junk subscriber records. This routes it through the site's Cloudflare Worker at `POST /api/newsletter`:

- **Origin allowlist** → 403 for cross-origin POSTs
- **Rate limit** (native binding, 5 req/IP/60s) → 429
- **Honeypot** (silent success) + **time trap** (reject <2s or >24h)
- **Cloudflare Turnstile** siteverify (new Managed widget, `interaction-only` — invisible to real visitors)
- **Email sanity check** (format, length ≤254, disposable-domain block)
- **Authenticated upsert** to PROdb TeamDesk API v2 (`Email Newsletter Subscriber`, matched on email → dedupes) — replaces the public gateway
- **303 redirect** to the existing thank-you page

Redirect targets and the stored reference URL are constructed server-side from a fixed per-locale table, never read from the request (closes the old `retURL` open-redirect). The public gateway URL and field IDs are removed from page HTML. Mirrors the existing `esolia-2025` contact-form Worker.

### Files
- `worker/index.ts` — `handleNewsletter()` + `Env`/binding types; existing rebuild cron untouched
- `wrangler.jsonc` — `run_worker_first: ["/api/*"]` + `NEWSLETTER_LIMIT` ratelimit binding
- `src/_includes/templates/panel-cta.vto` — form posts to `/api/newsletter`; locale, honeypot, time-trap, Turnstile widget, error message, loader script; gateway URL + `retURL`/reference hidden fields removed
- `src/_data.yml` — `turnstile_sitekey` (public)
- `.gitignore` — `.dev.vars`

## Deploy prerequisites (done / to confirm)
- [x] Turnstile widget created; sitekey in `_data.yml`
- [x] Worker secrets set: `TURNSTILE_SECRET_KEY`, `DBFLEX_API_KEY_01`
- [ ] After deploy: retire the public gateway for table 1510483 (#283)

## Test Plan
- [ ] CF Workers Build succeeds on this PR (authoritative build — local Lume build couldn't run in the dev sandbox due to network egress limits)
- [ ] Happy path ja: submit real email → `/thank-you/`, record in PROdb
- [ ] Happy path en: submit → `/en/thank-you/`, record in PROdb
- [ ] Same email twice → one record (upsert match)
- [ ] Turnstile failure / honeypot / time-trap / bad email / cross-origin → no record; error banner where applicable
- [ ] 6 rapid POSTs from one IP → 429
- [ ] `retURL=https://evil.example/` in body → still lands on the real thank-you URL

Verified locally: `deno check` (worker), `deno lint`, `deno fmt` (worker/wrangler/_data), Vento tag balance, and all referenced template variables exist.

InfoSec: adds bot verification, origin allowlist, rate limiting, and server-built redirect targets; moves dbFlex writes to the authenticated API and removes the unauthenticated public gateway URL from public HTML.