### PR TITLE
fix(newsletter): return 400 (not 500) on malformed POST bodies

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -171,6 +171,16 @@ function redirect(location: string): Response {
   return new Response(null, { status: 303, headers: { Location: location } });
 }
 
+// Parse a form body without throwing on missing/garbled bodies (e.g. an empty
+// POST from a bot probe) — returns null instead of surfacing a 500.
+async function parseForm(request: Request): Promise<FormData | null> {
+  try {
+    return await request.formData();
+  } catch {
+    return null;
+  }
+}
+
 async function handleNewsletter(
   request: Request,
   env: Env,
@@ -192,7 +202,10 @@ async function handleNewsletter(
 
   // 3. Parse the form and resolve locale (never trusted for redirects below —
   //    only used to select from the fixed LOCALES table).
-  const form = await request.formData();
+  const form = await parseForm(request);
+  if (!form) {
+    return new Response("Bad Request", { status: 400 });
+  }
   const locale = form.get("locale") === "en" ? "en" : "ja";
   const l = LOCALES[locale];
 
@@ -514,8 +527,8 @@ async function handleSubOp(
   if (!rl.success) {
     return subPage("ja", SUB_ERROR.ja.title, SUB_ERROR.ja.body, "", 429);
   }
-  const form = await request.formData();
-  const guid = String(form.get("guid") ?? "");
+  const form = await parseForm(request);
+  const guid = form ? String(form.get("guid") ?? "") : "";
   if (!PK_GUID_RE.test(guid)) {
     return subPage("ja", SUB_INVALID.ja.title, SUB_INVALID.ja.body, "", 400);
   }


### PR DESCRIPTION
Refs #289.

## Problem
`request.formData()` throws when a POST has an empty or non-form body (e.g. a bot/scanner probing the endpoint). That throw was unhandled, so `/api/newsletter` and the verify/unsubscribe POST endpoints returned **500** on garbage input — error noise in Workers observability. Found while smoke-testing the live verify/unsubscribe deploy.

## Change
Add a `parseForm()` helper that catches the parse error and returns null; callers respond with a clean **400** / invalid-link page. The real form-submit and confirm-button paths always send a proper body, so they're unaffected.

## Validation
`wrangler dev`: empty POST to `/api/newsletter`, `/verify`, `/unsubscribe` all return **400** (were 500). `deno check`, stable-deno `deno fmt --check`, `deno lint` clean.

InfoSec: hardens request parsing against malformed input; removes 500-level noise from bot probes.