### PR TITLE
fix(newsletter): create.json with dup check and "already subscribed" message

### DIFF
--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -36,6 +36,7 @@ newsletter:
   placeholder: Email address
   success: Subscribed!
   error: Subscription failed
+  already: You're already subscribed with this email address.
   reference: https://blog.esolia.pro/en/
   thanks_url: https://blog.esolia.pro/en/thank-you/
 contact:

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -38,6 +38,7 @@ newsletter:
   placeholder: メールアドレス
   success: 登録完了しました！
   error: 登録に失敗しました
+  already: このメールアドレスは既にご登録済みです。
   reference: https://blog.esolia.pro
   thanks_url: https://blog.esolia.pro/thank-you/
 contact:

--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -81,6 +81,14 @@
     >
       {{ i18n.newsletter.error }}
     </p>
+    {{# Shown when the Worker redirects back with ?newsletter=exists. #}}
+    <p
+      id="newsletter-exists"
+      class="mt-3 hidden text-sm text-emerald-600 dark:text-emerald-400"
+      role="status"
+    >
+      {{ i18n.newsletter.already }}
+    </p>
   </form>
   <div
     class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40 mt-6 lg:mt-0"
@@ -124,12 +132,17 @@
     // Stamp the time-trap field so the Worker can reject impossibly fast bots.
     var ts = document.querySelector('#newsletter input[name="ts"]');
     if (ts) ts.value = String(Date.now());
-    // Reveal the error message when the Worker bounced us back with an error.
-    if (
-      new URLSearchParams(window.location.search).get("newsletter") === "error"
-    ) {
-      var err = document.getElementById("newsletter-error");
-      if (err) err.classList.remove("hidden");
+    // Reveal the matching message when the Worker bounced us back:
+    // ?newsletter=error (something failed) or =exists (already subscribed).
+    var state = new URLSearchParams(window.location.search).get("newsletter");
+    var msgId = state === "error"
+      ? "newsletter-error"
+      : state === "exists"
+      ? "newsletter-exists"
+      : null;
+    if (msgId) {
+      var msg = document.getElementById(msgId);
+      if (msg) msg.classList.remove("hidden");
     }
   })();
 </script>

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -80,11 +80,18 @@ export default {
 // InfoSec: Defense-in-depth gate on the "Stay Informed" signup. In order:
 // origin allowlist, per-IP rate limit, honeypot + time-trap, Cloudflare
 // Turnstile siteverify, then server-side email validation. Only then does it
-// write to PROdb (dbFlex) via the AUTHENTICATED TeamDesk API v2 — not the old
-// public WebToRecord gateway. Every redirect target and the stored reference
-// URL are constructed server-side from a fixed allowlist, never read from the
-// request, so a caller cannot use this endpoint as an open redirect or inject
-// an arbitrary reference. Mirrors ~/dev/esolia-2025 workers/contact-form.
+// look up the address and create the record in PROdb (dbFlex) via the
+// AUTHENTICATED TeamDesk API v2 — not the old public WebToRecord gateway. Every
+// redirect target and the stored reference URL are constructed server-side from
+// a fixed allowlist, never read from the request, so a caller cannot use this
+// endpoint as an open redirect or inject an arbitrary reference. Mirrors
+// ~/dev/esolia-2025 workers/contact-form.
+//
+// dbFlex writes use create.json (not upsert-on-match) because the Email column
+// is not marked unique yet — TeamDesk rejects match on a non-unique column
+// (code 3106). A pre-insert lookup gives friendly "already subscribed" feedback
+// and avoids duplicates in the normal case. See the follow-up issue to clean
+// the table, mark Email unique, and switch back to upsert.
 // ---------------------------------------------------------------------------
 
 const DBFLEX_API = "https://pro.dbflex.net/secure/api/v2/15331";
@@ -214,24 +221,57 @@ async function handleNewsletter(
     return redirect(l.home + "?newsletter=error#panel-cta");
   }
 
-  // 8. Upsert to PROdb via the authenticated API. Matching on the email field
-  //    dedupes repeat signups. `reference` comes from the fixed LOCALES table.
-  const upsertUrl =
-    `${DBFLEX_API}/${encodeURIComponent(NEWSLETTER_TABLE)}/upsert.json` +
-    `?match=${EMAIL_FIELD}&workflow=1`;
+  const dbHeaders = {
+    "Authorization": `Bearer ${env.DBFLEX_API_KEY_01}`,
+    "Content-Type": "application/json",
+  };
+  const tablePath = `${DBFLEX_API}/${encodeURIComponent(NEWSLETTER_TABLE)}`;
+
+  // 8. Already-subscribed check. The Email column is not (yet) marked unique in
+  //    dbFlex, so TeamDesk upsert-on-match is rejected (code 3106). Until it is
+  //    (see follow-up issue), query for the address first: if it exists, tell
+  //    the visitor they're already subscribed instead of creating a duplicate.
+  //    On any query error we fall through to create — better a rare duplicate
+  //    than a lost signup. Small race window for two simultaneous first-time
+  //    signups of the same address; the eventual unique constraint mops it up.
+  //    Email is validated above (no quotes/spaces), so the filter string is safe.
   try {
-    const resp = await fetch(upsertUrl, {
+    const filter = encodeURIComponent(`[Email]="${email}"`);
+    const found = await fetch(
+      `${tablePath}/select.json?filter=${filter}&top=1`,
+      { headers: dbHeaders },
+    );
+    if (found.ok) {
+      const rows = (await found.json()) as unknown[];
+      if (Array.isArray(rows) && rows.length > 0) {
+        console.log("newsletter already subscribed", { locale });
+        return redirect(l.home + "?newsletter=exists#panel-cta");
+      }
+    } else {
+      console.error("newsletter dbFlex lookup failed", {
+        locale,
+        status: found.status,
+      });
+    }
+  } catch (error) {
+    console.error(
+      "newsletter dbFlex lookup error",
+      error instanceof Error ? error.message : "unknown",
+    );
+  }
+
+  // 9. Create the subscriber record via the authenticated API. `reference`
+  //    comes from the fixed LOCALES table, never the request.
+  try {
+    const resp = await fetch(`${tablePath}/create.json?workflow=1`, {
       method: "POST",
-      headers: {
-        "Authorization": `Bearer ${env.DBFLEX_API_KEY_01}`,
-        "Content-Type": "application/json",
-      },
+      headers: dbHeaders,
       body: JSON.stringify([
         { [EMAIL_FIELD]: email, [REFERENCE_FIELD]: l.reference },
       ]),
     });
     if (!resp.ok) {
-      console.error("newsletter dbFlex upsert failed", {
+      console.error("newsletter dbFlex create failed", {
         locale,
         status: resp.status,
       });
@@ -239,13 +279,13 @@ async function handleNewsletter(
     }
   } catch (error) {
     console.error(
-      "newsletter dbFlex upsert error",
+      "newsletter dbFlex create error",
       error instanceof Error ? error.message : "unknown",
     );
     return redirect(l.home + "?newsletter=error#panel-cta");
   }
 
-  // 9. Success — full-page redirect to the existing thank-you page.
+  // 10. Success — full-page redirect to the existing thank-you page.
   return redirect(l.thanks);
 }
 


### PR DESCRIPTION
Refs #282. Interim fix pending #287 (mark Email unique → revert to upsert).

## Problem
The newsletter Worker used `upsert.json?match=f_64244897`, but PROdb rejected it:

```
{"error":403,"code":3106,"source":"match","message":"Column is not marked unique"}
```

TeamDesk upsert-on-match requires the match column to be a unique field. The `Email Newsletter Subscriber` table can't be marked unique yet — it has nulls and duplicate rows left over from prior spam (cleanup tracked in #287).

## Change
- Switch dbFlex write from `upsert.json?match=…` to `create.json`.
- **Pre-insert lookup** for the requested address (`select.json?filter=[Email]="…"&top=1`). If it exists → redirect `?newsletter=exists` and show an "already subscribed" message; otherwise create the record. On any lookup error, fall through to create (better a rare duplicate than a lost signup).
- Add i18n `newsletter.already` (ja/en) and a second status paragraph in the CTA panel. Inline script now reveals **error** vs **exists** based on the `?newsletter=` value.

The lookup filter is built from the already server-validated email (regex rejects quotes/spaces), so the formula string is safe. All redirect targets remain server-constructed.

## Files
- `worker/index.ts` — steps 8 (lookup) + 9 (create) replace the upsert; header comment updated
- `src/_includes/templates/panel-cta.vto` — `#newsletter-exists` message + two-state reveal script
- `src/_data/i18n.yml`, `src/_data/en/i18n.yml` — `newsletter.already`

## Test Plan
- [ ] CF Workers Build green
- [ ] New address ja/en → thank-you page, row created in `Email Newsletter Subscriber`
- [ ] Existing address → stays on home with "already subscribed" message, **no** new row
- [ ] Turnstile fail / honeypot / time-trap / bad email / cross-origin still rejected

Verified locally: `deno check`, stable-deno `deno fmt --check` (2.8.2, matches CF 2.7.14), `deno lint`, YAML valid, `wrangler deploy --dry-run` bundles clean.

InfoSec: dbFlex writes remain on the authenticated API; lookup filter from a server-validated email; redirect targets server-constructed. No new unauthenticated surface.