### PR TITLE
fix(newsletter): state-aware dedupe (verified / pending / re-subscribe)

### DIFF
--- a/src/_data/en/i18n.yml
+++ b/src/_data/en/i18n.yml
@@ -37,6 +37,7 @@ newsletter:
   success: Subscribed!
   error: Subscription failed
   already: You're already subscribed with this email address.
+  pending: You're already registered but haven't confirmed yet. Please check your inbox (and spam) for the confirmation link — we'll also send a reminder.
   reference: https://blog.esolia.pro/en/
   thanks_url: https://blog.esolia.pro/en/thank-you/
 contact:

--- a/src/_data/i18n.yml
+++ b/src/_data/i18n.yml
@@ -39,6 +39,7 @@ newsletter:
   success: 登録完了しました！
   error: 登録に失敗しました
   already: このメールアドレスは既にご登録済みです。
+  pending: 既にご登録いただいていますが、確認がまだ完了していません。受信トレイ（迷惑メールフォルダも）で確認メールのリンクをご確認ください。数日以内にリマインダーもお送りします。
   reference: https://blog.esolia.pro
   thanks_url: https://blog.esolia.pro/thank-you/
 contact:

--- a/src/_includes/templates/panel-cta.vto
+++ b/src/_includes/templates/panel-cta.vto
@@ -89,6 +89,15 @@
     >
       {{ i18n.newsletter.already }}
     </p>
+    {{# Shown when the Worker redirects back with ?newsletter=pending
+        (registered but not yet verified). #}}
+    <p
+      id="newsletter-pending"
+      class="mt-3 hidden text-sm text-amber-600 dark:text-amber-400"
+      role="status"
+    >
+      {{ i18n.newsletter.pending }}
+    </p>
   </form>
   <div
     class="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40 mt-6 lg:mt-0"
@@ -133,15 +142,10 @@
     var ts = document.querySelector('#newsletter input[name="ts"]');
     if (ts) ts.value = String(Date.now());
     // Reveal the matching message when the Worker bounced us back:
-    // ?newsletter=error (something failed) or =exists (already subscribed).
+    // ?newsletter=error | exists | pending → #newsletter-{state}.
     var state = new URLSearchParams(window.location.search).get("newsletter");
-    var msgId = state === "error"
-      ? "newsletter-error"
-      : state === "exists"
-      ? "newsletter-exists"
-      : null;
-    if (msgId) {
-      var msg = document.getElementById(msgId);
+    if (state === "error" || state === "exists" || state === "pending") {
+      var msg = document.getElementById("newsletter-" + state);
       if (msg) msg.classList.remove("hidden");
     }
   })();

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -268,26 +268,42 @@ async function handleNewsletter(
   };
   const tablePath = `${DBFLEX_API}/${encodeURIComponent(NEWSLETTER_TABLE)}`;
 
-  // 8. Already-subscribed check. The Email column is not (yet) marked unique in
-  //    dbFlex, so TeamDesk upsert-on-match is rejected (code 3106). Until it is
-  //    (see follow-up issue), query for the address first: if it exists, tell
-  //    the visitor they're already subscribed instead of creating a duplicate.
-  //    On any query error we fall through to create — better a rare duplicate
-  //    than a lost signup. Small race window for two simultaneous first-time
-  //    signups of the same address; the eventual unique constraint mops it up.
-  //    Email is validated above (no quotes/spaces), so the filter string is safe.
+  // 8. Existing-record check, state-aware. The Email column is not (yet) marked
+  //    unique in dbFlex, so instead of upsert-on-match (rejected, code 3106) we
+  //    query the address and branch on the record state:
+  //      - subscribed AND verified → confirmed subscriber ("exists").
+  //      - subscribed, not verified → "pending". dbFlex's daily nag re-sends the
+  //        confirmation at 3/7 days and auto-unsubscribes at 10, so we point them
+  //        back to that email rather than create a duplicate.
+  //      - only unsubscribed/auto-unsubscribed rows (Subscribed? false), or no
+  //        row at all → fall through and CREATE a fresh record, restarting a
+  //        clean verify + nag cycle (re-subscribe).
+  //    Fetch a few rows so any leftover duplicate rows for one address still
+  //    resolve to the best state (until the table is de-duped, issue #287). On
+  //    any query error we fall through to create — better a rare duplicate than a
+  //    lost signup. Email is validated above, so the filter string is safe.
   try {
     const filter = encodeURIComponent(`[Email]="${email}"`);
     const found = await fetch(
-      `${tablePath}/select.json?filter=${filter}&top=1`,
+      `${tablePath}/select.json?filter=${filter}&top=5`,
       { headers: dbHeaders },
     );
     if (found.ok) {
-      const rows = (await found.json()) as unknown[];
-      if (Array.isArray(rows) && rows.length > 0) {
-        console.log("newsletter already subscribed", { locale });
+      const rows = (await found.json()) as Array<
+        { "Subscribed?"?: boolean; "Verified?"?: boolean }
+      >;
+      const subscribed = Array.isArray(rows)
+        ? rows.filter((r) => r["Subscribed?"] === true)
+        : [];
+      if (subscribed.some((r) => r["Verified?"] === true)) {
+        console.log("newsletter already subscribed (verified)", { locale });
         return redirect(l.home + "?newsletter=exists#panel-cta");
       }
+      if (subscribed.length > 0) {
+        console.log("newsletter pending verification", { locale });
+        return redirect(l.home + "?newsletter=pending#panel-cta");
+      }
+      // else: new, unsubscribed, or auto-unsubscribed → create fresh below.
     } else {
       console.error("newsletter dbFlex lookup failed", {
         locale,

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -104,11 +104,13 @@ export default {
 // endpoint as an open redirect or inject an arbitrary reference. Mirrors
 // ~/dev/esolia-2025 workers/contact-form.
 //
-// dbFlex writes use create.json (not upsert-on-match) because the Email column
-// is not marked unique yet — TeamDesk rejects match on a non-unique column
-// (code 3106). A pre-insert lookup gives friendly "already subscribed" feedback
-// and avoids duplicates in the normal case. See the follow-up issue to clean
-// the table, mark Email unique, and switch back to upsert.
+// dbFlex writes use create.json (not upsert-on-match). The Email column is
+// intentionally NOT marked unique: a legitimate re-subscribe adds a fresh row,
+// which doubles as an audit log of renewed consent — so a DB unique constraint
+// isn't an option. Instead this handler's pre-insert lookup (step 8) is the
+// dedup mechanism, branching on the record's state. TeamDesk would also reject
+// upsert-match on a non-unique column (code 3106), so create + lookup is the
+// permanent design here, not a stopgap.
 // ---------------------------------------------------------------------------
 
 const DBFLEX_API = "https://pro.dbflex.net/secure/api/v2/15331";
@@ -268,9 +270,9 @@ async function handleNewsletter(
   };
   const tablePath = `${DBFLEX_API}/${encodeURIComponent(NEWSLETTER_TABLE)}`;
 
-  // 8. Existing-record check, state-aware. The Email column is not (yet) marked
-  //    unique in dbFlex, so instead of upsert-on-match (rejected, code 3106) we
-  //    query the address and branch on the record state:
+  // 8. Existing-record check, state-aware. The Email column is intentionally not
+  //    unique (re-subscribes add a fresh row as a consent log), so this lookup —
+  //    not a DB constraint — is the dedup. Query the address and branch on state:
   //      - subscribed AND verified → confirmed subscriber ("exists").
   //      - subscribed, not verified → "pending". dbFlex's daily nag re-sends the
   //        confirmation at 3/7 days and auto-unsubscribes at 10, so we point them
@@ -278,10 +280,10 @@ async function handleNewsletter(
   //      - only unsubscribed/auto-unsubscribed rows (Subscribed? false), or no
   //        row at all → fall through and CREATE a fresh record, restarting a
   //        clean verify + nag cycle (re-subscribe).
-  //    Fetch a few rows so any leftover duplicate rows for one address still
-  //    resolve to the best state (until the table is de-duped, issue #287). On
-  //    any query error we fall through to create — better a rare duplicate than a
-  //    lost signup. Email is validated above, so the filter string is safe.
+  //    Fetch a few rows so multiple rows for one address (spam-era dupes, or the
+  //    old row from a re-subscribe) still resolve to the best state. On any query
+  //    error we fall through to create — better a rare duplicate than a lost
+  //    signup. Email is validated above, so the filter string is safe.
   try {
     const filter = encodeURIComponent(`[Email]="${email}"`);
     const found = await fetch(


### PR DESCRIPTION
Refs #282, #289.

## Problem
The signup dup-check treated *any* existing row as "already subscribed." So someone who registered but never clicked verify, and re-signs up thinking it failed, was told "already subscribed" — a dead end. It also had no path for people who were unsubscribed (incl. dbFlex's day-10 auto-unsubscribe) and want back.

## dbFlex lifecycle (confirmed from setup)
`Subscribed? && !Verified? && Effectual?` records are **nagged** daily at 9:00 — `Nag Needed?` fires at **3 days** and **7 days** after creation (re-sending the confirmation email, which now carries the Worker verify link). At **10 days** `Auto Unsubscribe Needed?` → the 8:45 `Auto-Unsubscribe` trigger sets `Subscribed?=false` and emails them; nagging then stops (its clauses require `Subscribed?`).

## Change
Branch the signup dup-check on record state:

| State | Outcome |
|---|---|
| subscribed **and** verified | "already subscribed" (`?newsletter=exists`) |
| subscribed, not verified | **"pending"** — registered but unconfirmed; check inbox, nag re-sends (`?newsletter=pending`) |
| only unsubscribed / auto-unsubscribed (or none) | fall through → **create a fresh record** (re-subscribe, clean verify+nag cycle) |

Reads a few rows per address so leftover duplicates still resolve to the best state until the table is de-duped (#287). Adds i18n `newsletter.pending` (ja/en) + an amber pending message; the reveal script now maps `?newsletter=error|exists|pending → #newsletter-{state}`.

## Validation
`deno check`, stable-deno `deno fmt --check`, `deno lint`, `wrangler deploy --dry-run` clean; Vento tags balanced; `newsletter.pending` present both locales. dbFlex `Subscribed?`/`Verified?` reads confirmed via the API earlier. Full signup flow validated on the production deploy.

## Note / open question
For a re-subscribing address that was **verified then unsubscribed**, this creates a fresh record (they'll re-confirm). If you'd rather just flip `Subscribed?=true` on the existing record (no re-confirm) for that specific sub-case, say so and I'll adjust — I chose create-fresh to keep the nag/auto-unsubscribe timing (which keys off `Created Elapsed`) correct.

InfoSec: no new surface; dbFlex reads/writes remain on the authenticated API.