### PR TITLE
fix: repair homepage search (pagefind module) + silence TOC warning

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -489,6 +489,20 @@ site.addEventListener("afterBuild", "makeFontpathAbsoluteJa");
 site.process([".html"], externalLinksIcon("https://blog.esolia.pro"));
 if (!isCms) {
   site.process([".html"], deferPagefind());
+  // Pagefind's pagefind-ui.js is shipped as an ES module (it imports a shared
+  // ../chunk-*.js and sets window.PagefindUI). Lume's pagefind plugin injects it
+  // as a classic <script>, so the browser throws "Cannot use import statement
+  // outside a module" and PagefindUI never defines — breaking site search. Load
+  // it as a module; the init runs on DOMContentLoaded, which fires after the
+  // deferred module executes, so window.PagefindUI is ready in time.
+  site.process([".html"], (pages) => {
+    for (const page of pages) {
+      const script = page.document?.querySelector(
+        'script[src="/pagefind/pagefind-ui.js"]',
+      );
+      if (script) script.setAttribute("type", "module");
+    }
+  });
 }
 
 // site.filter("tdate", (value: string | undefined, locale: string, timezone: string) => {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -186,7 +186,7 @@ document.addEventListener("keydown", function (event) {
 document.addEventListener("DOMContentLoaded", () => {
   const tocDetails = document.getElementById("toc-details");
   if (!tocDetails) {
-    console.warn("Table of Contents details element not found!");
+    // No TOC on this page (home/listing pages) — nothing to do.
     return;
   }
   const handleDetailsState = () => {


### PR DESCRIPTION
Closes #285, #286. Both surfaced in the console while verifying the newsletter work.

## #285 — site search broken (functional)
The served `/pagefind/pagefind-ui.js` is a **hybrid ES module**: it `import`s a shared `../chunk-*.js` (resolves to `/chunk-*.js`, present) **and** sets `window.PagefindUI`. Lume's pagefind plugin injects it as a **classic** `<script src=…>`, so the browser throws `Cannot use import statement outside a module`, `PagefindUI` never defines, and search doesn't initialize on any page.

**Fix:** a `_config.ts` post-process sets `type="module"` on the tag. The init is wrapped in a `DOMContentLoaded` listener, which fires *after* deferred modules execute, so `window.PagefindUI` is ready by the time `new PagefindUI()` runs. Minimal, no version bumps. (The same fix could live in hibana's `deferPagefind`, which already touches this script — happy to move it there and cut a hibana release if you'd prefer.)

## #286 — console noise (cosmetic)
`main.js` logged "Table of Contents details element not found!" on every page without a TOC. Dropped the `console.warn`; kept the silent early return.

## Validation
Stable-deno `deno fmt --check` + `deno lint` clean on both files. Post-deploy I'll confirm the built homepage script carries `type="module"`; **search behavior needs a real browser check** (load `/`, open search, type a query).

InfoSec: no security impact — client-side script loading + console cleanup.