### PR TITLE
chore(content): light-touch copyedit of English posts

### DIFF
--- a/src/posts/20250226-are-you-doing-clear-desk-and-clear-screen-en.md
+++ b/src/posts/20250226-are-you-doing-clear-desk-and-clear-screen-en.md
@@ -6,34 +6,34 @@ last_modified: 2025-05-31T20:00:27.000Z
 title: Are you doing Clear Desk and Clear Screen?
 description: >-
   A quick security tip about the importance of keeping clear desk / clear screen
-  in mind. 
+  in mind.
 image: /uploads/20250226-clear-desk-social-en.jpg
 image_top: /uploads/20250226-clear-desk-top.jpg
 author: Rick Cogley
 category: Security
 tags:
   - ISO-27001
-oldUrl: 
+oldUrl:
   - /2505cleardeske/
 comments: {}
 draft: false
 hot: false
 featured: false
 ---
-One security policy that is probably used at most organizations is *"clear desk, clear screen"*. Are you aware and doing it? 
+One security policy that is probably used at most organizations is *"clear desk, clear screen"*. Are you aware and doing it?
 
 <!--more-->
 
 ### The simple story
-On the surface, "clear desk, clear screen" means you should take care to keep your desk or work area clean and neat, and to be aware of what is on your screen, locking your computer with a screensaver or lock screen, to avoid leaking confidential information. 
+On the surface, "clear desk, clear screen" means you should take care to keep your desk or work area clean and neat, and to be aware of what is on your screen, locking your computer with a screensaver or lock screen, to avoid leaking confidential information.
 
-However the fact is, even this simple directive is sometimes ignored, leading to information leaks and other issues. 
+However the fact is, even this simple directive is sometimes ignored, leading to information leaks and other issues.
 
 ### There's more to it
 
-"Clear desk, clear screen" is an easy-to-remember mnemonic, and the reality is it covers a lot more areas that you should be aware of, besides just keeping your desk tidy. 
+"Clear desk, clear screen" is an easy-to-remember mnemonic, and the reality is it covers a lot more areas that you should be aware of, besides just keeping your desk tidy.
 
-Like what? 
+Like what?
 
 * Go paperless where possible
 * Lock assets up when they are not in use
@@ -43,7 +43,7 @@ Like what?
 * Clean up meeting rooms of any printed materials, and clean whiteboards after use, properly disposing of unneeded printed materials using a shredder
 * Make it clear using software where possible, such as with labels and popups in the UI, that the information being accessed is sensitive
 
-While you think about these areas, of course you need to consider culture, laws and regulations, contractual requirements and identified risks, because they will all impact the details of your policy. 
+While you think about these areas, of course you need to consider culture, laws and regulations, contractual requirements and identified risks, because they will all impact the details of your policy.
 
 > [!tip]
 >

--- a/src/posts/20250403-essential-keyboard-shortcuts-en.md
+++ b/src/posts/20250403-essential-keyboard-shortcuts-en.md
@@ -6,31 +6,31 @@ lang: en
 id: 202503c-essential-shortcuts
 title: >-
   This Is Your First Step to Saving Time! Essential Shortcuts You Can Use
-  Starting Today 
+  Starting Today
 description: >-
   Discover useful shortcut keys for Windows and Office 365 to enhance
-  productivity and streamline your workflow, starting today! 
+  productivity and streamline your workflow, starting today!
 image: /uploads/202503c-essential-shortcuts-social-en.jpg
 author: 'YN'
 category: Microsoft-365
 comments: {}
 date: 2025-03-28T03:12:00.000Z
 last_modified: 2025-05-31T20:00:27.000Z
-tags: 
+tags:
   - shortcuts
 oldUrl:
   - /2505shortcutse/
 image_top: /uploads/202503c-essential-shortcuts-top.jpg
 ---
-Have you ever experienced something like this? You keep clicking through windows thinking, “Wait, where did that screen go?” Or you make a mistake and find yourself scrambling to figure out how to undo it. Sometimes you even slam your laptop shut when someone suddenly starts talking to you. Before you know it, a simple task ends up taking over 3 minutes. But what if I told you — _there’s a way to do that same task in just **one second**_? 
+Have you ever experienced something like this? You keep clicking through windows thinking, “Wait, where did that screen go?” Or you make a mistake and find yourself scrambling to figure out how to undo it. Sometimes you even slam your laptop shut when someone suddenly starts talking to you. Before you know it, a simple task ends up taking over 3 minutes. But what if I told you — _there’s a way to do that same task in just **one second**_?
 
 <!--more-->
 
-Here, we’ve gathered a collection of basic shortcuts you can start using right now. 
-No complicated steps, no advanced knowledge required. Just simple, practical shortcuts that feel intuitive — ones your fingers will remember for you. 
+Here, we’ve gathered a collection of basic shortcuts you can start using right now.
+No complicated steps, no advanced knowledge required. Just simple, practical shortcuts that feel intuitive — ones your fingers will remember for you.
 
 ## Useful Shortcut Keys for Windows
-### Basic operations 
+### Basic operations
 For relieving everyday little frustrations...
 
 <table class="not-prose w-full text-sm">
@@ -67,7 +67,7 @@ For relieving everyday little frustrations...
   </tbody>
 </table>
 
-### Boost productivity 
+### Boost productivity
 Quiet time-savers for smart workers...
 
 <table class="not-prose w-full text-sm">
@@ -99,14 +99,14 @@ Quiet time-savers for smart workers...
     </tr>
     <tr>
       <td><kbd>Win</kbd> + <kbd>.</kbd></td>
-      <td>Show a Emoji panel</td>
+      <td>Show an Emoji panel</td>
     </tr>
   </tbody>
 </table>
 
 
-## Shortcut Keys for Office 365 
-### Word 
+## Shortcut Keys for Office 365
+### Word
 
 <table class="not-prose w-full text-sm">
   <caption>
@@ -214,19 +214,17 @@ Quiet time-savers for smart workers...
   </tbody>
 </table>
 
-Once you start using keyboard shortcuts, you’ll be surprised how much faster your work gets. Each shortcut may save just a few seconds, but when used many times a day, it really adds up. 
+Once you start using keyboard shortcuts, you’ll be surprised how much faster your work gets. Each shortcut may save just a few seconds, but when used many times a day, it really adds up.
 
-**Knowing shortcuts isn’t enough — what matters is actually using them.** 
-Try picking just one shortcut that interests you and use it today. Even that small step can change the pace of your workflow. In fact, you can even try one right now in this site - press <kbd>Ctrl</kbd> + <kbd>k</kbd> if you're on Windows, or <kbd>Cmd</kbd> + <kbd>k</kbd> on Mac, to open the search popup.
+**Knowing shortcuts isn’t enough — what matters is actually using them.**
+Try picking just one shortcut that interests you and use it today. Even that small step can change the pace of your workflow. In fact, you can even try one right now on this site - press <kbd>Ctrl</kbd> + <kbd>k</kbd> if you're on Windows, or <kbd>Cmd</kbd> + <kbd>k</kbd> on Mac, to open the search popup.
 
-A little help from your fingertips might just make your workday smoother. 
+A little help from your fingertips might just make your workday smoother.
 
-![図形](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAANSURBVBhXY2BgYGAAAAAFAAGKM+MAAAAAAElFTkSuQmCC) 
-
-> [!TIP] 
+> [!TIP]
 > **Top 4 Shortcuts to Try Today:**
-> - <kbd>Alt</kbd> + <kbd>Tab</kbd>: Switch between windows 
-> - <kbd>Win</kbd> + <kbd>L</kbd>: Instantly lock your screen 
+> - <kbd>Alt</kbd> + <kbd>Tab</kbd>: Switch between windows
+> - <kbd>Win</kbd> + <kbd>L</kbd>: Instantly lock your screen
 > - <kbd>Win</kbd> + <kbd>V</kbd>: Show clipboard history
-> - <kbd>Win</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd>: Take a screenshot of a selected area  
+> - <kbd>Win</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd>: Take a screenshot of a selected area
 >  <br>

--- a/src/posts/20250408-outlook-calendar-sync-issues-en.md
+++ b/src/posts/20250408-outlook-calendar-sync-issues-en.md
@@ -31,13 +31,13 @@ If you use Outlook, you might occasionally encounter problems where your calenda
 The first thing you should try is using **Outlook on the web**. This is the simplest and most reliable way to avoid sync issues. Since the web version has different sync timings than the app, it can help prevent problems that occur in the app. If you notice that updates aren’t reflecting or there’s a delay in the app, always check the web version first.
 
 ## Clear the Cache
-Another effective method is to **clear the cache**. Outlook app creates a local file called an **OST file** that helps you access emails, calendar, and contacts even when you're offline. Over time, if you’ve been using Outlook for a long time or manage a large number of calendars, the OST file can become quite large, which may lead to syncing problems. 
+Another effective method is to **clear the cache**. The Outlook app creates a local file called an **OST file** that helps you access emails, calendar, and contacts even when you're offline. Over time, if you’ve been using Outlook for a long time or manage a large number of calendars, the OST file can become quite large, which may lead to syncing problems.
 
 ### How to Delete the OST File
 Follow these steps to delete the OST file in the Classic version of Outlook:
 
 1. Open the **File tab**
-2. Select **Account Settings** 
+2. Select **Account Settings**
 3. Click on **Account Settings** again
 4. Choose **Data Files**
 5. Click on the OST file and select **Open File Location**
@@ -47,21 +47,21 @@ Follow these steps to delete the OST file in the Classic version of Outlook:
   <img alt="Screenshot of Outlook settings" src="/uploads/202503e-outlook-calender-sync-issues-en.png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
-7. Delete the OST file. (Even if you delete the OST file, Outlook will re-create it automatically.) 
+7. Delete the OST file. (Even if you delete the OST file, Outlook will re-create it automatically.)
 
 Additionally, rebuilding your profile can help resolve syncing issues. Here’s how to do it:
 
 1. Open **Control Panel** and go to **Mail (Microsoft Outlook)**
 2. Click **Show Profiles**
-3. Delete the current profile 
+3. Delete the current profile
 4. Create a new profile and give it a slightly different name
 
 
 > [!CAUTION]
-> After deleting the OST file and rebuilding your profile, it might take several hours for emails and other data to sync back to your app. This method doesn’t always resolve the issue, but it can help in many cases. 
+> After deleting the OST file and rebuilding your profile, it might take several hours for emails and other data to sync back to your app. This method doesn’t always resolve the issue, but it can help in many cases.
 
 ## Check Manually
-Although the first two methods are effective, delays in syncing can still occur because the information is transmitted over the internet. In time-sensitive situations or when you have conflicting appointments, the most reliable way to avoid issues is to **check manually.** 
+Although the first two methods are effective, delays in syncing can still occur because the information is transmitted over the internet. In time-sensitive situations or when you have conflicting appointments, the most reliable way to avoid issues is to **check manually.**
 
 While this may seem old-fashioned, directly confirming with the calendar owner or manager ensures that the schedule is accurate, preventing double bookings and other mistakes.
 

--- a/src/posts/20250408-simple-maintenance-tips-en.md
+++ b/src/posts/20250408-simple-maintenance-tips-en.md
@@ -9,7 +9,7 @@ last_modified: 2025-05-31T20:00:27.000Z
 title: 'Simple Maintenance Tips to keep your PC running smoothly '
 description: >-
   By performing simple maintenance regularly, you can maintain your PC's
-  performance and use it smoothly. 
+  performance and use it smoothly.
 image: /uploads/202503d-simple-maintenance-tips-social-en.jpg
 author: 'Sachiko Kosuge '
 category: Troubleshooting
@@ -20,10 +20,10 @@ oldUrl:
 comments: {}
 image_top: /uploads/202503d-simple-maintenance-tips-top.jpg
 ---
-Simple maintenance tips to keep your PC running smoothly. By regularly performing these easy maintenance tasks, you can maintain your PC’s performance and enjoy using it for a long time. 
+Simple maintenance tips to keep your PC running smoothly. By regularly performing these easy maintenance tasks, you can maintain your PC’s performance and enjoy using it for a long time.
 <!--more-->
 
-## Remove dust from your PC 
+## Remove dust from your PC
 Dust can reduce the cooling efficiency of your PC and lead to overheating. Use an air duster or brush to remove dust accumulated around the PC’s fan area and inside the USB and HDMI ports.
 
 ## Software Updates
@@ -35,6 +35,6 @@ Deleting unnecessary files can increase your disk space and improve your PC’s 
 ## Restart PC
 Using a computer for long periods or running multiple programs simultaneously can deplete memory and system resources, leading to slower performance. Regularly restarting your computer helps reset system resources and maintain smooth operation.
 
-Regular maintenance is key to extending your PC’s lifespan and maintaining its performance. Give these tips a try! 
+Regular maintenance is key to extending your PC’s lifespan and maintaining its performance. Give these tips a try!
 
 At eSolia Inc, we provide reliable IT support services as an outsourced IT department for businesses. If you're considering IT outsourcing, feel free to contact us here for more information.

--- a/src/posts/20250410-admin-asked-ai-about-the-it-terminology-en.md
+++ b/src/posts/20250410-admin-asked-ai-about-the-it-terminology-en.md
@@ -29,56 +29,56 @@ How to Use AI to turn “Kind of Know” into “Truly Understand” for the IT 
 <!--more-->
 
 ## Introduction
-As part of Office Manager or Admin work at an IT services firm like eSolia, we often see IT terms such as "UTP cable," "CAT 6 cable," or "RJ45 connector" in estimate details for LAN cabling constructions. Based on the job content, I had a vague impression that those terms were something used for network lines. 
+As part of Office Manager or Admin work at an IT services firm like eSolia, we often see IT terms such as "UTP cable," "CAT 6 cable," or "RJ45 connector" in estimate details for LAN cabling constructions. Based on the job content, I had a vague impression that those terms were something used for network lines.
 
-One of our internal knowledgebase articles from Nikkei Network - “What you surprisingly don’t know about LAN cables” (日経ネットワーク – 意外と知らないLANケーブル" - provides a broad interpretation of LAN cables, including some specialized knowledge, but I wanted an even simpler explanation to understand, so I asked AIs to try to get a better understanding of these terms. Let me share what I found out. 
+One of our internal knowledgebase articles from Nikkei Network - “What you surprisingly don’t know about LAN cables” (日経ネットワーク – 意外と知らないLANケーブル" - provides a broad interpretation of LAN cables, including some specialized knowledge, but I wanted an even simpler explanation to understand, so I asked AIs to try to get a better understanding of these terms. Let me share what I found out.
 
 ## The First Question to AI
-First, I asked a simple question to three different AI tools. 
+First, I asked a simple question to three different AI tools.
 
 {{- comp.icon({ name: "chat-centered-dots", size: 4, color: "sky" }) -}}Question to AI: **What is a UTP cable?**
 
-As summarized in the linked PDF, the search results from each AI seem to be similar. It looks like that it is a compilation of explanations of IT terms that appear in textbooks; it was easier to read through rather than reading textbooks, but I still need some simple clarification to grasp the ideas of these terms.
+As summarized in the linked PDF, the search results from each AI seem to be similar. It looks like it is a compilation of explanations of IT terms that appear in textbooks; it was easier to read through rather than reading textbooks, but I still need some simple clarification to grasp the ideas of these terms.
 
 {{- comp.icon({ name: "file-pdf", size: 4, color: "red" }) -}}
 [What is a UTP cable? - AI Answers](/uploads/excel-20250307-utpケーブルって何-aiの回答-en.pdf)
 
 ## Changing the Way I Asked AI
-So next, I tried asking a more detailed question, prompting the AI to take the knowledge level of the audience into consideration. This time, the AI responses showed some noticeable differences. 
+So next, I tried asking a more detailed question, prompting the AI to take the knowledge level of the audience into consideration. This time, the AI responses showed some noticeable differences.
 
 {{- comp.icon({ name: "chat-centered-dots", size: 4, color: "sky" }) -}}Question to AI: **What are UTP cables, Cat cables, and RJ45 connectors? I'd like an easy-to-understand explanation for people without IT knowledge.**
 
-This time, there was a slight change in the answers from AIs. 
+This time, there was a slight change in the answers from AIs.
 
 {{- comp.icon({ name: "brain", size: 4, color: "pink" }) -}}**ChatGPT** (free version): Turned on the "inference" function and then asked the question. The answer was displayed in the form of a summary of the explanation in the table above.
 
-It was interesting to be able to see the basis for the answer given by the AI based on the "inference" function. As for the content of the explanation, difficult terms are summarized in bullet points, which gives the impression that users can quickly check and understand the content rather than reading long explanations. 
+It was interesting to be able to see the basis for the answer given by the AI based on the "inference" function. As for the content of the explanation, difficult terms are summarized in bullet points, which gives the impression that users can quickly check and understand the content rather than reading long explanations.
 
-{{- comp.icon({ name: "lightbulb-filament", size: 4, color: "yellow" }) -}}**Copilot** (free version): Provided a straightforward explanation for general users and IT beginners: UTP cables are like “electrical cords,” Cat cables are like “speed meters” that show UTP performance, and RJ45 connectors are “outlet plugs” for making connections.  
+{{- comp.icon({ name: "lightbulb-filament", size: 4, color: "yellow" }) -}}**Copilot** (free version): Provided a straightforward explanation for general users and IT beginners: UTP cables are like “electrical cords,” Cat cables are like “speed meters” that show UTP performance, and RJ45 connectors are “outlet plugs” for making connections.
 
-{{- comp.icon({ name: "smiley-wink", size: 4, color: "emerald" }) -}}**DeepSeek** (Japanese mobile app version): Asked the question with the "Deep Think (R1)" feature turned on.  
+{{- comp.icon({ name: "smiley-wink", size: 4, color: "emerald" }) -}}**DeepSeek** (Japanese mobile app version): Asked the question with the "Deep Think (R1)" feature turned on.
 
-First of all, like ChatGPT, DeepSeek was able to confirm the theory behind the explanatory text, and to see that it was trying to answer after exploring and considering the questioner's true intention. 
+First of all, like ChatGPT, DeepSeek was able to confirm the theory behind the explanatory text, and to see that it was trying to answer after exploring and considering the questioner's true intention.
 
-Then, in terms of the explanation, it gave an answer similar to Copilot's, describing a UTP cable as "a cable like a normal telephone line," a Cat cable as "a number that indicates the generation of the cable," and an RJ45 connector as "a plug at the end of a LAN cable." 
+Then, in terms of the explanation, it gave an answer similar to Copilot's, describing a UTP cable as "a cable like a normal telephone line," a Cat cable as "a number that indicates the generation of the cable," and an RJ45 connector as "a plug at the end of a LAN cable."
 
-In addition, the “illustrating the overall relationship” part should be the easiest to understand for users and IT beginners without IT knowledge. The explanation in the final overview diagram is simple to understand: “a type of cable called UTP cable with Cat6 performance and RJ45 connectors on both ends.” 
+In addition, the “illustrating the overall relationship” part should be the easiest to understand for users and IT beginners without IT knowledge. The explanation in the final overview diagram is simple to understand: “a type of cable called UTP cable with Cat6 performance and RJ45 connectors on both ends.”
 
 Here’s how each AI might respond if we were to give them a bit of personality:
 
-{{- comp.icon({ name: "brain", size: 4, color: "pink" }) -}}**ChatGPT** (free version): "A UTP cable is made with twisted pairs of wires... it’s a bit technical, but I’ve listed the key points for you!" 
+{{- comp.icon({ name: "brain", size: 4, color: "pink" }) -}}**ChatGPT** (free version): "A UTP cable is made with twisted pairs of wires... it’s a bit technical, but I’ve listed the key points for you!"
 
-{{- comp.icon({ name: "lightbulb-filament", size: 4, color: "yellow" }) -}}**Copilot** (free version): "Think of a UTP cable as an 'electric cord'! And a Cat cable? It’s kind of like a 'speedometer' showing performance." 
+{{- comp.icon({ name: "lightbulb-filament", size: 4, color: "yellow" }) -}}**Copilot** (free version): "Think of a UTP cable as an 'electric cord'! And a Cat cable? It’s kind of like a 'speedometer' showing performance."
 
-{{- comp.icon({ name: "smiley-wink", size: 4, color: "emerald" }) -}}**DeepSeek** (Japanese mobile app version): "Hmm, I see what you're really asking... You want to understand the 'generations' of LAN cables, right? Okay, let me draw a diagram for you!" 
+{{- comp.icon({ name: "smiley-wink", size: 4, color: "emerald" }) -}}**DeepSeek** (Japanese mobile app version): "Hmm, I see what you're really asking... You want to understand the 'generations' of LAN cables, right? Okay, let me draw a diagram for you!"
 
-Since I was able to get easy-to-understand answers, feel free to try using the above question yourself if you'd like to see the actual responses. 
+Since I was able to get easy-to-understand answers, feel free to try using the above question yourself if you'd like to see the actual responses.
 
 ## Summary
-Here we listed results of asking three types of AI about UTP cables. Getting simplified answers rather than technical terms will give general users or IT beginners a basic understanding of UTP cables. It was interesting to be able to see some of the logic behind how AI tries to come up with answers, and this experience made me really felt that advanced AI technology is an extremely useful tool.  
+Here we listed results of asking three types of AI about UTP cables. Getting simplified answers rather than technical terms will give general users or IT beginners a basic understanding of UTP cables. It was interesting to be able to see some of the logic behind how AI tries to come up with answers, and this experience made me really feel that advanced AI technology is an extremely useful tool.
 
-However, it is important to remember that the accuracy of the answers provided by AI and the credibility of the answer resources are not 100% guaranteed (after all, they are ingesting articles and text they found on the internet), so please be aware that the use of AI must be interpreted by the individual or in accordance with the policies of their company.  
+However, it is important to remember that the accuracy of the answers provided by AI and the credibility of the answer resources are not 100% guaranteed (after all, they are ingesting articles and text they found on the internet), so please be aware that the use of AI must be interpreted by the individual or in accordance with the policies of their company.
 
-eSolia provides daily IT support as a reliable IT department for companies in Japan, and we can definitely answer your answers about cabling!  
+eSolia provides daily IT support as a reliable IT department for companies in Japan, and we can definitely answer your questions about cabling!
 
-If you are considering outsourcing your IT department, or if you need help on any IT-related projects (office relocation or LAN cablign constructions,  equipment installation, etc.), please feel free to contact us here.
+If you are considering outsourcing your IT department, or if you need help on any IT-related projects (office relocation or LAN cabling constructions, equipment installation, etc.), please feel free to contact us here.

--- a/src/posts/20250411-check-battery-health-en.md
+++ b/src/posts/20250411-check-battery-health-en.md
@@ -23,32 +23,32 @@ image_top: /uploads/202503f-laptop-battery-health-top.jpg
 oldUrl:
   - /en/posts/20250409-check-battery-health-en/
 ---
-Every mobile device has a battery. And the battery condition will get gradually worse over time, lasting less time as you continue to use it. Windows offers a useful feature to check the battery status of your device by simply inputting a single command on the command line. Read on for a quick tip to check it on Windows laptops. 
+Every mobile device has a battery. And the battery condition will get gradually worse over time, lasting less time as you continue to use it. Windows offers a useful feature to check the battery status of your device by simply inputting a single command on the command line. Read on for a quick tip to check it on Windows laptops.
 
 <!--more-->
 
 ## 1. Open “Command Prompt”
-The quickest way to open Command Prompt is: 
+The quickest way to open Command Prompt is:
 
 A. Press the <kbd>Windows</kbd> button
-B. Type “cmd” in the search bar and press <kbd>Enter</kbd> 
+B. Type “cmd” in the search bar and press <kbd>Enter</kbd>
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of searching comand prompt on windows" src="/uploads/202503e-laptop-battery-health-en(1).png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
 ## 2. Generate Battery Report
-In the black screen that pops up, input the below command and press Enter. 
+In the black screen that pops up, input the below command and press Enter.
 
 ```powershell
-PS c:\> powercfg/batteryreport    
+PS c:\> powercfg/batteryreport
 ```
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of Typing a command into the Command Prompt" src="/uploads/202503e-laptop-battery-health-en(2).png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
-Once the command is entered, Command Prompt tells you that the battery report has been generated. 
+Once the command is entered, Command Prompt tells you that the battery report has been generated.
 
 > [!TIP]
 > Just copy the folder path displayed in the black terminal window and paste it to Explorer using <kbd>Ctrl</kbd> + <kbd>C</kbd>, <kbd>Ctrl</kbd> + <kbd>V</kbd>
@@ -57,10 +57,10 @@ Once the command is entered, Command Prompt tells you that the battery report ha
   <img alt="Screenshot of Typing the path into explorer" src="/uploads/202503e-laptop-battery-health-en(3).png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
-Paste the folder path here and press Enter 
+Paste the folder path here and press Enter
 
-## 3. Check the Battery Report 
-Your default web browser launches and you will see a report page like this: 
+## 3. Check the Battery Report
+Your default web browser launches and you will see a report page like this:
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of the battery report" src="/uploads/202503e-laptop-battery-health(4).png" width="600px" transform-images="avif webp png jpeg 600@2">

--- a/src/posts/20250412-my-computer-froze-7-easy-fixes-for-beginners-en.md
+++ b/src/posts/20250412-my-computer-froze-7-easy-fixes-for-beginners-en.md
@@ -7,7 +7,7 @@ id: 202503a-pc-freeze
 title: My Computer Froze! 7 Easy Fixes for Beginners
 description: >-
   Here are seven easy fixes that beginners can try when their computer suddenly
-  stops responding. 
+  stops responding.
 image: /uploads/202503a-pc-freeze-social-en.jpg
 author: Shiori
 category: Troubleshooting
@@ -23,30 +23,30 @@ image_top: /uploads/202503a-pc-freeze-top.png
 oldUrl:
   - /en/posts/20250402-my-computer-froze-7-easy-fixes-for-beginners-en/
 ---
-When your computer screen suddenly freezes while you're using it, it can be quite stressful, and frustrating especially if you’re busy. However, immediately forcing a shutdown or yanking the power plug can lead to data loss or make the situation worse. First, take a deep breath and stay calm. Then, try **the seven solutions** below. 
+When your computer screen suddenly freezes while you're using it, it can be quite stressful, and frustrating especially if you’re busy. However, immediately forcing a shutdown or yanking the power plug can lead to data loss or make the situation worse. First, take a deep breath and stay calm. Then, try **the seven solutions** below.
 
 <!--more-->
 
 ## Wait for a While
-If your computer is processing tasks and struggling to keep up, rushing and pressing multiple keys may make things worse. Confirm whether the access lamp is blinking, which indicates that your hard drive (HDD) or other storage device is actively reading or writing data. If it is, simply waiting a while can sometimes resolve the freeze. Try waiting at least **10 minutes** before taking further action. 
+If your computer is processing tasks and struggling to keep up, rushing and pressing multiple keys may make things worse. Confirm whether the access lamp is blinking, which indicates that your hard drive (HDD) or other storage device is actively reading or writing data. If it is, simply waiting a while can sometimes resolve the freeze. Try waiting at least **10 minutes** before taking further action.
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of the access lamp" src="/uploads/202503a-pc-freeze-.png" width="500px" transform-images="avif webp png jpeg 500@2">
 <figcaption class="text-left mt-2"><small>ex）Dell Latitude7290 access lamp</small></figcaption></figure>
 
 
-## Disconnect Peripherals 
+## Disconnect Peripherals
 Sometimes, what seems like a frozen screen may actually be an issue with your external keyboard or mouse. If you're using external devices, check their connection:
 
 &nbsp;&nbsp;**For wired devices**: Try unplugging and reconnecting the cable.
-&nbsp;&nbsp;**For wireless devices**: Make sure Bluetooth is still connected and check if the battery is dead or needs charging. 
+&nbsp;&nbsp;**For wireless devices**: Make sure Bluetooth is still connected and check if the battery is dead or needs charging.
 
-If your computer’s built-in keyboard or trackpad still works, the problem is likely with the external device. Wireless devices often run out of battery without warning, so it's a good idea to check them regularly. 
+If your computer’s built-in keyboard or trackpad still works, the problem is likely with the external device. Wireless devices often run out of battery without warning, so it's a good idea to check them regularly.
 
 ## Check External Mouse & Keyboard
-Sometimes, connected USB devices or peripherals can cause your computer to freeze. Try unplugging all peripherals and checking whether the problem resolves. 
+Sometimes, connected USB devices or peripherals can cause your computer to freeze. Try unplugging all peripherals and checking whether the problem resolves.
 
-Common peripherals include: 
+Common peripherals include:
 
 * Monitors
 * Docking stations
@@ -64,34 +64,34 @@ Even if your computer appears completely frozen, certain keyboard commands may h
 </figure>
 
 * Try <kbd>Alt</kbd> + <kbd>Tab</kbd> to switch between open applications.
-* Press <kbd>Windows</kbd> + <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd> to refresh the display. 
+* Press <kbd>Windows</kbd> + <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd> to refresh the display.
 
 ## Sign Out
 If the keyboard is still functional, signing out may help unfreeze your computer.
 
 * Press <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Del</kbd> and select **Sign Out** from the menu.
-  
+
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of task manager" src="/uploads/202503a-pc-freeze-en-(2).png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
 
-## Restart Your Computer 
+## Restart Your Computer
 If possible, restarting your computer may resolve the issue.
 
 * Press <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Del</kbd>, then click **Restart** from the lower-right corner of the screen.
-  
+
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of sleep, shutdown, and restart button" src="/uploads/202503a-pc-freeze-en-(3).png" width="500px" transform-images="avif webp png jpeg 500@2">
 </figure>
 
-##  Force Shutdown (Last Resort)  
-If none of the above solutions work, you may need to **force shutdown** as a last resort. 
+##  Force Shutdown (Last Resort)
+If none of the above solutions work, you may need to **force shutdown** as a last resort.
 
 * Press and hold the power button for **10 seconds** or more until the computer turns off completely.
 * Wait a few seconds, then turn the system back on.
 * If you see a message saying "Windows was not shut down properly," select "Start Windows Normally".
 
 Using a force shutdown can cause data loss, so it should only be used as a last resort. As a general rule, to prevent losing important data, make it a habit to save your work frequently.
- 
+
 At eSolia Inc, we provide reliable IT support services as an outsourced IT department for businesses. If you're considering IT outsourcing, feel free to contact us here for more information.

--- a/src/posts/20250623-how-to-strengthen-password-management-in-your-company-en.md
+++ b/src/posts/20250623-how-to-strengthen-password-management-in-your-company-en.md
@@ -12,7 +12,7 @@ title: >-
 description: >-
   Enhance your company's password management with practical strategies. Learn
   about MFA, password policies, and password managers to improve security. A
-  must-read for IT managers and decision-makers. 
+  must-read for IT managers and decision-makers.
 image: /uploads/202503h-password-management-en2.jpeg
 image_top: /uploads/202503h-password-management2.jpeg
 author: Kabaya
@@ -24,16 +24,16 @@ tags:
 comments: {}
 oldUrl: []
 ---
-Are you leaving password management up to individual employees? Many cyberattacks start by exploiting weaknesses in password practices—often due to human error or poor internal management. If your company's password policies are too lax, a single compromised account could lead to a major data breach. In this article, we’ll break down five key strategies IT professionals should implement to strengthen internal password management. From realistic policy setting based on the latest NIST guidelines, to effective tool usage and employee education, we’ll cover practical steps you can take to protect your organization. 
+Are you leaving password management up to individual employees? Many cyberattacks start by exploiting weaknesses in password practices—often due to human error or poor internal management. If your company's password policies are too lax, a single compromised account could lead to a major data breach. In this article, we’ll break down five key strategies IT professionals should implement to strengthen internal password management. From realistic policy setting based on the latest NIST guidelines, to effective tool usage and employee education, we’ll cover practical steps you can take to protect your organization.
 <!--more-->
 
 ## Why Is Password Management Important?
-Many corporate security risks stem from poorly managed passwords. Weak or reused passwords often become targets for cyberattacks. Phishing attacks and credential leaks are increasing, leading to unauthorized access that can cause significant damage to businesses. 
+Many corporate security risks stem from poorly managed passwords. Weak or reused passwords often become targets for cyberattacks. Phishing attacks and credential leaks are increasing, leading to unauthorized access that can cause significant damage to businesses.
 
-## Five Key Points to Strengthen Password Management 
+## Five Key Points to Strengthen Password Management
 
-### 1.Establish and Enforce a Password Policy 
-To maintain password strength while minimizing user frustration, consider adopting the following rules based on recommendations from NIST (National Institute of Standards and Technology): 
+### 1.Establish and Enforce a Password Policy
+To maintain password strength while minimizing user frustration, consider adopting the following rules based on recommendations from NIST (National Institute of Standards and Technology):
 
 * Minimum password length of 8 characters (using 15 characters or more in a passphrase format is highly recommended)
 * Mixing uppercase, lowercase, numbers, and symbols is optional (length is more important than complexity)
@@ -43,41 +43,41 @@ To maintain password strength while minimizing user frustration, consider adopti
 
 NIST’s latest guidelines emphasize **length over complexity** and **maintaining secure passwords over enforcing periodic changes.** Forcing regular updates often leads to predictable patterns (e.g., Spring2024! → Summer2024!), which can weaken security rather than enhance it.
 
-### 2.Implement Multi-Factor Authentication (MFA) 
-MFA significantly reduces the risk of unauthorized access, even if a password is compromised. Consider using: 
+### 2.Implement Multi-Factor Authentication (MFA)
+MFA significantly reduces the risk of unauthorized access, even if a password is compromised. Consider using:
 * One-time passwords (OTP)
 * Authentication apps (such as Microsoft or Google Authenticator)
 * Hardware tokens
 
-### 3.Utilize a Password Manager 
-Password managers such as Zetetic [Codebook](https://www.zetetic.net/codebook/){target="_blank" rel="noopener"} (eSolia’s choice) or 1Password help employees generate and store strong passwords securely, in an encrypted database application. Benefits include: 
+### 3.Utilize a Password Manager
+Password managers such as Zetetic [Codebook](https://www.zetetic.net/codebook/){target="_blank" rel="noopener"} (eSolia’s choice) or 1Password help employees generate and store strong passwords securely, in an encrypted database application. Benefits include:
 
 * Automatic generation and secure storing of strong passwords
 * Preventing password reuse
 * Checking if your passwords were leaked in a security breach
 * Ease of entering your passwords when requested
-  
+
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of the main page in Zetetic Codebook" src="/uploads/202503h-password-management-(1).png" width="600px" transform-images="avif webp png jpeg 600@2">
 <figcaption class="text-left mt-2"><small>Fig）the main screen in Zetetic Codebook</small></figcaption>
 </figure>
 
 ### 4.Strengthen Access Control
-Apply **the Principle of Least Privilege (PoLP)** by granting only necessary access rights, and consider “Just in Time” access rights allocation solutions, such as M365 PIM. 
-Additionally: 
+Apply **the Principle of Least Privilege (PoLP)** by granting only necessary access rights, and consider “Just in Time” access rights allocation solutions, such as M365 PIM.
+Additionally:
 * Regularly review access permissions
 * Properly manage accounts of former or transferred employees
 
-### 5.Employee Education and Regular Security Training 
-Password security is not just an IT issue; all employees should understand its importance. 
-Conduct training on: 
+### 5.Employee Education and Regular Security Training
+Password security is not just an IT issue; all employees should understand its importance.
+Conduct training on:
 * Identifying phishing emails
 * Raising awareness of security best practices
 * Simulated attacks to test employees’ responses
 
-At eSolia, in addition to taking part in security training, all employees create a monthly quiz based on articles from the magazine Nikkei Network, covering a wide range of IT and security topics. These quizzes are then delivered daily through TMC, our attendance and work tracking app, in a True/False format. This unique initiative helps reinforce both security awareness and overall IT knowledge as part of our everyday workflow. 
+At eSolia, in addition to taking part in security training, all employees create a monthly quiz based on articles from the magazine Nikkei Network, covering a wide range of IT and security topics. These quizzes are then delivered daily through TMC, our attendance and work tracking app, in a True/False format. This unique initiative helps reinforce both security awareness and overall IT knowledge as part of our everyday workflow.
 
 ## Conclusion
-Strengthening password management is a fundamental part of corporate cybersecurity. IT managers and decision-makers must lead efforts in setting policies, implementing security tools, and educating employees. Start by assessing your company’s current password management practices and take steps to enhance security today! 
+Strengthening password management is a fundamental part of corporate cybersecurity. IT managers and decision-makers must lead efforts in setting policies, implementing security tools, and educating employees. Start by assessing your company’s current password management practices and take steps to enhance security today!
 
 At eSolia Inc, we provide reliable IT support services for businesses as an outsourced IT department. If you're considering IT outsourcing, feel free to contact us for more information.

--- a/src/posts/20250702-sharepoint-online-post-migration-problems-solutions-en.md
+++ b/src/posts/20250702-sharepoint-online-post-migration-problems-solutions-en.md
@@ -11,7 +11,7 @@ description: >-
   Files won't open after migrating to SharePoint Online? In this article, we
   explain the differences in SPO's folder structure, URL limitations, access
   management, and give some practical solutions. Contains a detailed guide on
-  metadata management to enhance searchability! 
+  metadata management to enhance searchability!
 image: /uploads/202503b-sharepoint-migration-part1-social-en.jpg
 author: Ena
 category: Microsoft-365
@@ -29,7 +29,7 @@ Are you facing issues where files won't open **after migrating to SharePoint Onl
 
 <!--more-->
 
-## From On-Premises to the Cloud 
+## From On-Premises to the Cloud
 
 > Decommission all on-premises servers across all sites and move to the cloud!
 
@@ -46,13 +46,13 @@ The migration was successfully completed. However, the local IT team had lingeri
 
 > Is this really going to work? Will end users be able to adapt?
 
-Their fears soon materialized as users began reporting issues: 
+Their fears soon materialized as users began reporting issues:
 
 > I'm seeing an error, and I can’t access my files!
 
 So, what exactly was the problem? Let’s break it down.
 
-## SPO Limitations and Workplace Confusion 
+## SPO Limitations and Workplace Confusion
 With a strict deadline in place and limited time for careful implementation, the team aimed to minimize disruption by maintaining the existing operational approach, as much as possible, like so:
 
 * **Access permissions were set per folder**
@@ -60,7 +60,7 @@ With a strict deadline in place and limited time for careful implementation, the
 
 However, SPO is fundamentally different from on-premises file servers in its design. As a result, retaining the old folder structure led to frequent errors where files could not be opened. But why?
 
-Many companies manage their files in deeply nested folder structures, categorizing files by year, client, and other attributes within multiple subfolders. However, in SPO, this approach leads to errors such as: 
+Many companies manage their files in deeply nested folder structures, categorizing files by year, client, and other attributes within multiple subfolders. However, in SPO, this approach leads to errors such as:
 
 "Files won’t open due to path length limitations!"  
 
@@ -69,35 +69,35 @@ Many companies manage their files in deeply nested folder structures, categorizi
 
 To better understand the issue, let's examine SPO’s unique characteristics and the constraints it imposes.
 
-## SharePoint Online Constraints 
+## SharePoint Online Constraints
 ### 1. Folder Structure Limitations
 
 Deep folder structures are not recommended in SPO. Instead, a *metadata-driven approach* should be used for better searchability.
 
 ### 2. File Path Length Restrictions
 
-When syncing files to a local PC and opening them via Windows Explorer, the file path is limited to 256 characters. Even if a file opens in SPO via your web browser, it may fail to open on a local PC if the path exceeds this limit. 
+When syncing files to a local PC and opening them via Windows Explorer, the file path is limited to 256 characters. Even if a file opens in SPO via your web browser, it may fail to open on a local PC if the path exceeds this limit.
 
-Here are the two main scenarios and their limits when opening files: 
+Here are the two main scenarios and their limits when opening files:
 
-**OneDrive Sync Client:** 
+**OneDrive Sync Client:**
 
 * When accessing synced files from Windows Explorer, the 256-character limit applies.
 * If the folder structure is too deep, files may not open unless the path is shortened.
 
-**Browser Access:** 
+**Browser Access:**
 
 * If files are opened directly from the SharePoint Web interface, the local PC limit does not apply.
-* However, SharePoint Online itself has a URL length limit of 400 characters. 
+* However, SharePoint Online itself has a URL length limit of 400 characters.
 
 ### 3. Leveraging Search Features
 Instead of relying on deep folder structures, users can utilize metadata management and search functionality to find files more efficiently.
  
-Since SPO follows a different architectural approach than traditional file servers, it cannot be used in the same way. A new operational strategy aligned with SPO’s capabilities is necessary. 
+Since SPO follows a different architectural approach than traditional file servers, it cannot be used in the same way. A new operational strategy aligned with SPO’s capabilities is necessary.
 
 ## Solutions
 
-So in the end, how can we avoid the above issues and use SPO efficiently? 
+So in the end, how can we avoid the above issues and use SPO efficiently?
 
 * **Utilize metadata management** - instead of hierarchical folder structures, categorize files using "columns".
 * **Split document libraries by use case** - keep folder structures as simple as possible.
@@ -105,12 +105,12 @@ So in the end, how can we avoid the above issues and use SPO efficiently?
 * **Use shorter filenames** - prevent path length issues.
 * **Establish a naming convention** for consistency (e.g., if the convention is **"Date_Project"**, then you might name a folder "20250107-ProjectName". )
 
-## Summary 
+## Summary
 SPO migration projects don’t end with migration completion - they require ongoing adaptation to a more suitable operational model. By understanding SPO’s characteristics and establishing operational rules, companies can maximize the benefits of the cloud. One client shared with us:
 
 > At first, it was confusing, but after using the search feature, I realized it made my work much easier!
 
-To ensure more users share this sentiment, it’s essential to review operations and implement the right measures. 
+To ensure more users share this sentiment, it’s essential to review operations and implement the right measures.
 
 **Next: Practical Metadata Management**
 

--- a/src/posts/20250709-sharepoint-online-post-migration-problems-solutions-part-2-en.md
+++ b/src/posts/20250709-sharepoint-online-post-migration-problems-solutions-part-2-en.md
@@ -10,7 +10,7 @@ title: Files Won’t Open After Migrating to SharePoint Online! Part 2
 description: >-
   Learn how to prevent file access errors in SharePoint Online by using metadata
   management instead of deep folder structures. Boost searchability and
-  efficiency with practical tips. 
+  efficiency with practical tips.
 image: /uploads/202504d-sharepoint-migration-part2-en.jpeg
 image_top: /uploads/202504d-sharepoint-migration-part2.jpeg
 author: Ena
@@ -25,42 +25,42 @@ tags:
 comments: {}
 oldUrl: []
 ---
-In Part 1, we discussed an issue that commonly occurs when migrating to SharePoint Online (SPO): files failing to open when accessed through File Explorer. This problem is often caused by exceeding SPO’s limits on folder depth and file name length. In this article, we’ll focus on how to prevent such issues by using metadata management and adopting more efficient file management practices. 
+In Part 1, we discussed an issue that commonly occurs when migrating to SharePoint Online (SPO): files failing to open when accessed through File Explorer. This problem is often caused by exceeding SPO’s limits on folder depth and file name length. In this article, we’ll focus on how to prevent such issues by using metadata management and adopting more efficient file management practices.
 
 <!--more-->
 
-## 1. What is Metadata? 
-Metadata means "data about data"—in other words, it’s supplementary information that describes or gives context to other data. 
-For example, when you take a photo with your smartphone, the image itself is the data. But the background details, like when and where it was taken, are metadata. 
+## 1. What is Metadata?
+Metadata means "data about data"—in other words, it’s supplementary information that describes or gives context to other data.
+For example, when you take a photo with your smartphone, the image itself is the data. But the background details, like when and where it was taken, are metadata.
 
-Typical metadata for photos might include: 
-* The date and time the photo was taken 
-* Location information (GPS coordinates) 
-* The device model (smartphone or camera) 
-* Image size and resolution 
+Typical metadata for photos might include:
+* The date and time the photo was taken
+* Location information (GPS coordinates)
+* The device model (smartphone or camera)
+* Image size and resolution
 * File format (e.g., JPEG, PNG)
   
-Here’s an example: 
-When you take a photo with your smartphone, metadata such as the date, location, camera specs, and image details are automatically saved with it. 
-Hopefully, this gives you a general idea of what metadata is. 
+Here’s an example:
+When you take a photo with your smartphone, metadata such as the date, location, camera specs, and image details are automatically saved with it.
+Hopefully, this gives you a general idea of what metadata is.
 Let’s now take a look at how metadata is used in SharePoint Online.
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of photo information on iPhone" src="/uploads/202504d-sharepoint-migration-part2-1.png" width="500px" transform-images="avif webp png jpeg 500@2">
 </figure>
 
-## 2. What is Metadata in SharePoint Online? 
-In SharePoint Online, metadata refers to the "tags" or supplementary information attached to files and list items within sites, libraries, or lists. 
+## 2. What is Metadata in SharePoint Online?
+In SharePoint Online, metadata refers to the "tags" or supplementary information attached to files and list items within sites, libraries, or lists.
 
 It allows users to easily organize, categorize, and search for content. Key steps include:
 
-* Creating custom columns (e.g., project name, date, category) 
-* Setting up views to sort and filter by specific conditions 
+* Creating custom columns (e.g., project name, date, category)
+* Setting up views to sort and filter by specific conditions
 * Tagging existing files with metadata to improve searchability
 
-Example: Document Management for Proposals and Contracts 
-On a traditional file server, folders are usually organized hierarchically like: 
-Year > Department > Project > Contract 
+Example: Document Management for Proposals and Contracts
+On a traditional file server, folders are usually organized hierarchically like:
+Year > Department > Project > Contract
 But in SharePoint Online, metadata makes file searching much easier and more dynamic.
 
 <figure class="flex flex-col justify-start items-left">
@@ -69,15 +69,15 @@ But in SharePoint Online, metadata makes file searching much easier and more dyn
 
 {{- comp.icon({ name: "lightbulb", size: 4, color: "yellow" }) -}}**Key Metadata Fields and Their Benefits:**
 
-**Category**: Labels like "Proposal," "Contract," or "Report" are color-coded and easy to identify. 
-**File Name**: Using a naming convention is recommended. 
-**Client**: No need for folders—files can be sorted by client using metadata. 
-**Owner/Department**: Responsibility is clearly visible based on who owns the document. 
-**Contract Status**: You can see progress at a glance via status indicators. 
-**Due Date**: Helps clarify timelines and enables filtering by schedule. 
+**Category**: Labels like "Proposal," "Contract," or "Report" are color-coded and easy to identify.
+**File Name**: Using a naming convention is recommended.
+**Client**: No need for folders—files can be sorted by client using metadata.
+**Owner/Department**: Responsibility is clearly visible based on who owns the document.
+**Contract Status**: You can see progress at a glance via status indicators.
+**Due Date**: Helps clarify timelines and enables filtering by schedule.
 
-## 3. Why Use Metadata Management? 
-Let’s compare traditional folder management with metadata management to better understand the advantages: 
+## 3. Why Use Metadata Management?
+Let’s compare traditional folder management with metadata management to better understand the advantages:
 <table class="not-prose w-full text-sm">
   <thead>
     <tr class="bg-blue-100">
@@ -110,15 +110,15 @@ Let’s compare traditional folder management with metadata management to better
   </tbody>
 </table>
 
-{{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**Searchability**: Instead of opening folders one by one, you can instantly locate files using metadata keywords. 
-{{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**Access Control**: Dividing libraries based on metadata (like departments or confidentiality) helps streamline permissions. 
-{{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**URL Length**: Flat structures prevent long URLs and potential errors. 
-{{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**Collaboration**: Metadata enables cross-functional sharing by classifying content by department, project, or document type. 
+{{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**Searchability**: Instead of opening folders one by one, you can instantly locate files using metadata keywords.
+{{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**Access Control**: Dividing libraries based on metadata (like departments or confidentiality) helps streamline permissions.
+{{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**URL Length**: Flat structures prevent long URLs and potential errors.
+{{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**Collaboration**: Metadata enables cross-functional sharing by classifying content by department, project, or document type.
 
-While metadata brings major improvements, switching away from traditional folder habits can be challenging. 
+While metadata brings major improvements, switching away from traditional folder habits can be challenging.
 To make the most of SharePoint Online, we recommend rethinking your current workflows.
 
-{{- comp.icon({ name: "push-pin", size: 4, color: "black" }) -}}**Traditional vs. Recommended Management in SPO** 
+{{- comp.icon({ name: "push-pin", size: 4, color: "black" }) -}}**Traditional vs. Recommended Management in SPO**
 
 <table class="not-prose w-full text-sm">
   <thead>
@@ -129,15 +129,15 @@ To make the most of SharePoint Online, we recommend rethinking your current work
   </thead>
   <tbody>
     <tr>
-      <td>Create foldfers per project</td>
-      <td>Use a custum "Project Name" column</td>
+      <td>Create folders per project</td>
+      <td>Use a custom "Project Name" column</td>
     </tr>
     <tr>
       <td>Create folders per year</td>
-      <td>Add a "Year" colum and filter</td>
+      <td>Add a "Year" column and filter</td>
     </tr>
     <tr>
-      <td>Create folders per pearson</td>
+      <td>Create folders per person</td>
       <td>Add an "Owner" column and manage via views</td>
     </tr>
   </tbody>
@@ -145,11 +145,11 @@ To make the most of SharePoint Online, we recommend rethinking your current work
 
 {{- comp.icon({ name: "arrow-fat-right", size: 4, color: "black" }) -}}**Reducing folder dependency and managing files with metadata adds flexibility to your operations!**
 
-## 4. Conclusion 
-By adopting metadata management, you can free yourself from rigid folder structures and move toward more flexible, modern file organization. 
+## 4. Conclusion
+By adopting metadata management, you can free yourself from rigid folder structures and move toward more flexible, modern file organization.
 
-With metadata, you can leverage powerful search and customized views, unlocking the full potential of SharePoint Online. 
+With metadata, you can leverage powerful search and customized views, unlocking the full potential of SharePoint Online.
 
-That said, changing long-standing habits isn't easy. Rather than overhauling everything at once, consider starting small—for example, create a new library for a current project and test out metadata-based management. 
+That said, changing long-standing habits isn't easy. Rather than overhauling everything at once, consider starting small—for example, create a new library for a current project and test out metadata-based management.
 
 Let’s take the first step together toward a **"new way of file management"** that doesn’t rely on folders!

--- a/src/posts/20250723-practical-ai-for-everyday-life-how-i-use-chatgpt-en.md
+++ b/src/posts/20250723-practical-ai-for-everyday-life-how-i-use-chatgpt-en.md
@@ -9,7 +9,7 @@ last_modified: 2025-07-23T09:33:00.000Z
 title: 'Practical AI for Everyday Life: How I Use ChatGPT'
 description: >-
   ChatGPT is a tool that can be used in a wide range of situations. I’d like to
-  share some of the ways I personally use it. 
+  share some of the ways I personally use it.
 image: /uploads/202504a-everyday-ai-en.jpeg
 image_top: /uploads/202504a-everyday-ai.jpeg
 author: KC
@@ -23,46 +23,46 @@ tags:
 comments: {}
 oldUrl: []
 ---
-Now that AI has become a familiar part of our lives, many people may be wondering, 
-"What can ChatGPT actually do?" ChatGPT is a tool that can be used in a wide range of situations—everyday life, learning, and work. Here, I’d like to share some of the ways I personally use it. 
+Now that AI has become a familiar part of our lives, many people may be wondering,
+"What can ChatGPT actually do?" ChatGPT is a tool that can be used in a wide range of situations—everyday life, learning, and work. Here, I’d like to share some of the ways I personally use it.
 
 <!--more-->
 
-## 1. As a Quick Question Solver 
-One of the most basic uses is asking questions or looking up small bits of information. 
-For example, things like “When is the tax filing deadline?” or even getting help proofreading a business email. 
+## 1. As a Quick Question Solver
+One of the most basic uses is asking questions or looking up small bits of information.
+For example, things like “When is the tax filing deadline?” or even getting help proofreading a business email.
 Compared to using a dictionary or doing a full web search, it’s faster and less affected by distracting ads.
 
 **How I use it:**
-* Asking for softer wording for phrases like “No need to reply.” 
-* Proofreading long emails 
+* Asking for softer wording for phrases like “No need to reply.”
+* Proofreading long emails
 {{- comp.icon({ name: "warning-diamond", size: 4, color: "amber" }) -}}**Things to keep in mind:**
 * The information might not always be accurate, so double-check when needed.
 * Sometimes the output feels too “AI-like,” so I try to add my own touch to keep it natural.
 
-## 2. As a Study Buddy for Exams 
-ChatGPT is also a great partner for anyone studying for certifications. 
-For example, you can ask it things like “Give me practice questions for the IT Passport exam” or “Tell me the key points for the FP Level 3 test.” 
-You can even customize how you study—Q&A format, quizzes, or summaries—to match your mood or learning style. 
+## 2. As a Study Buddy for Exams
+ChatGPT is also a great partner for anyone studying for certifications.
+For example, you can ask it things like “Give me practice questions for the IT Passport exam” or “Tell me the key points for the FP Level 3 test.”
+You can even customize how you study—Q&A format, quizzes, or summaries—to match your mood or learning style.
 
 **How I use it:**
 * Getting 5 practice questions a day for an upcoming certification
  {{- comp.icon({ name: "warning-diamond", size: 4, color: "amber" }) -}}**Things to keep in mind:**
 * Make sure to confirm the accuracy and scope of the content yourself
   
-## 3. For Language Learning 
-ChatGPT is also useful for language learning—especially English. 
-It can help you practice daily conversation, correct your sentences, or give you example phrases for new vocabulary. 
+## 3. For Language Learning
+ChatGPT is also useful for language learning—especially English.
+It can help you practice daily conversation, correct your sentences, or give you example phrases for new vocabulary.
 If talking to people feels intimidating, it’s a great way to practice at your own pace.
 
 **How I use it:**
 * Not yet—but I’d love to try it in the future!
 
 ## 4. For Dieting and Lifestyle Improvements
-ChatGPT can help you with health goals like dieting, too. 
-If you provide your height, weight, eating habits, and activity level, it can create a realistic plan or suggest weekly meal ideas. 
-What’s nice is, it praises you even for small efforts and encourages you without judgment—even if you slip up. 
-It’s perfect for people who have trouble staying motivated (like me, haha). 
+ChatGPT can help you with health goals like dieting, too.
+If you provide your height, weight, eating habits, and activity level, it can create a realistic plan or suggest weekly meal ideas.
+What’s nice is, it praises you even for small efforts and encourages you without judgment—even if you slip up.
+It’s perfect for people who have trouble staying motivated (like me, haha).
 
 **How I use it:**
 * I told it my height, weight, and goals, and shared my weekly schedule to get meal and workout suggestions
@@ -71,9 +71,9 @@ It’s perfect for people who have trouble staying motivated (like me, haha).
 * If you give too much info at once, it can get confused—keep it organized
 * If something sounds off, don’t hesitate to correct it
 
-## 5. As a Conversation Partner 
-One surprising but helpful use is simply talking to ChatGPT. 
-It responds with emotional understanding, so it’s great for sorting out your thoughts when you’re feeling stuck. 
+## 5. As a Conversation Partner
+One surprising but helpful use is simply talking to ChatGPT.
+It responds with emotional understanding, so it’s great for sorting out your thoughts when you’re feeling stuck.
 
 **How I use it:**
 * Sharing worries or frustrations—things I might hesitate to tell a real person
@@ -83,10 +83,10 @@ It responds with emotional understanding, so it’s great for sorting out your t
 * It’s easy to feel good when you’re being validated, but don’t get too dependent
 * For venting, try asking for a neutral perspective—it might help you see things more clearly
 
-## Summary 
-ChatGPT is a versatile AI tool that adapts to your needs—whether you’re studying, organizing your life, or just chatting. 
-There’s no single “right” way to use it. The key is figuring out what works best for you. 
+## Summary
+ChatGPT is a versatile AI tool that adapts to your needs—whether you’re studying, organizing your life, or just chatting.
+There’s no single “right” way to use it. The key is figuring out what works best for you.
 
-By the way, the main structure of this article was also drafted by ChatGPT! 
-I just added my personal examples and gave it my own twist. 
+By the way, the main structure of this article was also drafted by ChatGPT!
+I just added my personal examples and gave it my own twist.
 I hope this gives you some inspiration on how to use it, too.

--- a/src/posts/20250730-3-easy-ways-to-take-a-screenshot-instantly-en.md
+++ b/src/posts/20250730-3-easy-ways-to-take-a-screenshot-instantly-en.md
@@ -24,19 +24,19 @@ tags:
 comments: {}
 oldUrl: []
 ---
-"All I wanted was to show part of my screen, but I fumbled with the tools again. Have you ever had that moment? Taking screenshots is one of the most common tasks in the workplace, but the best method actually depends on your purpose. Here, we compare 3 useful screenshot methods on Windows and explain when each one shines. 
+"All I wanted was to show part of my screen, but I fumbled with the tools again." Have you ever had that moment? Taking screenshots is one of the most common tasks in the workplace, but the best method actually depends on your purpose. Here, we compare 3 useful screenshot methods on Windows and explain when each one shines.
 
 <!--more-->
 
-## 1. Snipping Tool – Best for clean captures and annotations 
-**Ideal for:** 
-* Creating manuals or presentation materials 
+## 1. Snipping Tool – Best for clean captures and annotations
+**Ideal for:**
+* Creating manuals or presentation materials
 * Adding annotations like highlights and notes
 
-**How to use:** 
-1. Open "Snipping Tool" from the Start menu 
-2. Click "New" and select the area you want to capture 
-3. The image opens in an editor automatically 
+**How to use:**
+1. Open "Snipping Tool" from the Start menu
+2. Click "New" and select the area you want to capture
+3. The image opens in an editor automatically
 4. You can copy, save, or share from there
 
 <figure class="flex flex-col justify-start items-left">
@@ -46,20 +46,20 @@ oldUrl: []
   <img alt="Screenshot of Snipping tool" src="/uploads/202504b-screenshot-instantly2.png"  width="300px" transform-images="avif webp png jpeg 300@2">
 </figure>
 
-**Personal Note:** 
-I often use this tool when I need a clean capture with comments. 
-Its intuitive interface makes editing and saving images quick and easy. 
+**Personal Note:**
+I often use this tool when I need a clean capture with comments.
+Its intuitive interface makes editing and saving images quick and easy.
 
-## 2. Win + Shift + S – Fast and flexible partial capture 
+## 2. Win + Shift + S – Fast and flexible partial capture
 
-**Ideal for:** 
-* Quickly sending screenshots in chat or email 
+**Ideal for:**
+* Quickly sending screenshots in chat or email
 * Highlighting only a portion of the screen
 
-**How to use:** 
-1. Press "Windows key + Shift + S" 
-2. The screen dims and the cursor becomes a crosshair 
-3. Drag to select the area – it's instantly copied to clipboard 
+**How to use:**
+1. Press "Windows key + Shift + S"
+2. The screen dims and the cursor becomes a crosshair
+3. Drag to select the area – it's instantly copied to clipboard
 4. Use "Ctrl + V" to paste wherever you need
 
 <figure class="flex flex-col justify-start items-left">
@@ -69,40 +69,40 @@ Its intuitive interface makes editing and saving images quick and easy.
   <img alt="Screenshot of Snip and Sketch" src="/uploads/202504b-screenshot-instantly4.png"  width="300px" transform-images="avif webp png jpeg 300@2">
 </figure>
 
-**Personal Note:** 
-Since I discovered this shortcut, I rarely use the Snipping Tool anymore. 
-What I love is that a thumbnail appears in the corner after the screenshot – click it, and you're instantly in edit mode where you can highlight or draw on it. 
-It saves time and makes explanations so much clearer. 
+**Personal Note:**
+Since I discovered this shortcut, I rarely use the Snipping Tool anymore.
+What I love is that a thumbnail appears in the corner after the screenshot – click it, and you're instantly in edit mode where you can highlight or draw on it.
+It saves time and makes explanations so much clearer.
 
-## 3. PrintScreen Key – Capture the entire screen at once 
+## 3. PrintScreen Key – Capture the entire screen at once
 
-**Ideal for:** 
-* Recording your full screen quickly 
+**Ideal for:**
+* Recording your full screen quickly
 * Sharing exactly what you see
 
-**How to use:** 
-1. Press the "PrintScreen" key (usually on the upper right of your keyboard) 
-2. The entire screen is copied to your clipboard 
-3. Paste it into Word, Paint, etc., using "Ctrl + V" 
+**How to use:**
+1. Press the "PrintScreen" key (usually on the upper right of your keyboard)
+2. The entire screen is copied to your clipboard
+3. Paste it into Word, Paint, etc., using "Ctrl + V"
 4. Save it if needed
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of full screen" src="/uploads/202504b-screenshot-instantly5.png"  width="500px" transform-images="avif webp png jpeg 500@2">
 </figure>
 
-**Personal Note:** 
-Still the simplest way to capture everything. 
+**Personal Note:**
+Still the simplest way to capture everything.
 But you’ll often need to crop it afterward if you only want part of the image.
 
-## Bonus: Use "Win + V" to access clipboard history 
-If you’ve taken multiple screenshots and want to reuse a previous one, press "Win + V" to open clipboard history. 
-This little-known feature lets you manage and reuse recent screenshots with ease. 
+## Bonus: Use "Win + V" to access clipboard history
+If you’ve taken multiple screenshots and want to reuse a previous one, press "Win + V" to open clipboard history.
+This little-known feature lets you manage and reuse recent screenshots with ease.
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of Clip board" src="/uploads/202504b-screenshot-instantly6.png"  width="500px" transform-images="avif webp png jpeg 500@2">
 </figure>
 
-## Summary 
+## Summary
 <table class="not-prose w-full text-sm">
   <thead>
     <tr>
@@ -120,7 +120,7 @@ This little-known feature lets you manage and reuse recent screenshots with ease
       <td>◎</td>
     </tr>
     <tr>
-      <td><kbd>Win</kbd> + <kbd>Win</kbd>+ <kbd>S</kbd></td>
+      <td><kbd>Win</kbd> + <kbd>Shift</kbd>+ <kbd>S</kbd></td>
       <td>Quick sharing</td>
       <td>◎</td>
       <td>〇</td>
@@ -134,7 +134,7 @@ This little-known feature lets you manage and reuse recent screenshots with ease
   </tbody>
 </table>
 
-Try out each method once and pick the one that feels most comfortable for you. 
-Once you've got the hang of it, sharing screenshots becomes quick and easy. 
-**Personally, I rely on “Win + Shift + S” – it’s fast, intuitive, and super handy.** 
+Try out each method once and pick the one that feels most comfortable for you.
+Once you've got the hang of it, sharing screenshots becomes quick and easy.
+**Personally, I rely on “Win + Shift + S” – it’s fast, intuitive, and super handy.**
 Give it a try and see which one works best for you!

--- a/src/posts/20250806-receive-teams-call-with-cisco-ip-communicator-en.md
+++ b/src/posts/20250806-receive-teams-call-with-cisco-ip-communicator-en.md
@@ -19,31 +19,31 @@ tags:
 comments: {}
 oldUrl: []
 ---
-Some of the companies use MS Teams as an internal chat tool while using a softphone application to receive external phone calls. Here is the quick tip for solving the problem where we cannot join MS Teams meetings while using Cisco IP Communicator due to a functional conflict. 
+Some companies use MS Teams as an internal chat tool while using a softphone application to receive external phone calls. Here is a quick tip for solving the problem where we cannot join MS Teams meetings while using Cisco IP Communicator due to a functional conflict.
 
 <!--more-->
 
 ## 1. About the issue
 
-**Requirements:** 
-Both MS Teams and Cisco IP Communicator app are running on Windows PC (including running in the background). 
+**Requirements:**
+Both MS Teams and Cisco IP Communicator app are running on a Windows PC (including running in the background).
 
-**Trouble:** 
-When you try to join a meeting in MS Teams, the handset of the Cisco IP Communicator app is automatically turned on and the user leaves from the Teams meeting. 
+**Trouble:**
+When you try to join a meeting in MS Teams, the handset of the Cisco IP Communicator app is automatically turned on and the user leaves the Teams meeting.
 
-## 2. Solution 
-From MS Teams setting menu, **turn off** the **Sync Devices button**. 
+## 2. Solution
+From the MS Teams settings menu, **turn off** the **Sync Devices button**.
 
-**Steps:** 
-A. Open MS Teams app. In the upper right corner of MS Teams, select “Settings” from the three dots button. 
+**Steps:**
+A. Open MS Teams app. In the upper right corner of MS Teams, select “Settings” from the three dots button.
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of setting button in Teams" src="/uploads/202504c-cisco-ip-communicator-problem1.png" width="400px" transform-images="avif webp png jpeg 00@2">
 </figure>
 
-B. Select “Devices” from the Settings menu and turn off the “Sync button for devices” in the Audio item 
+B. Select “Devices” from the Settings menu and turn off the “Sync button for devices” in the Audio item
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of setting button in Teams" src="/uploads/202504c-cisco-ip-communicator-problem2-en.png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
-## 3. Summary 
+## 3. Summary
 The “device sync button” is a feature that allows a physical button on the external device like a headset to start Teams calls. Cisco IP Communicator app seems to conflict with this functionality. But turning it off seems to resolve the above issue by desyncing.

--- a/src/posts/20250822-what-is-microsoft-copilot-en.md
+++ b/src/posts/20250822-what-is-microsoft-copilot-en.md
@@ -23,19 +23,19 @@ tags:
   - AI-at-Work
 comments: {}
 ---
-In recent years, various types of generative AI have evolved and are attracting attention from the public. This time, we will introduce basic information about **Microsoft Copilot**, a generative AI tool developed by Microsoft, its fee structure, how to use the free version, and examples of how to use it. 
+In recent years, various types of generative AI have evolved and are attracting attention from the public. This time, we will introduce basic information about **Microsoft Copilot**, a generative AI tool developed by Microsoft, its fee structure, how to use the free version, and examples of how to use it.
 
 <!--more-->
 
-## Basic introduction to Microsoft Copilot 
-Microsoft Copilot can search for information and generate documents and images using AI, and the paid version can create emails and Word documents, reducing the workload. 
+## Basic introduction to Microsoft Copilot
+Microsoft Copilot can search for information and generate documents and images using AI, and the paid version can create emails and Word documents, reducing the workload.
 
-* Real-time information search and document generation: It can also handle ambiguous questions, generate answers based on search results from Microsoft's search engine "Bing," and create documents such as emails and letters. 
-* Image generation: It is possible to generate images from text, check the contents of images, and provide information. 
-* Q&A through voice conversation: It is possible to input voice, generate answers by voice, and transcribe and translate audio files. 
+* Real-time information search and document generation: It can also handle ambiguous questions, generate answers based on search results from Microsoft's search engine "Bing," and create documents such as emails and letters.
+* Image generation: It is possible to generate images from text, check the contents of images, and provide information.
+* Q&A through voice conversation: It is possible to input voice, generate answers by voice, and transcribe and translate audio files.
 * (Paid version) Integration with Microsoft 365: It can be integrated with Microsoft 365 apps such as Word, Excel, PowerPoint, and Outlook to make work more efficient.
 
-## Pricing system 
+## Pricing system
 The differences between the free and paid versions are summarized below. The free version is suitable for use as an AI assistant that you can try out casually, while the paid version is suitable for those who want to integrate with Microsoft 365 and use advanced functions. We recommend that you choose the version that best suits your purpose and the functions you need.
 
 <table class="not-prose w-full text-sm">
@@ -72,7 +72,7 @@ The differences between the free and paid versions are summarized below. The fre
         ・Paid plan for corporate customers<br>
         ・Copilot can be used in Word、Excel、PowerPoint、OneNote、Outlook、Microsoft Teams<br>
         ・Possibility to utilize in-house data<br>
-        ・Corporate data protection, etc. 
+        ・Corporate data protection, etc.
       </td>
     </tr>
 　　<tr>
@@ -90,86 +90,86 @@ The differences between the free and paid versions are summarized below. The fre
   </tbody>
 </table>
 
-Please note that in order to use Microsoft 365 Copilot, you will first need to sign up for Microsoft 365 for business. 
+Please note that in order to use Microsoft 365 Copilot, you will first need to sign up for Microsoft 365 for business.
 [Prerequisites for users who can use Microsoft 365 Copilot](https://www.microsoft.com/ja-jp/microsoft-365/copilot/business#FAQ){target="_blank" rel="noopener"}
 
 > [!NOTE]
-> To use this service, you will need one of the following licenses: 
-> * Microsoft 365 Apps for enterprise or Microsoft 365 Apps for business 
-> * Microsoft 365 Business Basic, Business Standard, or Business Premium 
-> * Microsoft 365 E3, E5, F1, or F3 
-> * Office 365 E1, E3, E5, or F3 
-> * Exchange Online Kiosk, Plan 1, or Plan 2 
-> * OneDrive for Business Plan 1 or Plan 2 
-> * SharePoint Online Plan 1 or Plan 2 
-> * Teams Essentials or Teams Enterprise 
+> To use this service, you will need one of the following licenses:
+> * Microsoft 365 Apps for enterprise or Microsoft 365 Apps for business
+> * Microsoft 365 Business Basic, Business Standard, or Business Premium
+> * Microsoft 365 E3, E5, F1, or F3
+> * Office 365 E1, E3, E5, or F3
+> * Exchange Online Kiosk, Plan 1, or Plan 2
+> * OneDrive for Business Plan 1 or Plan 2
+> * SharePoint Online Plan 1 or Plan 2
+> * Teams Essentials or Teams Enterprise
 > * Versions of these plans that do not include Teams
 
-## Basic usage of Copilot (free version) 
+## Basic usage of Copilot (free version)
 
-**1. Web version of Microsoft Copilot (for personal users):** 
-The main functions are web search, text generation, and image generation. It is available when you access<a href="https://www.microsoft.com/ja-jp/microsoft-copilot/for-individuals?form=MA13YT" target="_blank" rel="noopener">Microsoft Copilot</a>
+**1. Web version of Microsoft Copilot (for personal users):**
+The main functions are web search, text generation, and image generation. It is available when you access <a href="https://www.microsoft.com/ja-jp/microsoft-copilot/for-individuals?form=MA13YT" target="_blank" rel="noopener">Microsoft Copilot</a>
 
 **2. Copilot in Edge (for individual users):**
-The main features are browser integration and the ability to save and share answers. 
-When you open the Edge browser, you will see the Copilot mark in the top right corner of the browser. If you click on that mark, a "Chat" window will appear on the right side of the browser, and you can start a conversation with Copilot. 
+The main features are browser integration and the ability to save and share answers.
+When you open the Edge browser, you will see the Copilot mark in the top right corner of the browser. If you click on that mark, a "Chat" window will appear on the right side of the browser, and you can start a conversation with Copilot.
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="Screenshot of MS Copilot in Edge" src="/uploads/202504e-what-is-copilot1-en.png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
-**3. Copilot in Windows (for individual users):** 
-The main features are Windows integration, information search, task assistance, etc. Copilot in Windows is the standard Copilot for Windows 11. The Copilot mark is automatically displayed on the taskbar, and you can start a conversation with Copilot by clicking on the mark. 
+**3. Copilot in Windows (for individual users):**
+The main features are Windows integration, information search, task assistance, etc. Copilot in Windows is the standard Copilot for Windows 11. The Copilot mark is automatically displayed on the taskbar, and you can start a conversation with Copilot by clicking on the mark.
 If you cannot find it on the taskbar, enter "Copilot" in the search box and the Copilot app will be displayed, so you can click on it to use it.
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="Screenshot of MS Copilot in Edge" src="/uploads/202504e-what-is-copilot2-en.png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
-**4. Use the dedicated app on your smartphone:** 
+**4. Use the dedicated app on your smartphone:**
 There are <a href="https://www.microsoft.com/ja-jp/microsoft-copilot/for-individuals/copilot-app?form=MA13M1&OCID=MA13M1" target="_blank" rel="noopener">iOS and Android versions</a> of the Copilot app, so you can use it by downloading it to your smartphone. When you open the Copilot app, you can type a message or click the microphone button to talk to Copilot.
 
-## Examples of how to use Copilot 
-### 1.Details of Copilot Prompts
-**Basics of prompts:** A prompt is a question to the generation AI. According to the Microsoft official website (details of Copilot prompts<a href="https://support.microsoft.com/ja-jp/topic/copilot-%E3%83%97%E3%83%AD%E3%83%B3%E3%83%97%E3%83%88%E3%81%AE%E8%A9%B3%E7%B4%B0-f6c3b467-f07c-4db1-ae54-ffac96184dd5" target="_blank" rel="noopener">details of Copilot prompts</a>), you should create a question that combines the four elements of "goal + context + expectation + source." 
+## Examples of how to use Copilot
+### 1. Details of Copilot Prompts
+**Basics of prompts:** A prompt is a question to the generative AI. According to the official Microsoft website (details of Copilot prompts<a href="https://support.microsoft.com/ja-jp/topic/copilot-%E3%83%97%E3%83%AD%E3%83%B3%E3%83%97%E3%83%88%E3%81%AE%E8%A9%B3%E7%B4%B0-f6c3b467-f07c-4db1-ae54-ffac96184dd5" target="_blank" rel="noopener">details of Copilot prompts</a>), you should create a question that combines the four elements of "goal + context + expectation + source."
 
-**Goal**: What a user wants Copilot to do. Setting a specific goal will allow Copilot to tackle the task without hesitation. 
-Example: A question like "Please conduct market research on XX and perform a comparative analysis with competitors A, B, and C" is more specific than a question like "Please conduct market research on XX." 
+**Goal**: What a user wants Copilot to do. Setting a specific goal will allow Copilot to tackle the task without hesitation.
+Example: A question like "Please conduct market research on XX and perform a comparative analysis with competitors A, B, and C" is more specific than a question like "Please conduct market research on XX."
 
 **Context:** Prerequisite information (such as the reason for the need). The user provides the background information Copilot needs to carry out the task.
 Example: "Make a trip plan" is unlikely to give the users the answer they are looking for. If a question is asked like "When, who, where, budget XX yen, XX days, XX nights, staying at XX hotel," Copilot will be able to grasp more accurate information and provide an answer based on the information the user is looking for.
 
-**Expectation**: The form of the desired output. By telling Copilot “In what format you want the answer to be," you can use the information more efficiently. 
-Example: "Please narrow down the report to three main points in bullet points." 
-Example: "Please create this travel plan for children." 
+**Expectation**: The form of the desired output. By telling Copilot “In what format you want the answer to be," you can use the information more efficiently.
+Example: "Please narrow down the report to three main points in bullet points."
+Example: "Please create this travel plan for children."
 
-**Source**: What information will be used in Copilot. By specifying the information to be referenced by Copilot, you can increase the reliability of the information and eliminate unintended information. 
-Example: "Please explain about XX based on the information published in (website URL)." 
-Example: "Please summarize XX based on the contents of this [file name]." 
+**Source**: What information will be used in Copilot. By specifying the information to be referenced by Copilot, you can increase the reliability of the information and eliminate unintended information.
+Example: "Please explain about XX based on the information published in (website URL)."
+Example: "Please summarize XX based on the contents of this [file name]."
 
-It is not necessarily necessary to enter all four elements, but you will get a clearer answer if you include one of them. In addition, if you are not satisfied with the first answer and modify the prompt while interacting with Copilot, you can obtain a more accurate output. 
+It is not always necessary to enter all four elements, but you will get a clearer answer if you include one of them. In addition, if you are not satisfied with the first answer and modify the prompt while interacting with Copilot, you can obtain a more accurate output.
 
 For example, in our blog post ["UTP cable? Cat cable? RJ45 connector? Admin staff asked AI about IT terms they were curious about,"](https://blog.esolia.pro/en/posts/20250410-admin-asked-ai-about-the-it-terminology-en/){target="_blank" rel="noopener"} the first prompt was "What is a UTP cable?", and the next prompt was "What are UTP cable, Cat cable, and RJ45 connector? Please explain it in an easy-to-understand way for people without IT knowledge."  
-In this way, by clarifying ambiguous parts and changing your perspective, you can convey your request to Copilot multiple times and arrive at the answer your users are looking for. 
+In this way, by clarifying ambiguous parts and changing your perspective, you can convey your request to Copilot multiple times and arrive at the answer your users are looking for.
 
-In addition, to avoid the risk of information leakage, please be careful not to include important information such as highly confidential information or personal information in the prompts of generation AI including Copilot.
+In addition, to avoid the risk of information leakage, please be careful not to include important information such as highly confidential information or personal information in the prompts of generative AI including Copilot.
 
 > [!CAUTION]
-> Points to note: 
+> Points to note:
 > ・Limit on the amount of information: Copilot has a limit on the amount of information it can process at one time, so avoid directly inputting long prompts or large files.
 > ・Total number of chats per day: Up to 300 times/day (unlimited with paid version)
 > ・Number of chats per session: Up to 30 turns
 > ・Maximum size of reference files: 10MB with Microsoft 365 license, up to 2GB/day of total uploads.
 
 ### 2. "Edit in Pages" feature of Microsoft 365 Copilot Chat:  
-Entra account users with the following licenses can use Microsoft 365 Copilot Chat. 
- <a href="https://learn.microsoft.com/ja-jp/copilot/manage#microsoft-365--chat-eligibility" target="_blank" rel="noopener">Microsoft 365 Copilot Chat Eligibility</a> 
+Entra account users with the following licenses can use Microsoft 365 Copilot Chat.
+ <a href="https://learn.microsoft.com/ja-jp/copilot/manage#microsoft-365--chat-eligibility" target="_blank" rel="noopener">Microsoft 365 Copilot Chat Eligibility</a>
 
 **Open chat**
-When you click "Try Copilot Chat" from the Microsoft 365 Copilot website, the Copilot Chat screen will be displayed in a new window. 
+When you click "Try Copilot Chat" from the Microsoft 365 Copilot website, the Copilot Chat screen will be displayed in a new window.
 
-Alternatively, open Edge and see the Copilot365 mark on the right side of the search bar. Click on that mark and the Copilot Chat window will appear. 
+Alternatively, open Edge and see the Copilot365 mark on the right side of the search bar. Click on that mark and the Copilot Chat window will appear.
 
 **Edit in Pages**
-Copilot Chat has a feature called “Edit in Pages.” Clicking this button will generate the searched content as a page, which will be displayed on the right side of the screen. The user can then edit it themselves (including formatting and styling) or share it with others. 
+Copilot Chat has a feature called “Edit in Pages.” Clicking this button will generate the searched content as a page, which will be displayed on the right side of the screen. The user can then edit it themselves (including formatting and styling) or share it with others.
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="Screenshot of MS Copilot in Edge" src="/uploads/202504e-what-is-copilot3-en.png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
@@ -177,26 +177,26 @@ Copilot Chat has a feature called “Edit in Pages.” Clicking this button will
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="Screenshot of MS Copilot in Edge" src="/uploads/202504e-what-is-copilot4-en.png" width="1000px" transform-images="avif webp png jpeg 1000@2">
 </figure>
-Click the drop-down button to the right of the "Edit in Pages" button and you'll see an option to "Add to Recent Pages." Click this button if you want to add the content you searched for to a page you've created in the past. 
+Click the drop-down button to the right of the "Edit in Pages" button and you'll see an option to "Add to Recent Pages." Click this button if you want to add the content you searched for to a page you've created in the past.
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="Screenshot of MS Copilot in Edge" src="/uploads/202504e-what-is-copilot5-en.png" width="800px" transform-images="avif webp png jpeg 800@2">
 </figure>
-For example, you might want to use this feature when you want to combine content on similar topics into one page. 
+For example, you might want to use this feature when you want to combine content on similar topics into one page.
 
-The generated page will also be automatically added to your Loop “My Workspace”. You can share and collaborate on pages added to Loop with your team
+The generated page will also be automatically added to your Loop “My Workspace”. You can share and collaborate on pages added to Loop with your team.
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="Screenshot of Loop page" src="/uploads/202504e-what-is-copilot6-en.png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
-### 3. Examples of features available for each application in the paid version: 
+### 3. Examples of features available for each application in the paid version:
 
 Word<a href="https://support.microsoft.com/ja-jp/copilot-word" rel="noopener">(Copilot in Word)</a>: taking minutes, creating proposals, etc.
 Excel<a href="https://support.microsoft.com/ja-JP/copilot-excel?" rel="noopener">(Copilot in Excel)</a>: automatic tabulation, chart generation, etc.
 PowerPoint<a href="https://support.microsoft.com/ja-jp/copilot-powerpoint" rel="noopener">(Copilot in PowerPoint)</a>: automatically generate data-based documents, etc.  
-Outlook<a href="https://support.microsoft.com/ja-jp/copilot-outlook" rel="noopener">(Copilot in Outlook)</a>: organize email, create drafts, summarize thread content, etc. 
-OneNote<a href="https://support.microsoft.com/ja-jp/copilot-onenote" rel="noopener">(Copilot in OneNote)</a>: summarize notes, suggest ideas, etc. 
+Outlook<a href="https://support.microsoft.com/ja-jp/copilot-outlook" rel="noopener">(Copilot in Outlook)</a>: organize email, create drafts, summarize thread content, etc.
+OneNote<a href="https://support.microsoft.com/ja-jp/copilot-onenote" rel="noopener">(Copilot in OneNote)</a>: summarize notes, suggest ideas, etc.
 Teams<a href="https://support.microsoft.com/ja-jp/copilot-teams" rel="noopener">(Copilot in Teams)</a>: take meeting minutes, organize key points, etc.
-Loop<a href="https://support.microsoft.com/ja-jp/copilot-loop" rel="noopener">(Copilot in Loop)</a>: summarize pages, paste into PowerPoint, etc. 
+Loop<a href="https://support.microsoft.com/ja-jp/copilot-loop" rel="noopener">(Copilot in Loop)</a>: summarize pages, paste into PowerPoint, etc.
 
-Above is an introduction to Copilot. If you haven't used Copilot yet, please give it a try. 
+Above is an introduction to Copilot. If you haven't used Copilot yet, please give it a try.
 However, Copilot is only intended to support users as a tool to enhance creativity and productivity, so be careful not to rely on it too much. Users must judge and reconfirm the authenticity of the information and the originality of the text. Don't just rely on the information provided; be sure to check and make your own judgments.

--- a/src/posts/20250910-proactive-telework-2025-en.md
+++ b/src/posts/20250910-proactive-telework-2025-en.md
@@ -19,51 +19,51 @@ category: Cloud
 tags: []
 comments: {}
 ---
-In my 2018 blog post[**Telework Offensive,**](https://blog.esolia.pro/en/posts/20180416-telework-offensive_en/){target="_blank" rel="noopener"} I shared thoughts on the potential of flexible work styles. At the time, the idea of large-scale telework seemed distant—long before the world was struck by the COVID-19 pandemic in 2020. 
+In my 2018 blog post [**Telework Offensive,**](https://blog.esolia.pro/en/posts/20180416-telework-offensive_en/){target="_blank" rel="noopener"} I shared thoughts on the potential of flexible work styles. At the time, the idea of large-scale telework seemed distant—long before the world was struck by the COVID-19 pandemic in 2020.
 
 <!--more-->
 
 ## Introduction
-Fast forward to 2025. Much has changed. Back then, our company had not yet implemented a telework system, but I personally believed in hybrid work and advocated for it both inside and outside the company. My motivation was simple: I wanted to make better use of my limited time and ease the burden of daily life. 
+Fast forward to 2025. Much has changed. Back then, our company had not yet implemented a telework system, but I personally believed in hybrid work and advocated for it both inside and outside the company. My motivation was simple: I wanted to make better use of my limited time and ease the burden of daily life.
 
-Then came the pandemic. As the government declared a state of emergency, society quickly pivoted to remote work. Thanks to our early efforts in preparing a remote work environment, we were able to smoothly transition to telework without major disruptions. 
+Then came the pandemic. As the government declared a state of emergency, society quickly pivoted to remote work. Thanks to our early efforts in preparing a remote work environment, we were able to smoothly transition to telework without major disruptions.
 
-Today, hybrid work—combining remote and in-office days—has become second nature for most of our team. It's safe to say that for many, a work style without telework is no longer imaginable. 
+Today, hybrid work—combining remote and in-office days—has become second nature for most of our team. It's safe to say that for many, a work style without telework is no longer imaginable.
 
 ## Current State of Telework
-So, what's the current state of Telework in Tokyo? 
-The Tokyo Metropolitan Government regularly surveys 10,000 companies within the city to assess the adoption of telework. 
+So, what's the current state of Telework in Tokyo?
+The Tokyo Metropolitan Government regularly surveys 10,000 companies within the city to assess the adoption of telework.
 
-According to the 2024 survey (FY2024) targeting Tokyo-based companies with 30 or more employees, the telework adoption rate was 58.0%. This marks a slight decrease compared to the previous year's 60.1%. 
+According to the 2024 survey (FY2024) targeting Tokyo-based companies with 30 or more employees, the telework adoption rate was 58.0%. This marks a slight decrease compared to the previous year's 60.1%.
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="Survey Results on Telework Implementation Rate" src="/uploads/202506a-telework-offensive-2025-1.png" width="700px" transform-images="avif webp png jpeg 700@2">
 </figure>
 
 [FY2024 Survey Report on Diverse Work Styles (Telework)](https://www.hataraku.metro.tokyo.lg.jp/hatarakikata/telework/teleworkjixtushirituchousa_4gatu.pdf){target="_blank" rel="noopener"}
 
-In addition, Tokyo conducts monthly surveys to monitor the telework implementation rate among companies with 30 or more employees. Recent trends show a gradual shift back to office-based work, which appears to be contributing to the slight decline. 
+In addition, Tokyo conducts monthly surveys to monitor the telework implementation rate among companies with 30 or more employees. Recent trends show a gradual shift back to office-based work, which appears to be contributing to the slight decline.
 
 ## To "Return to Office" Trend
-With the pandemic easing, many companies—including foreign-owned firms—have begun encouraging employees to return to the office. After several years of remote work becoming the norm, the tide now seems to be turning. 
+With the pandemic easing, many companies—including foreign-owned firms—have begun encouraging employees to return to the office. After several years of remote work becoming the norm, the tide now seems to be turning.
 
 **From a business perspective, the concerns include:**
-1. Rebuilding productivity and creativity 
-2. Challenges with on-the-job training for younger employees 
-3. Difficulties in management and governance (e.g., slacking off, lack of communication) 
-4. Weakened company culture and engagement 
+1. Rebuilding productivity and creativity
+2. Challenges with on-the-job training for younger employees
+3. Difficulties in management and governance (e.g., slacking off, lack of communication)
+4. Weakened company culture and engagement
 5. Pressure to justify investment in office spaces
 
-**From an employee’s perspective, common concerns include:** 
-1. Feelings of isolation and reduced communication 
-2. Difficulty concentrating due to home environment 
+**From an employee’s perspective, common concerns include:**
+1. Feelings of isolation and reduced communication
+2. Difficulty concentrating due to home environment
 3. Lack of visibility leading to fears of unfair evaluations
 
-So, how should we evolve our working styles from here? 
+So, how should we evolve our working styles from here?
 Reflecting on the thoughts I shared back in 2018, I believe now is the perfect time to revisit what telework truly means.
 
 ## Yes, We Still Want to Telework!
-Yes—many people still sincerely want to continue working remotely. 
-Even with challenges and constraints, telework remains desirable because of the significant benefits it offers: 
+Yes—many people still sincerely want to continue working remotely.
+Even with challenges and constraints, telework remains desirable because of the significant benefits it offers:
 
 1. Saving time and mental energy by eliminating commutes
 * Two hours saved each day can be used for self-care or productivity
@@ -79,9 +79,9 @@ Even with challenges and constraints, telework remains desirable because of the 
 * Helps visualize who is doing what, reducing individual workload dependencies
 
 ## In conclusion
-As IT professionals, our role spans a wide range of responsibilities. Through cross-functional communication, we can help solve challenges related to work styles and productivity—one issue at a time. 
+As IT professionals, our role spans a wide range of responsibilities. Through cross-functional communication, we can help solve challenges related to work styles and productivity—one issue at a time.
 
-If you ever have concerns, ideas, or even vague hopes like “Wouldn’t it be nice if…,” don’t hesitate to reach out to your IT team. We’re here not just to fix problems, but to help shape better ways of working—for everyone. 
+If you ever have concerns, ideas, or even vague hopes like “Wouldn’t it be nice if…,” don’t hesitate to reach out to your IT team. We’re here not just to fix problems, but to help shape better ways of working—for everyone.
 
 **Various subsidies and grants**
 [Subsidy for Securing Human Resources (Telework Course) – Ministry of Health, Labor and Welfare (Japan) ](https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/telework_zyosei_R3.html){target="_blank" rel="noopener"}

--- a/src/posts/20251001-how-to-fix-internet-connection-en.md
+++ b/src/posts/20251001-how-to-fix-internet-connection-en.md
@@ -27,88 +27,88 @@ tags:
   - Command Prompt
 comments: {}
 ---
-“It was working fine yesterday... but for some reason, I can't connect to the internet today.” 
-If you work in IT support, you've likely heard this line more times than you can count. 
-Sudden, unexplained network issues are a common headache. 
-This article shares a real-life case in which a laptop suddenly couldn’t connect via Wi-Fi or wired LAN—along with the specific recovery steps that worked in the end. 
+“It was working fine yesterday... but for some reason, I can't connect to the internet today.”
+If you work in IT support, you've likely heard this line more times than you can count.
+Sudden, unexplained network issues are a common headache.
+This article shares a real-life case in which a laptop suddenly couldn’t connect via Wi-Fi or wired LAN—along with the specific recovery steps that worked in the end.
 
 <!--more-->
 
-## The Symptom: No Network Connection at All 
-One day, a laptop used in our office began exhibiting the following symptoms: 
-* Unable to connect via Wi-Fi or wired LAN 
-* No improvement after swapping LAN cables, docking stations, or USB-LAN adapters 
+## The Symptom: No Network Connection at All
+One day, a laptop used in our office began exhibiting the following symptoms:
+* Unable to connect via Wi-Fi or wired LAN
+* No improvement after swapping LAN cables, docking stations, or USB-LAN adapters
 * Other PCs on the same network worked fine
-  
-In short, **this particular PC was completely unable to connect to any network.** 
 
-## Initial Troubleshooting Attempts 
-We started with standard network troubleshooting: 
-1. **Uninstalled network adapters** (Wi-Fi and Ethernet) from Device Manager → Rebooted 
-2. **Reset network settings** via: 
-Settings → Network & Internet → Network Reset 
+In short, **this particular PC was completely unable to connect to any network.**
+
+## Initial Troubleshooting Attempts
+We started with standard network troubleshooting:
+1. **Uninstalled network adapters** (Wi-Fi and Ethernet) from Device Manager → Rebooted
+2. **Reset network settings** via:
+Settings → Network & Internet → Network Reset
 3. **Tried renewing IP configuration** via command prompt:
 ```cmd
-C:\> ipconfig /release 
+C:\> ipconfig /release
 ```
 ```cmd
-C:\> ipconfig /renew 
+C:\> ipconfig /renew
 ```
-None of the above worked. Running the built-in Windows network troubleshooter only resulted in the message: 
-"**Ethernet doesn't have a valid IP configuration.**" 
+None of the above worked. Running the built-in Windows network troubleshooter only resulted in the message:
+"**Ethernet doesn't have a valid IP configuration.**"
 
-## What Solved It: Full Network Stack Reset 
-What finally fixed the issue was resetting the entire Windows network stack using the following commands. 
+## What Solved It: Full Network Stack Reset
+What finally fixed the issue was resetting the entire Windows network stack using the following commands.
 
-**Run as Administrator in Command Prompt**: 
+**Run as Administrator in Command Prompt**:
 ```cmd
 C:\> netsh winsock reset
 ```
 ```cmd
-C:\> netsh int ip reset 
+C:\> netsh int ip reset
 ```
 
-After restarting the PC, both Wi-Fi and wired LAN connections were fully restored— 
+After restarting the PC, both Wi-Fi and wired LAN connections were fully restored—
 **as if nothing had ever gone wrong.**
 
-## Why These Commands Worked 
+## Why These Commands Worked
 > [!NOTE]
 > **netsh winsock reset**
-→ Resets the Winsock catalog, which underpins Windows network communications 
-**netsh int ip reset** 
+→ Resets the Winsock catalog, which underpins Windows network communications
+**netsh int ip reset**
 → Restores IP and TCP/IP-related settings (including registry values) to default
 
-These two commands are often seen as a **last-resort fix for stubborn Windows networking issues.** 
+These two commands are often seen as a **last-resort fix for stubborn Windows networking issues.**
 
 ## Additional Notes: The Affected Environment
-The issue occurred on the following device: 
-**Device**: Surface Laptop 6 
-**Operating System**: Windows 10 
+The issue occurred on the following device:
+**Device**: Surface Laptop 6
+**Operating System**: Windows 10
 
-With Surface devices running Windows 10, the following issues are commonly reported: 
-* Network settings become corrupted after Windows Updates 
-* LAN ports on USB-C docks become temporarily disabled 
+With Surface devices running Windows 10, the following issues are commonly reported:
+* Network settings become corrupted after Windows Updates
+* LAN ports on USB-C docks become temporarily disabled
 * Winsock settings are altered or broken by VPN clients or security software
 This makes resetting the network configuration especially effective on Surface environments.
 
-## Prevention Tips and Quick Fixes 
+## Prevention Tips and Quick Fixes
 
-**Create a Batch File for Quick Recovery** 
+**Create a Batch File for Quick Recovery**
 ```bat
 @echo off
 netsh winsock reset
 netsh int ip reset
 pause
 ```
-Save this as a .bat file to keep a quick-fix tool on hand in case the issue returns. 
+Save this as a .bat file to keep a quick-fix tool on hand in case the issue returns.
 
-## Other Cases Where This Helps 
-* When multiple adapters (including USB-LAN) show similar symptoms 
-* When the IP address shows as 169.254.x.x (APIPA/auto-configured) 
+## Other Cases Where This Helps
+* When multiple adapters (including USB-LAN) show similar symptoms
+* When the IP address shows as 169.254.x.x (APIPA/auto-configured)
 * When DHCP fails to assign an IP and "no valid IP configuration" errors appear
 
-## Conclusion 
-Even when a network problem seems like a dead end, 
-**returning to the basics and resetting the entire network configuration** can often bring a system back to life. 
+## Conclusion
+Even when a network problem seems like a dead end,
+**returning to the basics and resetting the entire network configuration** can often bring a system back to life.
 
 If you're facing similar symptoms, we recommend trying the steps described here.

--- a/src/posts/20251023-how-to-spot-phishing-emails-en.md
+++ b/src/posts/20251023-how-to-spot-phishing-emails-en.md
@@ -20,54 +20,54 @@ tags:
   - Beginners
 comments: {}
 ---
-"Phishing emails" and "spam emails" — most people have heard these terms from news reports or online articles. While many are familiar with the names, more and more sophisticated phishing emails are circulating, and it’s easy to worry about falling for one. In this article, we’ll explain how even beginners can recognize phishing emails starting today! 
+"Phishing emails" and "spam emails" — most people have heard these terms from news reports or online articles. While many are familiar with the names, more and more sophisticated phishing emails are circulating, and it’s easy to worry about falling for one. In this article, we’ll explain how even beginners can recognize phishing emails starting today!
 
 <!--more-->
 
-## What is a Phishing Email? 
-A phishing email is a type of spam email that aims to deceive recipients for fraudulent purposes. The attacker pretends to be a legitimate company or service and sends fake emails in order to steal sensitive information, such as passwords or credit card numbers. 
+## What is a Phishing Email?
+A phishing email is a type of spam email that aims to deceive recipients for fraudulent purposes. The attacker pretends to be a legitimate company or service and sends fake emails in order to steal sensitive information, such as passwords or credit card numbers.
 
-Since many phishing emails now closely resemble genuine messages, extra caution is necessary. 
+Since many phishing emails now closely resemble genuine messages, extra caution is necessary.
 
 ## Common Types of Phishing Emails
-Here are some typical patterns: 
-* Fake delivery notices pretending to be from shipping companies 
-* Account suspension or security alerts from banks or credit card companies 
+Here are some typical patterns:
+* Fake delivery notices pretending to be from shipping companies
+* Account suspension or security alerts from banks or credit card companies
 * "Congratulations! You’ve won!" or other unexpected prize notifications
 
-## 5 Key Tips to Spot Phishing Emails 
-Here are five practical tips to help you identify phishing emails: 
+## 5 Key Tips to Spot Phishing Emails
+Here are five practical tips to help you identify phishing emails:
 
 **1. Check the sender’s email address**
-Look at the actual email address, not just the display name. 
+Look at the actual email address, not just the display name.
 For example, an email claiming to be from your bank might come from something like abc123@gmail.com or a random string of meaningless characters. These are red flags.
 
-**2. Watch for awkward or unnatural language** 
-Poor grammar or odd phrasing often indicate phishing. 
+**2. Watch for awkward or unnatural language**
+Poor grammar or odd phrasing often indicate phishing.
 Example: “Your account will suspended! Immediate response require necessary.”
 
-**3. Inspect the link URLs** 
-Hover over any links to verify the actual destination: 
-* The URL may start with http instead of secure https 
-* The domain name may be slightly altered (e.g., ○○bank.co.jp vs. ○○bank-login.xyz) 
+**3. Inspect the link URLs**
+Hover over any links to verify the actual destination:
+* The URL may start with http instead of secure https
+* The domain name may be slightly altered (e.g., ○○bank.co.jp vs. ○○bank-login.xyz)
 * Company names may be subtly misspelled (e.g., esolia.co.jp vs. ezolia.co.jp)
 
 **4. Beware of urgent or threatening language**
-Phishing emails often pressure recipients: 
+Phishing emails often pressure recipients:
 “Respond within 24 hours,” “Verify your account immediately,” or even threats involving law enforcement or legal action.
 
-**5. Never open suspicious attachments** 
+**5. Never open suspicious attachments**
 Attachments such as .zip, .exe, or macro-enabled files are especially risky and should not be opened.
 
-## What to Do if You Receive a Suspicious Email 
-If possible, delete the email without opening it. 
-If you've already opened it: 
-* Do not click on any links or open attachments. 
-* Contact your IT department immediately. 
-* Run a full scan using security software. 
+## What to Do if You Receive a Suspicious Email
+If possible, delete the email without opening it.
+If you've already opened it:
+* Do not click on any links or open attachments.
+* Contact your IT department immediately.
+* Run a full scan using security software.
 
-For delivery notifications, instead of clicking links, visit the official website or app directly and check your account for any notices. 
+For delivery notifications, instead of clicking links, visit the official website or app directly and check your account for any notices.
 
-## Summary 
-Phishing emails can be highly deceptive, but a bit of caution goes a long way. 
+## Summary
+Phishing emails can be highly deceptive, but a bit of caution goes a long way.
 If you ever think, “Is this real…?” — stop, avoid downloading or clicking anything, and consult your IT department or someone you trust.

--- a/src/posts/20251106-online-folders-are-not-visible-en.md
+++ b/src/posts/20251106-online-folders-are-not-visible-en.md
@@ -23,36 +23,36 @@ tags:
   - File Server
 comments: {}
 ---
-This article explains what to do if you are having problems accessing or viewing some files in network folders that require the internet connection, such as a company's shared folder (shared server) or NAS. 
+This article explains what to do if you are having problems accessing or viewing some files in network folders that require an internet connection, such as a company's shared folder (shared server) or NAS.
 <!--more-->
 
 ## Situations where problems occur
-When you cannot access the folder due to the Sync Center, the following situation will occur: 
+When you cannot access the folder due to the Sync Center, the following situation will occur:
 
-* All the folders that should be in the shared folder are not displayed, or only some of them are displayed 
-* There are no problems with the Internet connection. And the shared folder itself can be accessible 
-* You can access the folder from another PC. And also able to access with another person's account that has the same permissions
+* All the folders that should be in the shared folder are not displayed, or only some of them are displayed
+* There are no problems with the Internet connection. And the shared folder itself is accessible
+* You can access the folder from another PC. And also able to access it with another person's account that has the same permissions
 
-## Solution 
-It's easy to tell if this is the problem. 
+## Solution
+It's easy to tell if this is the problem.
 
-You'll see below message in the bottom left of Explorer. 
+You'll see the message below in the bottom left of Explorer.
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="A screenshot showing a green icon and the label Status: Online" src="/uploads/202506c-windows-sync-center-en2.png" width="700px" transform-images="avif webp png jpeg 700@2">
   <figcaption class="text-left mt-2"><small><em>Fig:↑ There should be "Status: Online" message with a green icon</em></small></figcaption>
 </figure>
 
-Turn off this feature from the following location: 
+Turn off this feature from the following location:
 
-* Open Control Panel > Sync Center 
-* Select "Manage offline files" on the left pane, and select "Disable offline files" in the separate window 
-* Apply > OK to close 
+* Open Control Panel > Sync Center
+* Select "Manage offline files" on the left pane, and select "Disable offline files" in the separate window
+* Apply > OK to close
 <figure class="flex flex-col justify-start items-left">
   <img class="shadow-lg rounded-lg" alt="A screenshot of Windows Sync Center" src="/uploads/202506c-windows-sync-center-en3.png" width="700px" transform-images="avif webp png jpeg 700@2">
 </figure>
-↑When this feature is on, you'll see the message "Offline files is currently **enabled**." 
+↑When this feature is on, you'll see the message "Offline files is currently **enabled**."
 
-## What is “Online Sync”? 
-This is a function that allows you to access files that are located online, such as in shared folders, even if your PC is not connected to the internet. If you turn this function on in advance, even if you find yourself in a situation where you cannot connect to the internet, the data will be temporarily downloaded to your PC as local data (cache file), and you will be able to edit it. Then, when you are back online again, it will automatically sync with the shared folder and update the files. 
+## What is “Online Sync”?
+This is a function that allows you to access files that are located online, such as in shared folders, even if your PC is not connected to the internet. If you turn this function on in advance, even if you find yourself in a situation where you cannot connect to the internet, the data will be temporarily downloaded to your PC as local data (cache file), and you will be able to edit it. Then, when you are back online again, it will automatically sync with the shared folder and update the files.
 
 Since most users who are working from home are connected to the internet constantly, this function is no longer helpful. We basically should disable this function.

--- a/src/posts/20251120-windows-11-features-en.md
+++ b/src/posts/20251120-windows-11-features-en.md
@@ -69,7 +69,7 @@ Sometimes, when copy & paste doesn’t work for some reason, pasting from the cl
 * Can insert kaomoji, symbols, and GIFs
 
 **How to open**
-<kbd>Windows</kbd> + <kbd>.(period)</kbd> or <kbd>Windows</kbd> + <kbd>; (semicolon)</kbd> 
+<kbd>Windows</kbd> + <kbd>.(period)</kbd> or <kbd>Windows</kbd> + <kbd>; (semicolon)</kbd>
 
 It is integrated with the clipboard, so you can operate both from the same panel.
 
@@ -95,7 +95,6 @@ Snap Layouts allow you to neatly arrange multiple windows on your screen in pres
   <img alt="Screenshot of Snap layout" src="/uploads/202507b-windows11-features-3.png" width="400px" transform-images="avif webp png jpeg 400@2">
 </figure>
 
-
 ### File Explorer Tabs
 This feature allows you to switch between multiple folders within a single window using tabs—just like using a browser.
 
@@ -112,7 +111,7 @@ You can rearrange tabs by dragging them.
 When copying and pasting files, you can simply drag them between tabs to move them easily.
 
 Below are some related shortcuts that also work with browsers like Edge and Chrome.
-Once you memorize them, they’re extremely useful. give them a try!
+Once you memorize them, they’re extremely useful. Give them a try!
 
 <table class="not-prose w-full text-sm">
   <caption>
@@ -134,7 +133,7 @@ Once you memorize them, they’re extremely useful. give them a try!
       <td>Switch to the next tab</td>
     </tr>
     <tr>
-      <td><kbd>Ctrl</kbd> + <kbd>Shit</kbd>+ <kbd>Tab</kbd></td>
+      <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd>+ <kbd>Tab</kbd></td>
       <td>Switch to the previous tab</td>
     </tr>
     <tr>
@@ -159,7 +158,6 @@ Once you memorize them, they’re extremely useful. give them a try!
     </tr>
   </tbody>
 </table>
-
 
 ## Conclusion
 The clipboard, snap layouts, and File Explorer tabs introduced today are all simple yet highly effective features.

--- a/src/posts/20251212-teams-webinar-en.md
+++ b/src/posts/20251212-teams-webinar-en.md
@@ -23,39 +23,39 @@ tags:
   - Teams Webinar
 comments: {}
 ---
-Microsoft Teams Webinar is a powerful tool for hosting large-scale online events, ideal for businesses and educational institutions. In this quick IT Tips blog, we’ll explore how to set up and optimize your Teams Webinar effectively 
+Microsoft Teams Webinar is a powerful tool for hosting large-scale online events, ideal for businesses and educational institutions. In this quick IT Tips blog, we’ll explore how to set up and optimize your Teams Webinar effectively.
 <!--more-->
 
 ## What is Teams Webinar?
-Unlike regular Teams meetings, Teams Webinar is designed for large virtual events, offering features such as: 
-- Up to 1,000 attendees (expandable with Teams Premium) 
-- Registration forms to manage participants 
-- Role-based controls for presenters and attendees 
+Unlike regular Teams meetings, Teams Webinar is designed for large virtual events, offering features such as:
+- Up to 1,000 attendees (expandable with Teams Premium)
+- Registration forms to manage participants
+- Role-based controls for presenters and attendees
 - Q&A functionality for interactive discussions
 
-## How to Set Up a Webinar 
+## How to Set Up a Webinar
 
-**Step 1: Create a webinar from the Teams calendar** 
-- Open Teams and navigate to Calendar 
-- Click New Webinar 
-- Set the title, date, and time 
+**Step 1: Create a webinar from the Teams calendar**
+- Open Teams and navigate to Calendar
+- Click New Webinar
+- Set the title, date, and time
 
-**Step 2: Set up the registration form** 
-- In the Registration tab, customize the registration page 
-- Collect details like name, email, and organization 
-- Share the registration link via email or website 
+**Step 2: Set up the registration form**
+- In the Registration tab, customize the registration page
+- Collect details like name, email, and organization
+- Share the registration link via email or website
 
-**Step 3: Assign roles** 
-- Organizer: Manages the event settings 
-- Presenter: Leads the presentation 
+**Step 3: Assign roles**
+- Organizer: Manages the event settings
+- Presenter: Leads the presentation
 - Attendee: Can view but not interact (no speaking or screen sharing)
 
-## Tips for a Successful Webinar 
+## Tips for a Successful Webinar
 
 > [!NOTE]
-> ・Conduct a rehearsal: Test sessions with presenters to prevent technical issues 
-・Engage your audience by fostering interaction through Q&A features and polls 
-・Check camera & audio quality: Ensure clear visuals and sound for a professional experience 
-・Provide follow-up materials by sharing recordings and additional resources after the webinar 
+> ・Conduct a rehearsal: Test sessions with presenters to prevent technical issues
+・Engage your audience by fostering interaction through Q&A features and polls
+・Check camera & audio quality: Ensure clear visuals and sound for a professional experience
+・Provide follow-up materials by sharing recordings and additional resources after the webinar
 
 Microsoft Teams Webinar is a great tool for running large-scale virtual events smoothly. With the right setup and planning, you can enhance audience engagement and deliver a seamless experience.

--- a/src/posts/20260106-what-is-pdf-en.md
+++ b/src/posts/20260106-what-is-pdf-en.md
@@ -19,37 +19,37 @@ tags:
   - Adobe
 comments: {}
 ---
-In our daily lives and business settings, there's hardly a day when we don't encounter PDF files. From email attachments and downloadable materials on websites to e-books, they're used everywhere as a matter of course. While many associate PDF with Acrobat (PDF＝Acrobat?), what exactly is the relationship between them? 
-This time, we'll explore the connection between PDF and Acrobat. 
+In our daily lives and business settings, there's hardly a day when we don't encounter PDF files. From email attachments and downloadable materials on websites to e-books, they're used everywhere as a matter of course. While many associate PDF with Acrobat (PDF＝Acrobat?), what exactly is the relationship between them?
+This time, we'll explore the connection between PDF and Acrobat.
 
 <!--more-->
 
 ## What is PDF in the first place?
-PDF is short for "Portable Document Format," an electronic document format developed by Adobe in the 1990s. True to the meaning of "Portable," its greatest feature is that it "guarantees documents will display with their original design on any device." This development was driven by frequent issues at the time: when exchanging documents between different computers (Mac, Windows, Unix, etc.) or different applications (Word, Excel, etc.), fonts would become garbled, or layouts would break. 
+PDF is short for "Portable Document Format," an electronic document format developed by Adobe in the 1990s. True to the meaning of "Portable," its greatest feature is that it "guarantees documents will display with their original design on any device." This development was driven by frequent issues at the time: when exchanging documents between different computers (Mac, Windows, Unix, etc.) or different applications (Word, Excel, etc.), fonts would become garbled, or layouts would break.
 
 In 2008, PDF was standardized internationally as ISO 32000-1, and it has since become a widely adopted standard format across all industries worldwide.
 [Adobe's official guide “PDF Basics"](https://www.adobe.com/jp/acrobat/about-adobe-pdf.html){target="_blank" rel="noopener"}
 
 ## Features and Use Cases of PDF
 The key characteristics of PDF can be summarized as follows:
-Environment-independent: Viewable identically across Windows, Mac, smartphones, and other devices. 
-* Fixed layout: Text, images, fonts, line spacing, etc., remain locked in position, preserving the original appearance like printed material. 
-* High compression: Reduces file size while maintaining image quality, making it ideal for email attachments. 
+Environment-independent: Viewable identically across Windows, Mac, smartphones, and other devices.
+* Fixed layout: Text, images, fonts, line spacing, etc., remain locked in position, preserving the original appearance like printed material.
+* High compression: Reduces file size while maintaining image quality, making it ideal for email attachments.
 * Security capabilities: Resistant to tampering through locking/signing functions. Supports password protection, digital signatures, and other business-oriented features.
 
-PDF is widely used in a variety of situations such as: 
-* Business documents (quotes, invoices, contracts, presentations) 
-* Government applications and official notices 
-* Educational materials (handouts, academic papers) 
+PDF is widely used in a variety of situations such as:
+* Business documents (quotes, invoices, contracts, presentations)
+* Government applications and official notices
+* Educational materials (handouts, academic papers)
 * E-books and manuals
 
-While PDF may seem universally capable based on these points, its critical limitation is difficulty in editing. Unlike Word, freely modifying text or replacing images is challenging. Scanned PDFs (from paper documents) have particularly low reusability. Additionally, operations like merging multiple PDFs or extracting specific pages are often impossible with standard viewers, creating workflow inefficiencies. 
-This is where Adobe Acrobat comes into play. 
+While PDF may seem universally capable based on these points, its critical limitation is difficulty in editing. Unlike Word, freely modifying text or replacing images is challenging. Scanned PDFs (from paper documents) have particularly low reusability. Additionally, operations like merging multiple PDFs or extracting specific pages are often impossible with standard viewers, creating workflow inefficiencies.
+This is where Adobe Acrobat comes into play.
 
 ## What is Adobe Acrobat?
-While PDF is often confused with Acrobat, Adobe Acrobat is the official software for creating, viewing, editing, and managing PDFs and is a centralized tool for all PDF-related operations. 
+While PDF is often confused with Acrobat, Adobe Acrobat is the official software for creating, viewing, editing, and managing PDFs and is a centralized tool for all PDF-related operations.
 
-Acrobat is available in three products: the free version Adobe Acrobat Reader, and the paid versions of Acrobat Standard and Acrobat Pro. The free version of Adobe Acrobat Reader is sufficient for viewing and printing, but Acrobat Standard and Acrobat Pro are required for full-scale editing and business use. 
+Acrobat is available in three products: the free version Adobe Acrobat Reader, and the paid versions of Acrobat Standard and Acrobat Pro. The free version of Adobe Acrobat Reader is sufficient for viewing and printing, but Acrobat Standard and Acrobat Pro are required for full-scale editing and business use.
 
 <table class="not-prose w-full text-sm">
   <thead>
@@ -83,19 +83,19 @@ Acrobat is available in three products: the free version Adobe Acrobat Reader, a
 </table>
 
 ## Acrobat Use Cases
-* Electronic Signatures on Contracts: Acrobat makes it easy to sign and date contracts with business partners. This greatly reduces the need for paper, printing, and mailing. 
-* PDF merging and page manipulation: Merge multiple PDFs into one PDF, rearrange pages, and easily edit the PDF itself with Acrobat. 
+* Electronic Signatures on Contracts: Acrobat makes it easy to sign and date contracts with business partners. This greatly reduces the need for paper, printing, and mailing.
+* PDF merging and page manipulation: Merge multiple PDFs into one PDF, rearrange pages, and easily edit the PDF itself with Acrobat.
 * Distribute shared materials with passwords: Set passwords to prevent unauthorized access and tampering. You can also set a read-only setting, prohibit printing, etc.
 
 ## Alternatives to Acrobat
-Historically, Acrobat was essential for PDFs. After ISO 32000-1 standardization, third-party tools emerged, and PDFs can now be opened in web browsers and standard OS functions. Therefore, there are now many alternative software.
+Historically, Acrobat was essential for PDFs. After ISO 32000-1 standardization, third-party tools emerged, and PDFs can now be opened in web browsers and standard OS functions. Therefore, there are now many alternative software options.
 
-* Free PDF viewers: macOS Preview, Microsoft Edge (with PDF viewer function) for Windows 10/11, Foxit Reader, etc. Some of them have viewing functions similar to Acrobat Reader. 
-* Free/paid PDF editing software: Foxit PDF Editor (PhantomPDF), PDF-Xchange Editor, macOS Preview (simple editing), etc. There are products that offer basic editing and conversion functions at a lower cost than Acrobat Pro. 
+* Free PDF viewers: macOS Preview, Microsoft Edge (with PDF viewer function) for Windows 10/11, Foxit Reader, etc. Some of them have viewing functions similar to Acrobat Reader.
+* Free/paid PDF editing software: Foxit PDF Editor (PhantomPDF), PDF-Xchange Editor, macOS Preview (simple editing), etc. There are products that offer basic editing and conversion functions at a lower cost than Acrobat Pro.
 * Online PDF tools: Smallpdf, iLovePDF, [Adobe Acrobat online tools](https://www.adobe.com/jp/acrobat/online.html){target="_blank" rel="noopener"}, etc. Simple conversion, merging, splitting, compression, etc. are possible on the browser. (Please note that handling confidential documents may involve security risks.)
 
-## Conclusion 
-The PDF files we use daily represent a format-tool relationship with Adobe. The common misconception that "PDF＝Acrobat" likely stems from corporate environments where Acrobat Reader is often pre-installed on work PCs. 
-For enterprises and professionals, Acrobat is probably better than other alternatives in terms of functionality, stability, comprehensive support, security, and long-term operation and reliability. 
-If you have never used a paid version of Adobe products, we would recommend you try [Adobe Acrobat online tools](https://www.adobe.com/jp/acrobat/online.html){target="_blank" rel="noopener"}. (Please avoid confidential/personal data.) 
-For viewing and printing only, let’s use Chrom or Microsoft Edge’s built-in PDF viewer, no download needed!
+## Conclusion
+The PDF files we use daily represent a format-tool relationship with Adobe. The common misconception that "PDF＝Acrobat" likely stems from corporate environments where Acrobat Reader is often pre-installed on work PCs.
+For enterprises and professionals, Acrobat is probably better than other alternatives in terms of functionality, stability, comprehensive support, security, and long-term operation and reliability.
+If you have never used a paid version of Adobe products, we would recommend you try [Adobe Acrobat online tools](https://www.adobe.com/jp/acrobat/online.html){target="_blank" rel="noopener"}. (Please avoid confidential/personal data.)
+For viewing and printing only, let’s use Chrome or Microsoft Edge’s built-in PDF viewer, no download needed!

--- a/src/posts/20260122-digital-detox-habits-en.md
+++ b/src/posts/20260122-digital-detox-habits-en.md
@@ -21,78 +21,78 @@ tags:
   - Offline Time
 comments: {}
 ---
-Have You Ever Felt Drained Surrounded by Digital Devices? 
-I work as an IT support specialist in a corporate environment, so I’m usually very close to digital devices in my daily life. In this article, I’d like to share a few simple digital detox habits that I personally practice. They may be small things, but I hope they’ll be helpful for anyone who has felt the same kind of fatigue. 
+Have You Ever Felt Drained Surrounded by Digital Devices?
+I work as an IT support specialist in a corporate environment, so I’m usually very close to digital devices in my daily life. In this article, I’d like to share a few simple digital detox habits that I personally practice. They may be small things, but I hope they’ll be helpful for anyone who has felt the same kind of fatigue.
 
 <!--more-->
 
-## What Is Digital Detox? 
-According to the Oxford Learner’s Dictionaries, a digital detox is: 
-*a period of time when a person does not use digital devices such as smartphones or computers, especially in order to reduce stress and relax. *
-This term was added to the online version of the Oxford Dictionary in 2013 and has gradually become more widely recognized. 
+## What Is Digital Detox?
+According to the Oxford Learner’s Dictionaries, a digital detox is:
+*a period of time when a person does not use digital devices such as smartphones or computers, especially in order to reduce stress and relax.*
+This term was added to the online version of the Oxford Dictionary in 2013 and has gradually become more widely recognized.
 
 ## What Made Me More Aware of It
-iPhones were already widely used when I was a student, but the apps back then weren’t as addictive as they are now. At most, checking Twitter or Instagram for friends’ updates was a small daily pleasure. 
-It’s only in the past five years or so that I began to really relate to the idea of a digital detox. 
+iPhones were already widely used when I was a student, but the apps back then weren’t as addictive as they are now. At most, checking Twitter or Instagram for friends’ updates was a small daily pleasure.
+It’s only in the past five years or so that I began to really relate to the idea of a digital detox.
 
-Despite working with digital devices all day, I found myself staying up late watching videos, or endlessly checking social media without any real purpose. 
-These small habits added up over time, and I started feeling a vague sense of fatigue from the sheer amount of information. Eventually, it became a more noticeable discomfort. 
+Despite working with digital devices all day, I found myself staying up late watching videos, or endlessly checking social media without any real purpose.
+These small habits added up over time, and I started feeling a vague sense of fatigue from the sheer amount of information. Eventually, it became a more noticeable discomfort.
 
-While I’m truly grateful for the convenience and possibilities digital technology brings, I can no longer ignore the fatigue and stress that can come with it. 
-I imagine I’m not the only one who feels this way. 
+While I’m truly grateful for the convenience and possibilities digital technology brings, I can no longer ignore the fatigue and stress that can come with it.
+I imagine I’m not the only one who feels this way.
 
 ## How I Try to Maintain a Healthy Distance
-It’s not easy to completely cut off from digital life these days, but I believe the key is finding a balance that doesn’t feel forced. 
-When we hear the word “detox,” we might feel pressured to quit all digital devices at once—but that in itself can become stressful. 
-Personally, I think having a relaxed mindset like “let’s just cut back a little” is perfectly fine. 
+It’s not easy to completely cut off from digital life these days, but I believe the key is finding a balance that doesn’t feel forced.
+When we hear the word “detox,” we might feel pressured to quit all digital devices at once—but that in itself can become stressful.
+Personally, I think having a relaxed mindset like “let’s just cut back a little” is perfectly fine.
 
-Here are some small things I do to avoid becoming overwhelmed by information: 
+Here are some small things I do to avoid becoming overwhelmed by information:
 
 ### At Work
 {{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Use paper intentionally**
-Instead of using a smartphone app, I write down quick notes with pen and paper. Especially when I feel stuck, writing things out on a blank sheet helps organize my thoughts. 
-It also gives a good impression to others—like I’m focused and taking things seriously. 
+Instead of using a smartphone app, I write down quick notes with pen and paper. Especially when I feel stuck, writing things out on a blank sheet helps organize my thoughts.
+It also gives a good impression to others—like I’m focused and taking things seriously.
 
-{{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Keep my desktop clean** 
-Has your desktop ever gotten cluttered without you realizing it? 
-I make it a habit to tidy up from time to time, removing unnecessary files, shortcuts, and apps. 
-A clean desktop reduces visual noise and encourages better file management. It also helps improve work efficiency. 
+{{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Keep my desktop clean**
+Has your desktop ever gotten cluttered without you realizing it?
+I make it a habit to tidy up from time to time, removing unnecessary files, shortcuts, and apps.
+A clean desktop reduces visual noise and encourages better file management. It also helps improve work efficiency.
 
-{{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Use noise-canceling earphones as earplugs on the commute** 
-Commuter trains can be overloaded with information—noise, crowds, and advertisements. 
+{{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Use noise-canceling earphones as earplugs on the commute**
+Commuter trains can be overloaded with information—noise, crowds, and advertisements.
 I intentionally don’t play music or podcasts, and just use the noise-canceling function. Surprisingly, that alone helps me feel calm. Regular earplugs work well too.
 
 ### On Days Off and During Daily Life
-{{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Use iPhone’s Screen Time feature** 
-The Screen Time feature on the iPhone lets you set daily time limits for specific apps. 
-When you hit the limit, a prompt appears with options like “Close now,” “One more minute,” “Remind me in 15 minutes,” or “Ignore for today.” 
-It’s easy to feel like you haven’t spent much time on your phone, but Screen Time makes you aware of just how much time you’re actually using. 
+{{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Use iPhone’s Screen Time feature**
+The Screen Time feature on the iPhone lets you set daily time limits for specific apps.
+When you hit the limit, a prompt appears with options like “Close now,” “One more minute,” “Remind me in 15 minutes,” or “Ignore for today.”
+It’s easy to feel like you haven’t spent much time on your phone, but Screen Time makes you aware of just how much time you’re actually using.
 
 > [!NOTE]
-> How to set it up: 
-1. Open “Settings” → “Screen Time” 
-2. Tap “App Limits” → “Add Limit” 
-3. Select the apps you want to limit 
+> How to set it up:
+1. Open “Settings” → “Screen Time”
+2. Tap “App Limits” → “Add Limit”
+3. Select the apps you want to limit
 4. Set your preferred time
 
 {{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Carry a book with you**
-Having a book on hand helps prevent me from reaching for my phone out of boredom. 
-I choose something with a bit of weight, like a paperback, so I feel more motivated to read it—after all, I brought it with me. 
+Having a book on hand helps prevent me from reaching for my phone out of boredom.
+I choose something with a bit of weight, like a paperback, so I feel more motivated to read it—after all, I brought it with me.
 
-{{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Don’t charge devices by the bed** 
-When I charge my smartphone or smartwatch by my bed, I notice a big difference in how refreshed I feel in the morning compared to when I keep them away. 
-I can’t explain it scientifically, but I’ve found I feel less sleepy and foggy during the day. 
-Try it—it might work for you too. 
+{{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Don’t charge devices by the bed**
+When I charge my smartphone or smartwatch by my bed, I notice a big difference in how refreshed I feel in the morning compared to when I keep them away.
+I can’t explain it scientifically, but I’ve found I feel less sleepy and foggy during the day.
+Try it—it might work for you too.
 
 {{- comp.icon({ name: "check-fat", size: 4, color: "sky" }) -}}**Plan offline time without your phone or PC**
-On weekends, I plan activities that don’t require digital devices. 
-Walking or jogging is a great option—it’s free, refreshing, and helps you reset. 
+On weekends, I plan activities that don’t require digital devices.
+Walking or jogging is a great option—it’s free, refreshing, and helps you reset.
 
-One of my favorite hobbies is hiking. When I’m surrounded by nature, I notice things I normally wouldn’t: the sound of the wind, birds chirping, the scent of trees… 
-It feels like my senses get a reset, and I can recharge deeply. 
-Spending time in nature is one of the best ways to step away from digital life. And best of all—it’s something I can continue doing easily and consistently. 
+One of my favorite hobbies is hiking. When I’m surrounded by nature, I notice things I normally wouldn’t: the sound of the wind, birds chirping, the scent of trees…
+It feels like my senses get a reset, and I can recharge deeply.
+Spending time in nature is one of the best ways to step away from digital life. And best of all—it’s something I can continue doing easily and consistently.
 
 ## In Closing
-If you ever feel exhausted from too much information, it might be your mind and body telling you it’s time to take a step back. 
-Start small—like setting Screen Time limits or planning offline activities for the weekend. 
+If you ever feel exhausted from too much information, it might be your mind and body telling you it’s time to take a step back.
+Start small—like setting Screen Time limits or planning offline activities for the weekend.
 May your days gain a little more breathing room and peace. I'm quietly cheering you on.

--- a/src/posts/20260216-monitor-won’t-display-en.md
+++ b/src/posts/20260216-monitor-won’t-display-en.md
@@ -26,54 +26,54 @@ tags:
   - End-user tips
 comments: {}
 ---
-One of the most common IT helpdesk tickets is: "My monitor suddenly stopped working…" 
-Especially in setups with dual monitors and docking stations, the cause is often simple and can be resolved in just a few steps. 
-This article outlines a practical checklist used by IT professionals for resolving monitor display issues quickly and efficiently. 
+One of the most common IT helpdesk tickets is: "My monitor suddenly stopped working…"
+Especially in setups with dual monitors and docking stations, the cause is often simple and can be resolved in just a few steps.
+This article outlines a practical checklist used by IT professionals for resolving monitor display issues quickly and efficiently.
 
 <!--more-->
 
 ## Step 1: Start with the Basic “Unplug and Replug” Method
-Over 80% of display issues can be fixed by doing one of the following: 
-1. **Unplug and replug the docking station's power cable** 
-  - Docking stations can freeze and a power cycle often resolves it 
-  - Unplug for about 10 seconds, then reconnect the power 
+Over 80% of display issues can be fixed by doing one of the following:
+1. **Unplug and replug the docking station's power cable**
+  - Docking stations can freeze and a power cycle often resolves it
+  - Unplug for about 10 seconds, then reconnect the power
 
-2. **Unplug and replug the monitor cable (HDMI/DisplayPort, etc.)** 
-  - The cable may not be fully seated or could have a loose connection 
-  - Remove it and firmly reinsert until it clicks into place 
+2. **Unplug and replug the monitor cable (HDMI/DisplayPort, etc.)**
+  - The cable may not be fully seated or could have a loose connection
+  - Remove it and firmly reinsert until it clicks into place
 
-3. **Unplug and replug the monitor’s power** 
-  - The monitor might be frozen or stuck in a low-power state 
+3. **Unplug and replug the monitor’s power**
+  - The monitor might be frozen or stuck in a low-power state
   - Turn off the main power and disconnect the cable for 10 seconds before reconnecting
 
-## Step 2: If It Still Doesn’t Work, Check These Next 
-4. **Check the monitor input source** 
-  - Use the monitor’s physical buttons to ensure the correct input (HDMI1, DisplayPort, etc.) is selected 
-  - Manually switching input may be necessary after replugging cables 
+## Step 2: If It Still Doesn’t Work, Check These Next
+4. **Check the monitor input source**
+  - Use the monitor’s physical buttons to ensure the correct input (HDMI1, DisplayPort, etc.) is selected
+  - Manually switching input may be necessary after replugging cables
 
-5. **Try replacing the dock or cables** 
-  - Common failure examples: 
-    Physically damaged HDMI cables 
-    A broken DisplayPort port on the dock 
+5. **Try replacing the dock or cables**
+  - Common failure examples:
+    Physically damaged HDMI cables
+    A broken DisplayPort port on the dock
   - If you have a spare dock or cable, swap them temporarily to test
 
-6. **Check Windows display settings for disconnected status** 
-  - Go to Windows Display Settings and verify that the monitor is detected 
+6. **Check Windows display settings for disconnected status**
+  - Go to Windows Display Settings and verify that the monitor is detected
   - Try clicking "Detect" or switching the mode to "Extend" or "Duplicate"
 
-## Step 3: Additional Checks if Nothing Else Works 
+## Step 3: Additional Checks if Nothing Else Works
 
-7. **Update your graphics driver** 
-  - Outdated Intel or NVIDIA drivers can cause display issues 
-  - Open Device Manager → Display adapters → Right-click → Update driver 
+7. **Update your graphics driver**
+  - Outdated Intel or NVIDIA drivers can cause display issues
+  - Open Device Manager → Display adapters → Right-click → Update driver
 
-8. **Try booting into Safe Mode** 
-  - Hold [F8] or Shift during startup to boot into Safe Mode and rule out driver issues 
+8. **Try booting into Safe Mode**
+  - Hold [F8] or Shift during startup to boot into Safe Mode and rule out driver issues
 
 9. **Test with a different monitor or PC**
   - Use a known working monitor or PC to cross-test and identify whether the issue lies with the PC or monitor
 
-## Summary: Start with Power, Cables, and Settings 
-Display issues are often caused by simple factors, and most of the time you can fix them by following the “unplug and replug” method and verifying display settings. 
-If that doesn’t work, proceed step by step by replacing cables, testing the dock, or updating system drivers. 
+## Summary: Start with Power, Cables, and Settings
+Display issues are often caused by simple factors, and most of the time you can fix them by following the “unplug and replug” method and verifying display settings.
+If that doesn’t work, proceed step by step by replacing cables, testing the dock, or updating system drivers.
 You’d be surprised how many cases are resolved with just a simple reset, so give this checklist a try before calling IT support.

--- a/src/posts/20260302-manage-your-passwords-en.md
+++ b/src/posts/20260302-manage-your-passwords-en.md
@@ -21,26 +21,26 @@ tags:
   - CyberSecurityTips
 comments: {}
 ---
-A Beginner-Friendly Guide to Password Management 
-Do you reuse the same password for multiple accounts? 
-Or do you tend to choose something easy to remember? 
-Passwords are essential keys that protect our personal and professional information. 
-But if they’re easy for you to remember, they might also be easy for others to guess. 
-In this article, we’ll look at how to manage passwords safely, and how to create stronger, harder-to-guess passwords — even for beginners. 
+A Beginner-Friendly Guide to Password Management
+Do you reuse the same password for multiple accounts?
+Or do you tend to choose something easy to remember?
+Passwords are essential keys that protect our personal and professional information.
+But if they’re easy for you to remember, they might also be easy for others to guess.
+In this article, we’ll look at how to manage passwords safely, and how to create stronger, harder-to-guess passwords — even for beginners.
 
 <!--more-->
 
-## Passwords That Are Easy to Guess 
-Here are some common cases where passwords are at risk: 
-* Using the same password across multiple services 
-* Using simple and predictable passwords like 123456 or password123 
+## Passwords That Are Easy to Guess
+Here are some common cases where passwords are at risk:
+* Using the same password across multiple services
+* Using simple and predictable passwords like 123456 or password123
 * Using personal information like your birthday or pet’s name
-  
+
 In recent years, **credential stuffing attacks** (where attackers use leaked IDs and passwords from other services) have become more common — so it’s more important than ever to strengthen your password habits.
 
-## How to Create Strong but Memorable Passwords 
-Random strings are strong — but hard to remember. 
-Luckily, with a few simple rules, you can create passwords that are both secure and memorable. 
+## How to Create Strong but Memorable Passwords
+Random strings are strong — but hard to remember.
+Luckily, with a few simple rules, you can create passwords that are both secure and memorable.
 
 Example: Base word is “esolia”
 <table class="not-prose w-full text-sm">
@@ -75,29 +75,29 @@ Example: Base word is “esolia”
 > Add random or unrelated words
 > Slightly modify a familiar word using a personal rule
 
-## Where Should You Store Your Passwords? 
-The stronger your passwords are, the harder they are to remember — that’s where password managers come in. 
+## Where Should You Store Your Passwords?
+The stronger your passwords are, the harder they are to remember — that’s where password managers come in.
 
-At Esolia, we use… 
-Our company uses a password management tool called **[Codebook](https://www.zetetic.net/codebook/){target="_blank" rel="noopener"}**, which helps store and manage passwords securely. 
-* Passwords are encrypted and stored safely 
-* You can sync data across your PC and mobile devices 
-* Includes a password generator 
+At Esolia, we use…
+Our company uses a password management tool called **[Codebook](https://www.zetetic.net/codebook/){target="_blank" rel="noopener"}**, which helps store and manage passwords securely.
+* Passwords are encrypted and stored safely
+* You can sync data across your PC and mobile devices
+* Includes a password generator
 * Supports two-factor authentication (2FA) settings
 
-Other password managers include **Keeper**, **Bitwarden** — but please follow company guidelines when choosing tools. 
+Other password managers include **Keeper**, **Bitwarden** — but please follow company guidelines when choosing tools.
 You can find more information about the Codebook subscription pricing [here](https://codebook.cloud/pricing?includeCommercial&coupon=ESOLIAREF25OFF){target="_blank" rel="noopener"}.
 
-## 3 Basic Rules for Password Management 
+## 3 Basic Rules for Password Management
 
 1. **Don’t reuse passwords**
- → Use different passwords for different services 
-2. **Change passwords regularly** 
- → Especially for important accounts, every 3–6 months is recommended 
-3. **Use two-factor authentication (2FA) or MFA** 
+ → Use different passwords for different services
+2. **Change passwords regularly**
+ → Especially for important accounts, every 3–6 months is recommended
+3. **Use two-factor authentication (2FA) or MFA**
  → Adds an extra layer of protection, even if your password is compromised
 
-## Summary 
-Passwords are like keys — and you wouldn’t want a door that opens with a coin. 
-Creating strong and secure passwords is the first step in protecting your data. 
+## Summary
+Passwords are like keys — and you wouldn’t want a door that opens with a coin.
+Creating strong and secure passwords is the first step in protecting your data.
 Make use of tools like Codebook to manage passwords safely, without relying on memory alone!

--- a/src/posts/20260323-acrobat-standard-en.md
+++ b/src/posts/20260323-acrobat-standard-en.md
@@ -168,11 +168,11 @@ Building on our previous blog,["What is PDF? How is it related to Adobe Acrobat?
 2. Select the "Edit" tool.
 3. Click the relevant text and enter or correct it directly. Or drag the relevant object to move it around or change its size.
 
-**Reorder, add, and extract pages**: Uses can easily change the page order within a PDF, add pages from another file, extract and save specific pages, and more.
+**Reorder, add, and extract pages**: Users can easily change the page order within a PDF, add pages from another file, extract and save specific pages, and more.
 *Please note that changes cannot be made in PDF files that have been marked as non-editable.
 {{- comp.icon({ name: "cursor-click", size: 4, color: "blue" }) -}} How to Operate
 1. Click "Edit" → "Organize Pages".
-2. Drag pages to change the order. 
+2. Drag pages to change the order.
 3. By right-clicking on a page, users can insert a page from another file, extract a page from another file, and save it as a separate file. Rotation and deletion of the relevant page are also possible.
 
 ### ② Security Management
@@ -201,7 +201,7 @@ It is also possible to send a request for signatures in a specific order of thos
 *By setting a reminder, the signer will automatically receive reminders until the document is signed.
 
 ### ④ Ability to convert between PDF and Office formats
-**Convert PDF to Word/Excel/PowerPoint**: Use this when users want to convert a PDF that does not have the original data back to Word for editing, or when users want to convert a PDF quotation or report to Excel for compilation. However, please 
+**Convert PDF to Word/Excel/PowerPoint**: Use this when users want to convert a PDF that does not have the original data back to Word for editing, or when users want to convert a PDF quotation or report to Excel for compilation. However, please
 note that there are limits to the accuracy of the conversion, and the format may not be reproduced accurately.
 
 **Examples of common problems**
@@ -217,7 +217,7 @@ Please note that the converted file needs to be checked and reformatted. It is s
 2. Or use the "Save as PDF" option in the Office app.
 
 ## Main differences from Acrobat Pro
-The main differences between Acrobat Pro and Acrobat Pro are listed in the comparison table at the beginning of this document, but here are some features of Acrobat Pro.　
+The main differences between Acrobat Standard and Acrobat Pro are listed in the comparison table at the beginning of this document, but here are some features of Acrobat Pro.
 
 * Masking of sensitive information: Masks text and images with a black fill, searches for specific keywords in the entire document, and removes metadata and hidden information.
 * OCR (Optical Character Recognition): Text can be automatically read from scanned images and photo PDFs. For example, paper contracts and receipts can be digitized and made searchable.

--- a/src/posts/20260325-the-file-saving-popup-en.md
+++ b/src/posts/20260325-the-file-saving-popup-en.md
@@ -29,15 +29,15 @@ Have you ever had trouble saving a file because the pop-up window for selecting 
 A pop-up screen is a small window that appears only when needed, separate from your regular work screen. When you save a file, the standard Windows "Save As" dialog box appears. This window allows you to select the destination folder and enter the file name, so if it’s too large or too small, it can be difficult to use. This leads to the question: is it possible to adjust its size?
 
 ## Is it possible to adjust the window size?
-Because the Save dialog is displayed using the OS’s standard mechanism, it may not always be possible to resize it freely. In many cases, especially on older operating systems or legacy business application, the window size is fixed.
+Because the Save dialog is displayed using the OS’s standard mechanism, it may not always be possible to resize it freely. In many cases, especially on older operating systems or legacy business applications, the window size is fixed.
 However, in Windows 10 and later, improvements have been made to the Save dialog, and as a result, in most cases you can now adjust the window size. When the Save dialog is displayed in Explorer format (the same layout used to display files and folders in Windows Explorer), you can freely resize it by dragging any corner or the bottom-right edge of the window.
 
 <Procedure>
-1. Open the save pop-up.  
-2. Move the mouse cursor to the right edge or bottom-right corner of the screen.  
-3. Confirm that the cursor changes to “↔” or “↕”.  
-4. If it changes, drag to adjust the size.  
-※Please note that this operation may be disabled in some applications.  
+1. Open the save pop-up.
+2. Move the mouse cursor to the right edge or bottom-right corner of the screen.
+3. Confirm that the cursor changes to “↔” or “↕”.
+4. If it changes, drag to adjust the size.
+※Please note that this operation may be disabled in some applications.
 
 ## How to adjust the size of a window that fills the entire screen
 Now, let’s look at how to restore a “Save As” dialog box that has expanded to fill the entire screen.
@@ -71,7 +71,7 @@ Here are three ways to fix this problem.
   <img alt="Screenshot of a Windows“Save As”dialog box showing the file name field" src="/uploads/202508a-file-saving-popup-en4.png" width="500px" transform-images="avif webp png jpeg 500@2">
 </figure>
 
-### Method 3：Resize via “Hide Folders” button
+### Method 3: Resize via “Hide Folders” button
 1. Click the "Hide Folders" button located in the bottom-left corner of the maximized dialog box.
 
 <figure class="flex flex-col justify-start items-left">
@@ -81,7 +81,7 @@ Here are three ways to fix this problem.
 2. The dialog box will be restored from its maximized state, allowing you to resize the window by dragging its bottom-right corner.
 
 <figure class="flex flex-col justify-start items-left">
-  <img alt="Screenshot of a Windows“Save As”dialog box showing showing the file name and settings" src="/uploads/202508a-file-saving-popup-en6.png" width="500px" transform-images="avif webp png jpeg 500@2">
+  <img alt="Screenshot of a Windows“Save As”dialog box showing the file name and settings" src="/uploads/202508a-file-saving-popup-en6.png" width="500px" transform-images="avif webp png jpeg 500@2">
 </figure>
 
 3. Alternatively, clicking “Browse for Folder” in the above step will return the dialog box to a fixed size without maximizing it.

--- a/src/posts/20260408-email-attachment-en.md
+++ b/src/posts/20260408-email-attachment-en.md
@@ -24,48 +24,48 @@ tags:
   - Macrovirus
 comments: {}
 ---
-Have you ever opened an email attachment without thinking twice? 
-Files labeled “Invoice”, “Report”, or “Meeting materials” may look routine -but some are cleverly disguised traps that can cause system failures or data breaches. 
-This post highlights two common threats in corporate environments. ZIP bombs and macro viruses. 
+Have you ever opened an email attachment without thinking twice?
+Files labeled “Invoice”, “Report”, or “Meeting materials” may look routine — but some are cleverly disguised traps that can cause system failures or data breaches.
+This post highlights two common threats in corporate environments: ZIP bombs and macro viruses.
 
 <!--more-->
 
-## ZIP Bombs: When You Unzipping Crashes Your System  
-A zip bomb is a maliciously compressed file that expands into gigabytes - or even terabytes – of date when extracted. This overloads your PC or antivirus software, potentially causing a system freeze or crash. 
+## ZIP Bombs: When Unzipping Crashes Your System
+A zip bomb is a maliciously compressed file that expands into gigabytes - or even terabytes – of data when extracted. This overloads your PC or antivirus software, potentially causing a system freeze or crash.
 
-**What to watch for:** 
-* Suspiciously small ZIP files (e.g., just a few KB) 
-* Generic names like “Invoice.zip”, “Report.zip” 
-* Unexpected behavior after extraction (e.g., freezing, antivirus shutdown) 
+**What to watch for:**
+* Suspiciously small ZIP files (e.g., just a few KB)
+* Generic names like “Invoice.zip”, “Report.zip”
+* Unexpected behavior after extraction (e.g., freezing, antivirus shutdown)
 
 > [!NOTE]
 > **What to do:**
-> ・Never unzip files from unknown senders 
-> ・Check file properties before extracting (right-click → Properties) 
+> ・Never unzip files from unknown senders
+> ・Check file properties before extracting (right-click → Properties)
 > ・Keep real-time protection enabled in your antivirus software
 
-## Macro Viruses: Hidden Code in Office Documents 
-Macro viruses are embedded in Word or Excel files and activate when the document is opened -especially if you click “Enable Content”. These scripts can perform unauthorized actions like sending data externally or modifying files. 
+## Macro Viruses: Hidden Code in Office Documents
+Macro viruses are embedded in Word or Excel files and activate when the document is opened — especially if you click “Enable Content”. These scripts can perform unauthorized actions like sending data externally or modifying files.
 
 **What to watch for:**
-* File extensions like “.docm” or “.xlsm” (macro-enabled formats) 
-* Prompts to “Enable Content” upon opening 
+* File extensions like “.docm” or “.xlsm” (macro-enabled formats)
+* Prompts to “Enable Content” upon opening
 * Unexpected behavior after enabling macros
 
 > [!NOTE]
-> **What to do:** 
-> ・Avoid clicking “Enable Content” unless you trust the sender 
-> ・Only open macro-enabled files from verified internal access 
-> ・Set office to “Disable VBA macros with notification” in your setting. 
->  (File >Options > Trust Center > Trust Center Settings) > Macro setting
+> **What to do:**
+> ・Avoid clicking “Enable Content” unless you trust the sender
+> ・Only open macro-enabled files from verified internal access
+> ・Set Office to “Disable VBA macros with notification” in your settings.
+>  (File > Options > Trust Center > Trust Center Settings) > Macro setting
 
-## Share and Report 
-Attachment-based attacks don’t just affect individuals – they can compromise entire departments. Early detection and communication are key. 
-* If something feels off, consult your IT team before opening  
-* If you’ve already opened a suspicious file, report it immediately 
-* Share alerts with colleagues -similar email may be circulating
+## Share and Report
+Attachment-based attacks don’t just affect individuals – they can compromise entire departments. Early detection and communication are key.
+* If something feels off, consult your IT team before opening
+* If you’ve already opened a suspicious file, report it immediately
+* Share alerts with colleagues — similar emails may be circulating
 
-## Think Before You Click 
-Attachments are useful, but they come with risks. 
-Before opening any file, ask yourself: “Who sent this?”,” What format is it?”, “Do I really need to open it?” 
+## Think Before You Click
+Attachments are useful, but they come with risks.
+Before opening any file, ask yourself: “Who sent this?”, “What format is it?”, “Do I really need to open it?”
 A moment of caution can protect your data and your team.

--- a/src/posts/20260408-runas-command-en.md
+++ b/src/posts/20260408-runas-command-en.md
@@ -28,58 +28,58 @@ tags:
   - InternalIT
 comments: {}
 ---
-In day-to-day IT support, situations often come up like: 
-“I normally work with a standard user account, but sometimes I need admin rights to uninstall drivers or access admin web consoles.” 
-Logging off and switching accounts every time is tedious. That’s where the built-in Windows **runas command** comes in handy. 
-It lets you run programs using an admin account only when needed, without changing your main login. 
+In day-to-day IT support, situations often come up like:
+“I normally work with a standard user account, but sometimes I need admin rights to uninstall drivers or access admin web consoles.”
+Logging off and switching accounts every time is tedious. That’s where the built-in Windows **runas command** comes in handy.
+It lets you run programs using an admin account only when needed, without changing your main login.
 
 <!--more-->
 
-## What is runas 
+## What is runas
 * runas is a Windows command that allows you to run a program as a different user.
-* Even if you’re logged in as a standard user, you can launch a program with admin privileges by entering the admin username and password. 
+* Even if you’re logged in as a standard user, you can launch a program with admin privileges by entering the admin username and password.
 * Think of it like having your own key for normal tasks, but borrowing an admin key to access a locked room when necessary.
-  
+
 > [!NOTE]
 > runas runs the program as another user. It does not automatically handle UAC elevation in all cases. Sometimes you need to use cmd.exe /c as an intermediary.
 
 ## Example 1: Opening Device Manager as an Admin
-In my daily IT support, I sometimes uninstall and reinstall drivers on user PCs. 
-To uninstall a device, admin rights are required, so I use runas to open Device Manager: 
+In my daily IT support, I sometimes uninstall and reinstall drivers on user PCs.
+To uninstall a device, admin rights are required, so I use runas to open Device Manager:
 
 ```cmd
-runas /user:DOMAIN\AdminAccount "cmd.exe /c mmc devmgmt.msc" 
+runas /user:DOMAIN\AdminAccount "cmd.exe /c mmc devmgmt.msc"
 ```
-* DOMAIN\AdminAccount = your admin account (or PCName\Administrator for local accounts) 
+* DOMAIN\AdminAccount = your admin account (or PCName\Administrator for local accounts)
 * After entering the password, Device Manager opens with admin rights
 
-Why it’s useful: You don’t need to log off and log on as an admin every time, saving time and effort. 
+Why it’s useful: You don’t need to log off and log on as an admin every time, saving time and effort.
 
-## Example 2: Opening Chrome as an Admin 
-Sometimes, I need to access admin web consoles like Exchange Admin Center or Intune. 
-In those cases, I use runas to launch Chrome with my admin account: 
+## Example 2: Opening Chrome as an Admin
+Sometimes, I need to access admin web consoles like Exchange Admin Center or Intune.
+In those cases, I use runas to launch Chrome with my admin account:
 
 ```cmd
 runas /user:admin_account@example.com "C:\ProgramFiles\Google\Chrome\Application\chrome.exe"
 ```
 
-* After entering the password, that Chrome session runs with admin privileges 
+* After entering the password, that Chrome session runs with admin privileges
 * Important: The Chrome installation path (C:\Program Files\Google\Chrome\Application\) may vary depending on the device. Adjust the path as needed.
 
-This lets you stay logged in as a standard user while accessing admin tools only when necessary. 
+This lets you stay logged in as a standard user while accessing admin tools only when necessary.
 
-## Common Questions / Tips 
-* Can I store the password in a script? → Not recommended. Storing in plain text is a security risk. 
-* Can I use /savecred? → Possible, but it has security risks. Always follow your company policy. 
+## Common Questions / Tips
+* Can I store the password in a script? → Not recommended. Storing in plain text is a security risk.
+* Can I use /savecred? → Possible, but it has security risks. Always follow your company policy.
 * What about UAC? → runas doesn’t handle all UAC prompts. If you get a 740 error, use cmd.exe /c or consider alternatives like Task Scheduler.
 
-## Practical tips 
-* Batch files: Create a .bat for frequently used commands. Double-click and enter the password. 
-* Task Scheduler: IT can pre-create admin tasks. Users can run them with a single click. 
+## Practical tips
+* Batch files: Create a .bat for frequently used commands. Double-click and enter the password.
+* Task Scheduler: IT can pre-create admin tasks. Users can run them with a single click.
 * Third-party tools (e.g., PsExec): Useful, but be cautious with passwords and logs.
 
-## Summary 
-* runas lets you run programs as another user without logging off. 
-* For Device Manager, use cmd.exe /c to avoid the 740 error. 
-* Apps like Chrome can also run with admin privileges via runas. 
+## Summary
+* runas lets you run programs as another user without logging off.
+* For Device Manager, use cmd.exe /c to avoid the 740 error.
+* Apps like Chrome can also run with admin privileges via runas.
 * Avoid storing passwords in scripts. Follow safe operational rules.

--- a/src/posts/20260514-it-professionals-en.md
+++ b/src/posts/20260514-it-professionals-en.md
@@ -25,47 +25,47 @@ tags:
   - DX
 comments: {}
 ---
-At the Heart of a Project That Feels Like Tokyo Station 
-In the world of IT projects, we often find ourselves in the middle of an environment where information, people, resources, and decisions constantly intersect. 
-At times, it feels as if we’re standing at the very center of Tokyo Station—a hub where bullet trains, local lines, subways, and countless passengers from all walks of life converge. 
+At the Heart of a Project That Feels Like Tokyo Station
+In the world of IT projects, we often find ourselves in the middle of an environment where information, people, resources, and decisions constantly intersect.
+At times, it feels as if we’re standing at the very center of Tokyo Station—a hub where bullet trains, local lines, subways, and countless passengers from all walks of life converge.
 Just as station controllers ensure travelers reach their destinations smoothly, IT professionals guide the flow of communication, requirements, and decisions to keep projects moving forward.
 
 <!--more-->
 
-## Coordinating the “Trains” Coming from All Directions 
-Projects involve numerous stakeholders, each with different goals and perspectives—end users, corporate IT, global teams, network and security engineers, facilities, legal, procurement, and finance departments. 
+## Coordinating the “Trains” Coming from All Directions
+Projects involve numerous stakeholders, each with different goals and perspectives—end users, corporate IT, global teams, network and security engineers, facilities, legal, procurement, and finance departments.
 
-IT project managers must collect and reconcile all incoming requirements, resolve potential conflicts, and ensure alignment across all parties. 
+IT project managers must collect and reconcile all incoming requirements, resolve potential conflicts, and ensure alignment across all parties.
 It’s a role not unlike a traffic controller, operating behind the scenes to keep a highly complex system running smoothly and safely.
 
 ## Making Informed Decisions with Data
-In situations where decision-making becomes complex, relying on data helps reduce errors and prevent over-reliance on individual judgment. 
+In situations where decision-making becomes complex, relying on data helps reduce errors and prevent over-reliance on individual judgment.
 
-For example, sizing a UPS (Uninterruptible Power Supply) requires accurate calculations based on the power consumption of connected devices and the desired backup duration during outages. 
-Switch port planning also requires calculating the number of nodes and considering floor layouts. 
-Even Wi-Fi access point placement is refined through on-site site surveys and signal analysis. 
+For example, sizing a UPS (Uninterruptible Power Supply) requires accurate calculations based on the power consumption of connected devices and the desired backup duration during outages.
+Switch port planning also requires calculating the number of nodes and considering floor layouts.
+Even Wi-Fi access point placement is refined through on-site site surveys and signal analysis.
 
 Being able to explain decisions with clear, data-driven logic increases both project speed and credibility.
 
-## Leveraging AI—With Human Oversight 
-AI is increasingly contributing to project acceleration—summarizing requirements, comparing design options, and drafting meeting notes or FAQs. 
+## Leveraging AI—With Human Oversight
+AI is increasingly contributing to project acceleration—summarizing requirements, comparing design options, and drafting meeting notes or FAQs.
 
-Moreover, interacting with AI can help clarify one’s thinking, especially in complex or uncertain situations. 
+Moreover, interacting with AI can help clarify one’s thinking, especially in complex or uncertain situations.
 
-That said, AI is a tool, not a decision-maker. 
-It’s still up to us to interpret context, navigate human relationships, and explain how local user needs can be aligned with global policies—or vice versa. 
-Neglecting this careful, human-centered communication can lead to misunderstandings that escalate into serious issues. 
+That said, AI is a tool, not a decision-maker.
+It’s still up to us to interpret context, navigate human relationships, and explain how local user needs can be aligned with global policies—or vice versa.
+Neglecting this careful, human-centered communication can lead to misunderstandings that escalate into serious issues.
 
-## Follow-up and Empathy: What Truly Moves the Project Forward 
-Technology continues to improve efficiency and speed, but what truly drives a project’s success is still the quality of human communication and trust. 
+## Follow-up and Empathy: What Truly Moves the Project Forward
+Technology continues to improve efficiency and speed, but what truly drives a project’s success is still the quality of human communication and trust.
 
-Whether bridging local users with headquarters, or translating between IT and business teams, IT project managers must take the lead in building mutual understanding and preventing misalignment. 
+Whether bridging local users with headquarters, or translating between IT and business teams, IT project managers must take the lead in building mutual understanding and preventing misalignment.
 
-## In Closing 
-An IT project manager isn’t simply someone with technical knowledge. 
-We are facilitators who translate, coordinate, and adapt. We pause when needed, detour when necessary, and make thoughtful decisions based on both data and dialogue. 
+## In Closing
+An IT project manager isn’t simply someone with technical knowledge.
+We are facilitators who translate, coordinate, and adapt. We pause when needed, detour when necessary, and make thoughtful decisions based on both data and dialogue.
 
-As we continue to integrate tools like AI and embrace data-driven practices, it’s important to remember: 
-At the core of every project are people—and it’s people who make collaboration possible. 
+As we continue to integrate tools like AI and embrace data-driven practices, it’s important to remember:
+At the core of every project are people—and it’s people who make collaboration possible.
 
 Standing at the center of this “Tokyo Station,” we bring structure to the chaos, and move projects forward—one thoughtful interaction at a time.

--- a/src/posts/20260519-comfortable-digital-environment-en.md
+++ b/src/posts/20260519-comfortable-digital-environment-en.md
@@ -25,37 +25,37 @@ tags:
   - WorkspaceImprovement
 comments: {}
 ---
-Since the pandemic, working from home has become the new normal. Without commuting, many people feel they have more time and find it easier to maintain a healthy work-life balance, which can even boost motivation. 
-On the other hand, remote work often brings new challenges: eye strain, shoulder and back pain, lack of focus, and feeling overwhelmed by too much information—what we might call “digital fatigue.” 
-In this article, I’ll share some practical IT-based tips to help you create a comfortable, “fatigue-free” work-from-home environment. 
+Since the pandemic, working from home has become the new normal. Without commuting, many people feel they have more time and find it easier to maintain a healthy work-life balance, which can even boost motivation.
+On the other hand, remote work often brings new challenges: eye strain, shoulder and back pain, lack of focus, and feeling overwhelmed by too much information—what we might call “digital fatigue.”
+In this article, I’ll share some practical IT-based tips to help you create a comfortable, “fatigue-free” work-from-home environment.
 
 <!--more-->
 
-## Optimize Your Screen Setup 
-The position and brightness of your monitor can have a huge impact on your body. Aligning the screen with your eye level helps reduce neck and shoulder strain. 
-If you haven’t yet invested in an external monitor, now is the time to consider it. Working only on a laptop often leads to hunching over, which strains your body. An external monitor naturally improves posture and boosts productivity. 
-For most people, a 24-inch monitor is easy to use, while a 27-inch model is great if you have more desk space and want to view multiple windows side by side. Choosing at least Full HD (1920×1080) resolution makes text clearer and reading easier. 
+## Optimize Your Screen Setup
+The position and brightness of your monitor can have a huge impact on your body. Aligning the screen with your eye level helps reduce neck and shoulder strain.
+If you haven’t yet invested in an external monitor, now is the time to consider it. Working only on a laptop often leads to hunching over, which strains your body. An external monitor naturally improves posture and boosts productivity.
+For most people, a 24-inch monitor is easy to use, while a 27-inch model is great if you have more desk space and want to view multiple windows side by side. Choosing at least Full HD (1920×1080) resolution makes text clearer and reading easier.
 Also, adjusting color temperature and brightness—or enabling features like Night Light or blue-light filters—can help reduce eye strain.
 
-## Improve Your Posture and Workspace 
-Small adjustments to chair and desk height, or choosing the right keyboard and mouse, can significantly reduce fatigue. Ergonomic products are designed to make long hours more comfortable. Don’t forget to optimize lighting and room temperature as well—these also affect your ability to stay focused. 
-Personally, I often switch to a standing position. Even just finding a place at home where I can stand and work helps me feel more focused. It refreshes my mind and feels easier on my body compared to sitting all day. 
-Standing desks have become increasingly popular, with many affordable and adjustable options available. If you’re not ready to invest in one yet, try working in a standing position at home to see how it feels. Even small changes can make a big difference. 
-I’ve also seen people at client offices working while seated on balance balls. I haven’t tried it myself yet, but since I often see it in practice, I imagine it must be effective. It’s something I’d like to test in the future. 
+## Improve Your Posture and Workspace
+Small adjustments to chair and desk height, or choosing the right keyboard and mouse, can significantly reduce fatigue. Ergonomic products are designed to make long hours more comfortable. Don’t forget to optimize lighting and room temperature as well—these also affect your ability to stay focused.
+Personally, I often switch to a standing position. Even just finding a place at home where I can stand and work helps me feel more focused. It refreshes my mind and feels easier on my body compared to sitting all day.
+Standing desks have become increasingly popular, with many affordable and adjustable options available. If you’re not ready to invest in one yet, try working in a standing position at home to see how it feels. Even small changes can make a big difference.
+I’ve also seen people at client offices working while seated on balance balls. I haven’t tried it myself yet, but since I often see it in practice, I imagine it must be effective. It’s something I’d like to test in the future.
 
-## Take Digital Breaks 
-When you’re deeply focused, it’s easy to forget to rest. That’s why it helps to build breaks into your routine. 
-One effective method is **the Pomodoro Technique**—25 minutes of work followed by a 5-minute break. After four cycles, take a longer break of 15–30 minutes. This rhythm alternates short bursts of focus with rest, preventing fatigue from building up. 
+## Take Digital Breaks
+When you’re deeply focused, it’s easy to forget to rest. That’s why it helps to build breaks into your routine.
+One effective method is **the Pomodoro Technique**—25 minutes of work followed by a 5-minute break. After four cycles, take a longer break of 15–30 minutes. This rhythm alternates short bursts of focus with rest, preventing fatigue from building up.
 
-On Windows 11, you can use the built-in Focus Sessions feature to manage Pomodoro-style breaks: 
-1. Open the Start menu, search for Clock, and select Focus Sessions from the left menu. 
-2. Set your desired work session (e.g., 25 minutes). 
-3. Adjust break times in the settings if needed. 
-4. Click Start—the timer will count down, automatically switching between work and break sessions. 
+On Windows 11, you can use the built-in Focus Sessions feature to manage Pomodoro-style breaks:
+1. Open the Start menu, search for Clock, and select Focus Sessions from the left menu.
+2. Set your desired work session (e.g., 25 minutes).
+3. Adjust break times in the settings if needed.
+4. Click Start—the timer will count down, automatically switching between work and break sessions.
 
-While active, Focus Mode blocks notifications so you can concentrate fully. Over time, you can adjust the session length to match your personal rhythm. 
+While active, Focus Mode blocks notifications so you can concentrate fully. Over time, you can adjust the session length to match your personal rhythm.
 
-## Conclusion 
-The key to “fatigue-free” remote work lies in reviewing both your environment and your habits. 
-Even small adjustments—like monitor setup, posture changes, or planned breaks—can make working from home much more comfortable. 
+## Conclusion
+The key to “fatigue-free” remote work lies in reviewing both your environment and your habits.
+Even small adjustments—like monitor setup, posture changes, or planned breaks—can make working from home much more comfortable.
 Start with just one change today, and build a more sustainable and enjoyable work style step by step.

--- a/src/posts/20260519-keyboard-function-keys-en.md
+++ b/src/posts/20260519-keyboard-function-keys-en.md
@@ -25,45 +25,45 @@ tags:
   - JIS layout
 comments: {}
 ---
-The keyboard we use every day without a second thought. While we take typing for granted, haven't you ever wondered, “Why are the keys arranged this way?” or “What are the F1 to F12 keys for?” or “What exactly is the Fn key?”  
-This time, let's explore how the keyboard layout evolved into its current form and delve into the roles of the function keys and the Fn key. 
+The keyboard we use every day without a second thought. While we take typing for granted, haven't you ever wondered, “Why are the keys arranged this way?” or “What are the F1 to F12 keys for?” or “What exactly is the Fn key?”
+This time, let's explore how the keyboard layout evolved into its current form and delve into the roles of the function keys and the Fn key.
 
 <!--more-->
 
 ## The Birth of the QWERTY Layout
-Today, the most widely used keyboard layout in the world is the QWERTY layout. Its name comes from the sequence of the first six letters on the top row of the alphabet keys: Q-W-E-R-T-Y. 
+Today, the most widely used keyboard layout in the world is the QWERTY layout. Its name comes from the sequence of the first six letters on the top row of the alphabet keys: Q-W-E-R-T-Y.
 
-The origins of this layout date back to the 1870s, when Christopher Sholes and his colleagues developed the early typewriter. At that time, mechanical typewriters faced a major challenge: when adjacent keys were pressed quickly in succession, the typebars (the metal arms that struck the characters onto paper) would collide and become jammed. 
+The origins of this layout date back to the 1870s, when Christopher Sholes and his colleagues developed the early typewriter. At that time, mechanical typewriters faced a major challenge: when adjacent keys were pressed quickly in succession, the typebars (the metal arms that struck the characters onto paper) would collide and become jammed.
 
-According to one theory, Sholes addressed this issue by deliberately spacing apart the typebars of commonly used letter combinations (such as “TH” or “HE” in English). This arrangement slowed down typing speed to some extent but helped reduce the risk of typebar collisions and jams. 
+According to one theory, Sholes addressed this issue by deliberately spacing apart the typebars of commonly used letter combinations (such as “TH” or “HE” in English). This arrangement slowed down typing speed to some extent but helped reduce the risk of typebar collisions and jams.
 
 Thus, a layout born as a workaround for the technological limitations of its time has, through social inertia and its status as a de facto standard, continued to dominate the world—even nearly 150 years later in the digital age.
 [※Reference URL: QWERTY layout ](https://ja.wikipedia.org/wiki/QWERTY%E9%85%8D%E5%88%97){target="_blank" rel="noopener"}
 
-## The DVORAK Layout 
-In the 1930s, Dr. August Dvorak focused on the inefficiencies of the QWERTY layout and set out to design a more logical and ergonomic alternative. The DVORAK layout was created with careful consideration of letter frequency in English and human ergonomics. 
+## The DVORAK Layout
+In the 1930s, Dr. August Dvorak focused on the inefficiencies of the QWERTY layout and set out to design a more logical and ergonomic alternative. The DVORAK layout was created with careful consideration of letter frequency in English and human ergonomics.
 
-The key features of the DVORAK layout include: 
-* Placing vowels on the left-hand home row and the most frequently used consonants on the right-hand home row to improve typing rhythm. 
-* Minimizing finger movement to the upper and lower rows, thereby reducing fatigue. 
+The key features of the DVORAK layout include:
+* Placing vowels on the left-hand home row and the most frequently used consonants on the right-hand home row to improve typing rhythm.
+* Minimizing finger movement to the upper and lower rows, thereby reducing fatigue.
 * Increasing the proportion of words that require alternating hands, which helps improve typing speed.
 
-According to Dr. Dvorak’s own studies, the layout offered potential benefits such as greater typing efficiency and reduced fatigue compared to QWERTY. However, due to QWERTY’s dominant market share and users’ familiarity with it, the DVORAK layout never achieved widespread adoption. Today, it is still supported as a standard option on major operating systems and continues to be used by a niche group of efficiency-focused typists and programmers. 
+According to Dr. Dvorak’s own studies, the layout offered potential benefits such as greater typing efficiency and reduced fatigue compared to QWERTY. However, due to QWERTY’s dominant market share and users’ familiarity with it, the DVORAK layout never achieved widespread adoption. Today, it is still supported as a standard option on major operating systems and continues to be used by a niche group of efficiency-focused typists and programmers.
 [※Reference URL:DVORAK Layout](https://ja.wikipedia.org/wiki/Dvorak%E9%85%8D%E5%88%97){target="_blank" rel="noopener"}
 
-## The JIS Layout 
-In Japan, the most widely used keyboard is the JIS layout, which is defined by the Japanese Industrial Standards (JIS). It was specifically designed to improve the efficiency of Japanese text input. 
+## The JIS Layout
+In Japan, the most widely used keyboard is the JIS layout, which is defined by the Japanese Industrial Standards (JIS). It was specifically designed to improve the efficiency of Japanese text input.
 
-The main features of the JIS layout are: 
-* Dedicated keys for Japanese input: including the Hankaku/Zenkaku key (to switch input modes), the Henkan (Convert) and Muhenkan (No Convert) keys for kanji conversion, and a dedicated Katakana/Hiragana key. 
-* Unique Enter key shape: typically a large, vertical style Enter key that makes it easier to press from different hand positions. 
+The main features of the JIS layout are:
+* Dedicated keys for Japanese input: including the Hankaku/Zenkaku key (to switch input modes), the Henkan (Convert) and Muhenkan (No Convert) keys for kanji conversion, and a dedicated Katakana/Hiragana key.
+* Unique Enter key shape: typically a large, vertical style Enter key that makes it easier to press from different hand positions.
 * Different symbol placement: compared to the US layout, the positions and even the types of symbols differ (for example, the position of the “@” key).
-These design choices strongly support the unique process of Japanese text entry, especially kanji conversion in both romaji input and kana input methods. 
+These design choices strongly support the unique process of Japanese text entry, especially kanji conversion in both romaji input and kana input methods.
 
-On the other hand, the internationally common US layout does not include these Japan-specific keys. As a result, it has fewer keys overall, giving it a simpler and cleaner appearance. Its symbol placement is also considered more suitable for programming languages, and the standardized key arrangement appeals to programmers, users who frequently type in English, and PC enthusiasts who prefer a uniform layout. 
+On the other hand, the internationally common US layout does not include these Japan-specific keys. As a result, it has fewer keys overall, giving it a simpler and cleaner appearance. Its symbol placement is also considered more suitable for programming languages, and the standardized key arrangement appeals to programmers, users who frequently type in English, and PC enthusiasts who prefer a uniform layout.
 
-## The Role of Function Keys 
-Function keys are the keys labeled F1 through F12, usually located on the top row of the keyboard. They are used to perform specific functions, either on their own or in combination with other keys. 
+## The Role of Function Keys
+Function keys are the keys labeled F1 through F12, usually located on the top row of the keyboard. They are used to perform specific functions, either on their own or in combination with other keys.
 
 Although the exact roles of these keys may vary depending on the operating system or application, there are some basic functions that are largely standardized, which we will introduce below.
 
@@ -152,23 +152,23 @@ Although the exact roles of these keys may vary depending on the operating syste
   </tbody>
 </table>
 
-## The Functions of the Fn Key 
-On laptops and compact keyboards, you’ll often find the Fn key (short for Function key). This is sometimes called an extended modifier key, and it acts like a “magic key” that allows multiple functions to be assigned to a limited number of keys. 
+## The Functions of the Fn Key
+On laptops and compact keyboards, you’ll often find the Fn key (short for Function key). This is sometimes called an extended modifier key, and it acts like a “magic key” that allows multiple functions to be assigned to a limited number of keys.
 
-Unlike a full-size desktop keyboard, laptops have physical space constraints, which limit the number of keys available. The Fn key solves this by giving a single key two different roles. Like the Shift or Ctrl keys, the Fn key doesn’t work on its own; it must be pressed in combination with another key. 
+Unlike a full-size desktop keyboard, laptops have physical space constraints, which limit the number of keys available. The Fn key solves this by giving a single key two different roles. Like the Shift or Ctrl keys, the Fn key doesn’t work on its own; it must be pressed in combination with another key.
 
-Here are some common Fn key combinations: 
-* Adjusting screen brightness: <kbd>Windows</kbd> + <kbd>F5</kbd> (darker) / <kbd>Windows</kbd> + <kbd>F6</kbd> (brighter) 
-* Controlling volume: <kbd>Windows</kbd> + <kbd>F2</kbd> (volume down) / <kbd>Windows</kbd> + <kbd>F3</kbd> (volume up) / <kbd>Windows</kbd> + <kbd>F1</kbd> (mute toggle) 
-* Switching display output: <kbd>Windows</kbd> + <kbd>F7</kbd> (toggle between laptop screen, external display, or duplicate mode) / <kbd>Windows</kbd> + <kbd>F8</kbd> (projector output, etc.) 
-* Other convenient functions: 
- <kbd>Windows</kbd> + <kbd>Spacebar</kbd> (toggle keyboard backlight on/off) 
+Here are some common Fn key combinations:
+* Adjusting screen brightness: <kbd>Windows</kbd> + <kbd>F5</kbd> (darker) / <kbd>Windows</kbd> + <kbd>F6</kbd> (brighter)
+* Controlling volume: <kbd>Windows</kbd> + <kbd>F2</kbd> (volume down) / <kbd>Windows</kbd> + <kbd>F3</kbd> (volume up) / <kbd>Windows</kbd> + <kbd>F1</kbd> (mute toggle)
+* Switching display output: <kbd>Windows</kbd> + <kbd>F7</kbd> (toggle between laptop screen, external display, or duplicate mode) / <kbd>Windows</kbd> + <kbd>F8</kbd> (projector output, etc.)
+* Other convenient functions:
+ <kbd>Windows</kbd> + <kbd>Spacebar</kbd> (toggle keyboard backlight on/off)
  <kbd>Windows</kbd> + <kbd>F9</kbd> (enable/disable touchpad)
  <kbd>Windows</kbd> + <kbd>Esc</kbd> (Fn lock — on some models, this switches the priority between the F1–F12 keys’ default functions and their extended functions)
-Note: The exact key assignments vary depending on the manufacturer and model. 
+Note: The exact key assignments vary depending on the manufacturer and model.
 
-By mastering these Fn key combinations, you can quickly control essential hardware functions without the need to open complicated settings menus. 
+By mastering these Fn key combinations, you can quickly control essential hardware functions without the need to open complicated settings menus.
 
-## Conclusion 
-Since we use computer keyboards every day, understanding why they are designed the way they are can make them more convenient and efficient to use. The keys you press without thinking, or the functions you see but have never tried, may carry historical reasons or tips for improving your workflow. 
+## Conclusion
+Since we use computer keyboards every day, understanding why they are designed the way they are can make them more convenient and efficient to use. The keys you press without thinking, or the functions you see but have never tried, may carry historical reasons or tips for improving your workflow.
 Take this opportunity to explore and familiarize yourself with the functions of the function keys on your own keyboard—you might discover some useful shortcuts you hadn’t noticed before.

--- a/src/posts/20260522-copilot-pc-performance-en.md
+++ b/src/posts/20260522-copilot-pc-performance-en.md
@@ -21,37 +21,37 @@ tags:
   - PC Performance
 comments: {}
 ---
-More and more people are using MS Copilot as a standard AI assistant tool for Windows PC. However, Copilot itself can sometimes slow down PC performance. Based on actual cases reported to IT help desk, we'll introduce the examples. Please check your company PC as well. 
+More and more people are using MS Copilot as a standard AI assistant tool for Windows PCs. However, Copilot itself can sometimes slow down PC performance. Based on actual cases reported to our IT help desk, we'll share some examples. Please check your company PC as well.
 
 <!--more-->
 
-## Copilot app is running in the background 
-We got an email from a user saying that the PC gradually became sluggish during operation even though there have been no newly installed applications or major updates. When we check the user’s PC when the issue occurred, multiple applications were running, but we found that the Copilot app was significantly consuming memory and CPU resources.
+## Copilot app is running in the background
+We got an email from a user saying that the PC gradually became sluggish during operation even though there have been no newly installed applications or major updates. When we checked the user’s PC when the issue occurred, multiple applications were running, but we found that the Copilot app was significantly consuming memory and CPU resources.
 
-## Turn OFF Copilot to prevent from launching when starting PC 
-To completely close an app, the simple method is to terminate it via Task Manager. However, depending on your environment, Copilot may be on the background app list rather than on the running app list. If so, locating & closing Copilot among numerous background apps is annoying. 
+## Turn OFF Copilot to prevent it from launching when starting your PC
+To completely close an app, the simple method is to terminate it via Task Manager. However, depending on your environment, Copilot may be on the background app list rather than on the running app list. If so, locating & closing Copilot among numerous background apps is annoying.
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of ending the Copilot app from Task Manager" src="/uploads/202603a-copilot-pc-performance-en1.png" width="600px" transform-images="avif webp png jpeg 600@2">
 </figure>
 
-To prevent Copilot from launching automatically, follow these steps:  Remove it from startup apps. 
+To prevent Copilot from launching automatically, follow these steps:  Remove it from startup apps.
 
-Restart your PC to apply changes and refresh the system. 
+Restart your PC to apply changes and refresh the system.
 
-Go to Settings app > Apps > Startup, find Copilot, and if it's turned on, switch it off > Restart your PC 
+Go to Settings app > Apps > Startup, find Copilot, and if it's turned on, switch it off > Restart your PC
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of disabling Copilot from Startup apps" src="/uploads/202603a-copilot-pc-performance-en2end.png" width="700px" transform-images="avif webp png jpeg 700@2">
 </figure>
 
-## Summary 
-This method only prevents the standalone Copilot application from launching. 
+## Summary
+This method only prevents the standalone Copilot application from launching.
 
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of the home page of Copilot" src="/uploads/202603a-copilot-pc-performance-en3.png" width="500px" transform-images="avif webp png jpeg 500@2">
-</figure> 
+</figure>
 
-Copilot within individual applications like Outlook or Word (Copilot add-in) will not be affected by this disabling. You can continue using Copilot within each respective application. 
+Copilot within individual applications like Outlook or Word (Copilot add-in) will not be affected by this disabling. You can continue using Copilot within each respective application.
 
-If you're experiencing performance issue on especially your company PC, it’s worth checking if Copilot is launching automatically and affecting the PC performance.
+If you're experiencing performance issues, especially on your company PC, it’s worth checking if Copilot is launching automatically and affecting the PC performance.

--- a/src/posts/20260526-remove-usb-device-en.md
+++ b/src/posts/20260526-remove-usb-device-en.md
@@ -22,34 +22,34 @@ tags:
   - Data Protection
 comments: {}
 ---
-After using a USB drive, you may wonder: “Can I just pull it out, or do I need to safely eject it?” 
-The answer depends on your system and timing. Here’s quick breakdown of what “**Safely Remove Hardware**” actually means and when it matters.  
+After using a USB drive, you may wonder: “Can I just pull it out, or do I need to safely eject it?”
+The answer depends on your system and timing. Here’s a quick breakdown of what “**Safely Remove Hardware**” actually means and when it matters.
 
 <!--more-->
 
-## What Does “Safely Remove” Really Do? 
-When using external media like USB storage, your computer may appear to finish reading or writhing files instantly. However, behind the scenes, it often continues caching operations in memory. 
+## What Does “Safely Remove” Really Do?
+When using external media like USB storage, your computer may appear to finish reading or writing files instantly. However, behind the scenes, it often continues caching operations in memory.
 
-**What is caching:** 
-* It temporarily stores files operations – like saves and deletions – in system memory. 
-* These are later written to disk in batches, which improves speed but introduces delay. 
+**What is caching:**
+* It temporarily stores file operations – like saves and deletions – in system memory.
+* These are later written to disk in batches, which improves speed but introduces delay.
 * This is especially common during large transfers or bulk edits.
-  
-**What “Safely Remove” actually does:** 
-* It tells the operation system to finish any pending processes. 
-* It confirms with the device that it’s safe to disconnect. 
-* This helps prevent file corruption or removal errors.
-  
-In short, it’s not a power-off switch – it’s a system-level handshake to ensure all data transfers are complete before unplugging. 
 
-## "Safely Remove” is Default in Modern Windows 
-Since Windows10, most USB drives are set to “Quick Removal” mode by default. 
-* This disables write caching. 
-* You can safely remove the USB as long as no file is actively being copied or used. 
-You can check the setting via: 
+**What “Safely Remove” actually does:**
+* It tells the operating system to finish any pending processes.
+* It confirms with the device that it’s safe to disconnect.
+* This helps prevent file corruption or removal errors.
+
+In short, it’s not a power-off switch – it’s a system-level handshake to ensure all data transfers are complete before unplugging.
+
+## "Safely Remove” is Default in Modern Windows
+Since Windows 10, most USB drives are set to “Quick Removal” mode by default.
+* This disables write caching.
+* You can safely remove the USB as long as no file is actively being copied or used.
+You can check the setting via:
     Device manager →USB device →Properties →Policy tab
 
-**When Extra Caution Is Still Recommended** 
+**When Extra Caution Is Still Recommended**
 <table class="not-prose w-full text-sm">
   <thead>
     <tr>
@@ -73,12 +73,12 @@ You can check the setting via:
   </tbody>
 </table>
 
-## Bottom Line: You can remove, but timing is key 
+## Bottom Line: You can remove, but timing is key
 > [!TIP]
-> Standard USB memory → Safe to remove after copying is completed (for Windows 10/11) 
-> External devices, large files, or older OS → “Safely remove” is recommended. 
+> Standard USB memory → Safe to remove after copying is completed (for Windows 10/11)
+> External devices, large files, or older OS → “Safely remove” is recommended.
 > Never unplug during data writing
 
-For most USB devices on modern systems, you don’t need to “Safely remove” every time. 
-But when handling large files, sensitive devices, or high-stakes data, using it is a smart habit. 
+For most USB devices on modern systems, you don’t need to “Safely remove” every time.
+But when handling large files, sensitive devices, or high-stakes data, using it is a smart habit.
 You can prevent unexpected issues where files suddenly won’t open – just by doing that.

--- a/src/posts/20260528-basic-things-to-check-en.md
+++ b/src/posts/20260528-basic-things-to-check-en.md
@@ -10,7 +10,7 @@ last_modified: 2026-07-06 15:06:00
 title: Three Basic Things to Check When an Error Happens.
 description: >-
   A short guide on what to check first when an error happens. It covers message
-  checks, your actions, and basic environment checks. 
+  checks, your actions, and basic environment checks.
 image: /uploads/202603d-basic-things-to-check-en.png
 image_top: /uploads/202603d-basic-things-to-check.png
 author: SK
@@ -22,40 +22,40 @@ tags:
   - ITLiteracy
 comments: {}
 ---
-When an error occurs during daily work, it is easy to repeat actions or react immediately. However, checking a few key points before acting can make a significant difference in how quickly the issue is resolved. 
-This article briefly summarizes three points to check first. 
+When an error occurs during daily work, it is easy to repeat actions or react immediately. However, checking a few key points before acting can make a significant difference in how quickly the issue is resolved.
+This article briefly summarizes three points to check first.
 
 <!--more-->
 
-## What to check when an error occurs 
-When an error appears, it’s tempting to fix it right away. 
-Before acting, pause and check the situation. 
-At this stage, the goal is not to fix it yet -just understand what’s happening. 
-Avoid closing screens or repeating actions until you’ve looked at what’s shown. 
+## What to check when an error occurs
+When an error appears, it’s tempting to fix it right away.
+Before acting, pause and check the situation.
+At this stage, the goal is not to fix it yet -just understand what’s happening.
+Avoid closing screens or repeating actions until you’ve looked at what’s shown.
 
-## Organize the error message and your action 
-First, preserve what’s on the screen. 
-* Exact wording of the error message 
-* Any error code or reference number 
-* Which action immediately preceded the error 
+## Organize the error message and your action
+First, preserve what’s on the screen.
+* Exact wording of the error message
+* Any error code or reference number
+* Which action immediately preceded the error
 
-It’s ok if you don’t understand the meaning -the raw message is a key clue. 
-Take a screenshot or copy the text if possible. 
-No need to guess the cause. Just note “what you tried” and “where it stopped.” 
+It’s ok if you don’t understand the meaning -the raw message is a key clue.
+Take a screenshot or copy the text if possible.
+No need to guess the cause. Just note “what you tried” and “where it stopped.”
 
-## Environment check and basic troubleshooting 
-* Reload the page 
-* Log out and log back in 
-* Restart the app or computer 
-* Try different browsers 
+## Environment check and basic troubleshooting
+* Reload the page
+* Log out and log back in
+* Restart the app or computer
+* Try different browsers
 
-Restarting often helps, but do it after confirming the details, so you can explain the situation later if needed. 
+Restarting often helps, but do it after confirming the details, so you can explain the situation later if needed.
 Also keep a quick note of what you tried -it speeds up support.
 
-## Summary (What do share with support) 
-* Error massage (Screenshot is fine) 
-* The action and timing when it occurred 
-* What you already tried (restart, different browser, etc.) 
+## Summary (What to share with support)
+* Error message (Screenshot is fine)
+* The action and timing when it occurred
+* What you already tried (restart, different browser, etc.)
 
-No deep technical knowledge required. 
+No deep technical knowledge required.
 Clear, organized facts are what make support fast and effective.

--- a/src/posts/20260528-restarting-your-pc-en.md
+++ b/src/posts/20260528-restarting-your-pc-en.md
@@ -11,7 +11,7 @@ title: 'Why Restarting Your PC Fixes Many Problems: A Simple Explanation'
 description: >-
   Why do IT support teams often say “Please restart your computer”? This article
   explains how restarting works, why it fixes many issues, and how it differs
-  from shutting down your PC. 
+  from shutting down your PC.
 image: /uploads/202603b-restarting-pc-en.png
 image_top: /uploads/202603b-restarting-pc.png
 author: KC
@@ -24,56 +24,56 @@ tags:
   - BeginnerFriendly
 comments: {}
 ---
-When your computer starts acting strangely, IT support often gives a very simple suggestion: “Please try restarting your computer.” It might sound too simple to be effective, but in reality, many common PC issues can be resolved with a restart. In this article, we’ll explain why restarting works and how it differs from shutting down your computer. 
+When your computer starts acting strangely, IT support often gives a very simple suggestion: “Please try restarting your computer.” It might sound too simple to be effective, but in reality, many common PC issues can be resolved with a restart. In this article, we’ll explain why restarting works and how it differs from shutting down your computer.
 
 <!--more-->
 
-## Why IT Support Often Recommends Restarting 
-A computer runs many applications and background services at the same time. 
-As you continue using the device, temporary processes and data accumulate. 
-This can sometimes lead to issues such as: 
-* Slow performance 
-* Applications freezing 
-* Unexpected error messages 
+## Why IT Support Often Recommends Restarting
+A computer runs many applications and background services at the same time.
+As you continue using the device, temporary processes and data accumulate.
+This can sometimes lead to issues such as:
+* Slow performance
+* Applications freezing
+* Unexpected error messages
 
-Restarting resets the system environment, which can clear many of these temporary issues. 
+Restarting resets the system environment, which can clear many of these temporary issues.
 
-## Restarting Resets the System 
-Computers use RAM (memory) as a workspace while running applications. 
-After long periods of use, unnecessary data can remain in memory, which may affect system performance. 
-Restarting the computer helps by: 
-* Clearing system memory 
-* Removing temporary data 
-* Reloading the operating system 
+## Restarting Resets the System
+Computers use RAM (memory) as a workspace while running applications.
+After long periods of use, unnecessary data can remain in memory, which may affect system performance.
+Restarting the computer helps by:
+* Clearing system memory
+* Removing temporary data
+* Reloading the operating system
 
-In other words, restarting allows the computer to start fresh. 
+In other words, restarting allows the computer to start fresh.
 
-## Temporary Software Issues Can Be Cleared 
-Modern operating systems and applications perform many tasks simultaneously. 
-Sometimes a small software error can cause problems such as: 
-* Outlook not launching 
-* Microsoft Teams freezing 
-* Files failing to open 
+## Temporary Software Issues Can Be Cleared
+Modern operating systems and applications perform many tasks simultaneously.
+Sometimes a small software error can cause problems such as:
+* Outlook not launching
+* Microsoft Teams freezing
+* Files failing to open
 
-Restarting closes all running processes and reloads the system, which can often clear these temporary issues. 
+Restarting closes all running processes and reloads the system, which can often clear these temporary issues.
 
-## Restart vs Shutdown 
-Restarting and shutting down may seem similar, but they behave slightly differently. 
+## Restart vs Shutdown
+Restarting and shutting down may seem similar, but they behave slightly differently.
 
 * **Restart**
-Turns the computer off and immediately starts it again. 
-* **Shutdown** 
-Completely powers off the computer. 
+Turns the computer off and immediately starts it again.
+* **Shutdown**
+Completely powers off the computer.
 
-In Windows, a feature called Fast Startup may keep part of the system state when shutting down. 
+In Windows, a feature called Fast Startup may keep part of the system state when shutting down.
 Because of this, restarting is sometimes more effective when troubleshooting issues.
 
-## When in Doubt, Restart 
-Restarting is one of the simplest and most effective troubleshooting steps. 
-If you experience problems such as: 
-* Slow performance 
-* Frozen applications 
-* Unexpected errors 
+## When in Doubt, Restart
+Restarting is one of the simplest and most effective troubleshooting steps.
+If you experience problems such as:
+* Slow performance
+* Frozen applications
+* Unexpected errors
 
-Try restarting your computer first. 
+Try restarting your computer first.
 If the problem continues, contacting your IT support team may be the next step.

--- a/src/posts/20260623-what-is-a-server-en.md
+++ b/src/posts/20260623-what-is-a-server-en.md
@@ -10,7 +10,7 @@ last_modified: 2026-06-23T05:20:53.000Z
 title: 'IT Terms You Think You Know: What Is a Server?'
 description: >-
   we’ll give a gentle and beginner-friendly explanation of the term “server,”
-  which you might know the sound of, but not fully understand. 
+  which you might know the sound of, but not fully understand.
 image: /uploads/202508c-what-is-server-en.png
 image_top: /uploads/202508c-what-is-server.png
 author: KC
@@ -25,29 +25,29 @@ A Simple Explanation of a Common IT Term: “Server.” You’ve probably heard 
 
 <!--more-->
 
-## Let’s Start with the Basics: What Is a Server? 
-A **server** is, in short, **a computer that provides services to other devices.** 
-It responds to requests and delivers information or functionality — basically, it plays the role of a “host” that serves others. 
-For example: 
-* Want to view a webpage? → A server sends that page to your device 
-* Want to send an email?  → A server delivers the email to the recipient 
+## Let’s Start with the Basics: What Is a Server?
+A **server** is, in short, **a computer that provides services to other devices.**
+It responds to requests and delivers information or functionality — basically, it plays the role of a “host” that serves others.
+For example:
+* Want to view a webpage? → A server sends that page to your device
+* Want to send an email?  → A server delivers the email to the recipient
 * Want to share a file?　 → A server stores the file and lets others access it
-  
+
 In short, everything from browsing websites to sending emails relies on servers working behind the scenes.
 
-## What’s the Difference Between a Server and a Client? 
-The word “**client**” often comes up alongside “server.” 
-A client is the device that **receives the service**, like your computer or smartphone. 
-For example: 
-* When you search something on Google from your phone → your device is the client 
-* The Google system that returns the search results   → that’s the server 
+## What’s the Difference Between a Server and a Client?
+The word “**client**” often comes up alongside “server.”
+A client is the device that **receives the service**, like your computer or smartphone.
+For example:
+* When you search something on Google from your phone → your device is the client
+* The Google system that returns the search results   → that’s the server
 It’s a “**client makes a request, server responds**” kind of relationship.
 
-## So, Where Are Servers Located? 
-You might have never seen one in person, but servers can be found in many places: 
-* A company’s office server room 
-* Data centers 
-* The cloud (e.g., AWS, Microsoft Azure) 
+## So, Where Are Servers Located?
+You might have never seen one in person, but servers can be found in many places:
+* A company’s office server room
+* Data centers
+* The cloud (e.g., AWS, Microsoft Azure)
 Recently, more companies are moving to **cloud servers**, meaning they don’t need to manage physical machines in-house anymore.
 
 **Examples of Servers You Might Use Without Realizing**
@@ -76,8 +76,8 @@ Recently, more companies are moving to **cloud servers**, meaning they don’t n
 
 In short: if something is quietly **providing something to others**, it’s probably a server!
 
-## Summary 
-A **server** isn’t something overly complicated — it’s just a computer that provides services. 
-Even if you weren’t aware of it before, servers are quietly working as the “unsung heroes” behind the internet and our internal systems. 
-Doesn’t it feel satisfying to finally understand what you kind of already thought you knew? 
+## Summary
+A **server** isn’t something overly complicated — it’s just a computer that provides services.
+Even if you weren’t aware of it before, servers are quietly working as the “unsung heroes” behind the internet and our internal systems.
+Doesn’t it feel satisfying to finally understand what you kind of already thought you knew?
 Take this chance to dive a little deeper into familiar IT terms!

--- a/src/posts/20260629-becoming-a-better-listener-en.md
+++ b/src/posts/20260629-becoming-a-better-listener-en.md
@@ -15,7 +15,7 @@ description: >-
   help IT support professionals resolve issues more quickly. From real-world IT
   support experience, it introduces six key tips for becoming a better listener
   when handling user inquiries. Recommended for new help desk staff and in-house
-  IT professionals. 
+  IT professionals.
 image: /uploads/202603e-better-listener-en.png
 image_top: /uploads/202603e-better-listener.png
 author: Shiori
@@ -26,73 +26,73 @@ tags:
   - IT Support
 comments: {}
 ---
-“I can't use my computer.” “My PC is very slow.” “Something just feels wrong.” If you work in IT support, you probably hear vague requests like these quite often. 
-However, once you start asking a few questions, the issue often turns out to be something simple. In many cases, it wouldn’t be an exaggeration to say that 80% of troubleshooting depends on proper questioning and listening. In this article, I’ll introduce practical techniques I personally use in the field to become a better listener and handle IT support inquiries more effectively. 
+“I can't use my computer.” “My PC is very slow.” “Something just feels wrong.” If you work in IT support, you probably hear vague requests like these quite often.
+However, once you start asking a few questions, the issue often turns out to be something simple. In many cases, it wouldn’t be an exaggeration to say that 80% of troubleshooting depends on proper questioning and listening. In this article, I’ll introduce practical techniques I personally use in the field to become a better listener and handle IT support inquiries more effectively.
 
 <!--more-->
 
-## Why Listening Skills Matter in IT Support 
-When users encounter technical problems, they often feel stressed or anxious. 
-When contacting IT, they may not know which information is important, or they might struggle to explain the situation clearly. 
-And that’s perfectly natural. This is where IT support professionals come in. 
+## Why Listening Skills Matter in IT Support
+When users encounter technical problems, they often feel stressed or anxious.
+When contacting IT, they may not know which information is important, or they might struggle to explain the situation clearly.
+And that’s perfectly natural. This is where IT support professionals come in.
 By carefully listening, organizing the information, and aligning our understanding with the user, we can dramatically speed up the troubleshooting process.
 
-## Six Tips to Resolve Issues Faster 
-### 1.Don’t Jump to a Solution Too Quickly 
-When users sound stressed, it’s easy to feel pressured to provide an immediate fix. 
-However, trying random solutions too quickly can lead to misidentifying the root cause and ultimately wasting more time. 
-Instead, take a moment to understand the situation first. A calm and structured approach often leads to faster resolution. In many IT environments, users also approach support staff directly. 
-If you're in the middle of another task, it’s easy to listen only halfway. But from the user’s perspective, feeling heard is very important. Simply pausing your work, facing the user, and making eye contact can significantly increase their sense of reassurance. 
-Many companies rely on ticket systems for support requests. But if someone comes to you directly, they’re probably feeling quite urgent or stressed. Start by listening carefully. 
-That is the first step in resolving the issue. 
+## Six Tips to Resolve Issues Faster
+### 1. Don’t Jump to a Solution Too Quickly
+When users sound stressed, it’s easy to feel pressured to provide an immediate fix.
+However, trying random solutions too quickly can lead to misidentifying the root cause and ultimately wasting more time.
+Instead, take a moment to understand the situation first. A calm and structured approach often leads to faster resolution. In many IT environments, users also approach support staff directly.
+If you're in the middle of another task, it’s easy to listen only halfway. But from the user’s perspective, feeling heard is very important. Simply pausing your work, facing the user, and making eye contact can significantly increase their sense of reassurance.
+Many companies rely on ticket systems for support requests. But if someone comes to you directly, they’re probably feeling quite urgent or stressed. Start by listening carefully.
+That is the first step in resolving the issue.
 
-### 2.Ask What the User Has Already Tried 
-A common exchange in IT support looks like this: 
-“Please try this step.” 
-“I already tried that.” 
-These kinds of back-and-forth conversations slow everything down. 
-To avoid this, start by asking: 
-“Have you already tried anything to fix it?” 
+### 2. Ask What the User Has Already Tried
+A common exchange in IT support looks like this:
+“Please try this step.”
+“I already tried that.”
+These kinds of back-and-forth conversations slow everything down.
+To avoid this, start by asking:
+“Have you already tried anything to fix it?”
 Understanding what the user has already attempted makes troubleshooting much smoother.
 
-### 3.Look for Recent Changes 
-Many technical problems are triggered by some kind of change. 
-For example: 
-* It started this morning 
-* After replacing the PC 
-* After network maintenance 
-* After a Windows update 
+### 3. Look for Recent Changes
+Many technical problems are triggered by some kind of change.
+For example:
+* It started this morning
+* After replacing the PC
+* After network maintenance
+* After a Windows update
 
-Identifying recent changes helps narrow down the possible causes. 
+Identifying recent changes helps narrow down the possible causes.
 
-### 4.Understand the User’s Real Goal 
-For example, when someone says “I can't print,” their real goal might actually be: 
-“I need to send this document today.” 
-Once you understand the goal, you can suggest alternative solutions: 
-* Use a different printer 
-* Ask a team member to print it 
-* Send the document as a PDF instead 
+### 4. Understand the User’s Real Goal
+For example, when someone says “I can't print,” their real goal might actually be:
+“I need to send this document today.”
+Once you understand the goal, you can suggest alternative solutions:
+* Use a different printer
+* Ask a team member to print it
+* Send the document as a PDF instead
 
-When the objective is clear, the solution doesn’t have to be limited to fixing the device. 
+When the objective is clear, the solution doesn’t have to be limited to fixing the device.
 
 > [!NOTE]
 > Providing options that keep the user’s work moving is also an important part of IT support.
 
-### 5.Gather the Facts 
-When troubleshooting, start by collecting clear facts: 
-What does the error message say? 
-What action triggers the issue? 
-Does it happen every time? 
-Confirming these details one by one helps narrow down the cause. 
-Sometimes, a simple screenshot provides more accurate information than a verbal explanation. I usually ask users to attach one whenever possible. 
+### 5. Gather the Facts
+When troubleshooting, start by collecting clear facts:
+What does the error message say?
+What action triggers the issue?
+Does it happen every time?
+Confirming these details one by one helps narrow down the cause.
+Sometimes, a simple screenshot provides more accurate information than a verbal explanation. I usually ask users to attach one whenever possible.
 
-### 6.Confirm Your Understanding 
-At the end of the conversation, briefly summarize the situation. 
-This helps ensure both you and the user share the same understanding. 
-When expectations are aligned, the next steps become much easier. 
-It’s also helpful to explain what you will do next and how the issue will be handled. This reassures users and builds trust. 
+### 6. Confirm Your Understanding
+At the end of the conversation, briefly summarize the situation.
+This helps ensure both you and the user share the same understanding.
+When expectations are aligned, the next steps become much easier.
+It’s also helpful to explain what you will do next and how the issue will be handled. This reassures users and builds trust.
 
-## Summary 
-In IT troubleshooting, technical knowledge is important—but listening skills are just as essential. 
-By carefully organizing the situation and extracting the right information, issues can often be resolved much faster. 
+## Summary
+In IT troubleshooting, technical knowledge is important—but listening skills are just as essential.
+By carefully organizing the situation and extracting the right information, issues can often be resolved much faster.
 Try applying these tips in your daily IT support work.

--- a/src/posts/20260630-automatically-power-on-a-pc-en.md
+++ b/src/posts/20260630-automatically-power-on-a-pc-en.md
@@ -13,7 +13,7 @@ title: >-
 description: >-
   Learn how to configure Dell Optiplex BIOS settings so that your PC
   automatically powers on after power loss or updates. Includes a real-world
-  case using a warehouse PC as an SCCM distribution point. 
+  case using a warehouse PC as an SCCM distribution point.
 image: /uploads/202508d-power-on-pc-en.png
 image_top: /uploads/202508d-power-on-pc.png
 author: Kabaya
@@ -29,15 +29,15 @@ tags:
   - PowerSettings
 comments: {}
 ---
-In business environments, it's not uncommon to run into situations where a PC doesn't automatically restart after a Windows update, or remains powered off after a power outage. 
-This can become a real problem, especially for PCs used for remote access or unattended operations like surveillance or server-related tasks. 
-In this article, we’ll walk you through how to configure the BIOS setting on Dell Optiplex PCs (e.g., 7060) so that the system will automatically power on after power is restored. 
+In business environments, it's not uncommon to run into situations where a PC doesn't automatically restart after a Windows update, or remains powered off after a power outage.
+This can become a real problem, especially for PCs used for remote access or unattended operations like surveillance or server-related tasks.
+In this article, we’ll walk you through how to configure the BIOS setting on Dell Optiplex PCs (e.g., 7060) so that the system will automatically power on after power is restored.
 
 <!--more-->
 
 ## When This Setting is Useful
-* After a Windows update, you want the PC to restart automatically 
-* When the power cable is accidentally unplugged or there's a power cut 
+* After a Windows update, you want the PC to restart automatically
+* When the power cable is accidentally unplugged or there's a power cut
 * For systems that should always stay on or boot before office hours
 
 ## BIOS Feature: Auto Power On
@@ -66,26 +66,26 @@ Many Dell systems provide several power-related BIOS settings. Here are the key 
   </tbody>
 </table>
 
-In this article, we'll focus on **AC Recovery**. 
+In this article, we'll focus on **AC Recovery**.
 
 ## How to Configure AC Recovery (Dell Optiplex 7060)
-1. Turn on the PC and press <kbd>F2</kbd> repeatedly to enter the BIOS Setup 
-2. Go to 
-　[Power Management] > [AC Recovery] 
-3. Change the setting to: 
-　[Power On] 
-　(The default is usually [Off]) 
+1. Turn on the PC and press <kbd>F2</kbd> repeatedly to enter the BIOS Setup
+2. Go to
+　[Power Management] > [AC Recovery]
+3. Change the setting to:
+　[Power On]
+　(The default is usually [Off])
 4. Click [Apply] to save, then [Exit] to reboot
 
 ## Related Settings (Optional)
-* **Auto On Time**: Useful if you want the PC to power on at a fixed time (e.g., 9:00 AM) 
+* **Auto On Time**: Useful if you want the PC to power on at a fixed time (e.g., 9:00 AM)
 * **Wake on LAN**: Use this if you want to boot the PC via network commands
 
-## Real-World Example 
-At one client site, a desktop PC placed in a warehouse was being used as an SCCM Distribution Point server. 
-However, the PC often powered off unexpectedly due to various reasons, and each time the warehouse staff had to manually turn it back on. 
-After enabling the AC Recovery setting, the PC now automatically powers back on after power is restored—whether it’s due to a power outage, updates, or the power strip being switched off. 
-This eliminated the need for manual intervention by on-site staff. 
+## Real-World Example
+At one client site, a desktop PC placed in a warehouse was being used as an SCCM Distribution Point server.
+However, the PC often powered off unexpectedly due to various reasons, and each time the warehouse staff had to manually turn it back on.
+After enabling the AC Recovery setting, the PC now automatically powers back on after power is restored—whether it’s due to a power outage, updates, or the power strip being switched off.
+This eliminated the need for manual intervention by on-site staff.
 
 ## Summary
 <table class="not-prose w-full text-sm">
@@ -105,6 +105,6 @@ This eliminated the need for manual intervention by on-site staff.
   </tbody>
 </table>
 
-This small but powerful BIOS setting can save time, reduce manual effort, and help maintain system uptime—especially for systems that should stay available at all times. 
+This small but powerful BIOS setting can save time, reduce manual effort, and help maintain system uptime—especially for systems that should stay available at all times.
 
 Make sure to check and configure this on any critical PC you manage.

--- a/src/posts/20260706-small-office-network-infrastructure-en.md
+++ b/src/posts/20260706-small-office-network-infrastructure-en.md
@@ -13,7 +13,7 @@ title: >-
 description: >-
   Learn how to understand a small office network even without a network diagram.
   This article explains practical steps for reviewing network infrastructure and
-  assessing the impact of changes such as migrating from PPPoE to IPoE. 
+  assessing the impact of changes such as migrating from PPPoE to IPoE.
 image: /uploads/202603f-small-office-infra-en.png
 image_top: /uploads/202603f-small-office-infra.png
 author: Kabaya
@@ -28,67 +28,67 @@ tags:
   - ITSupport
 comments: {}
 ---
-"We may want to change our Internet connection from PPPoE to IPoE." 
-This was a request I recently received. 
-Although I was familiar with the terms PPPoE and IPoE, I realized I needed to better understand what would actually change and how the existing network environment might be affected. 
-As I investigated the environment, one thing became clear: having a good understanding of your network topology makes it much easier to assess the impact of any infrastructure changes. 
-In this article, I'd like to share the approach I took to understand a small office network, even without a complete network diagram. 
+"We may want to change our Internet connection from PPPoE to IPoE."
+This was a request I recently received.
+Although I was familiar with the terms PPPoE and IPoE, I realized I needed to better understand what would actually change and how the existing network environment might be affected.
+As I investigated the environment, one thing became clear: having a good understanding of your network topology makes it much easier to assess the impact of any infrastructure changes.
+In this article, I'd like to share the approach I took to understand a small office network, even without a complete network diagram.
 
 <!--more-->
 
-## Why Understanding Your Network Matters 
-When everything is working normally, it's easy to overlook how the network is actually built. 
-However, things change when you need to modify the environment—whether it's changing the Internet connection, replacing hardware, or introducing new equipment. 
-In my case, the request to migrate from PPPoE to IPoE raised several questions: 
-* Would the VPN connection still work? 
-* Would the static IP address change? 
-* Would any network devices require configuration changes? 
+## Why Understanding Your Network Matters
+When everything is working normally, it's easy to overlook how the network is actually built.
+However, things change when you need to modify the environment—whether it's changing the Internet connection, replacing hardware, or introducing new equipment.
+In my case, the request to migrate from PPPoE to IPoE raised several questions:
+* Would the VPN connection still work?
+* Would the static IP address change?
+* Would any network devices require configuration changes?
 
-The more I investigated, the more I realized that even a seemingly simple change could have a broader impact than expected. 
-Without a clear understanding of the existing network, it's difficult to accurately evaluate those risks. 
-As part of my regular monthly maintenance, I already check the health of servers and network devices. However, this request encouraged me to revisit the environment from a different perspective by asking questions such as: 
-* What is the purpose of this configuration? 
+The more I investigated, the more I realized that even a seemingly simple change could have a broader impact than expected.
+Without a clear understanding of the existing network, it's difficult to accurately evaluate those risks.
+As part of my regular monthly maintenance, I already check the health of servers and network devices. However, this request encouraged me to revisit the environment from a different perspective by asking questions such as:
+* What is the purpose of this configuration?
 * What role does each device play within the overall network?
 
-By reviewing each component one by one, I gained a much clearer understanding of not only each device's role, but also how they work together and what could be affected by future changes. 
+By reviewing each component one by one, I gained a much clearer understanding of not only each device's role, but also how they work together and what could be affected by future changes.
 
-## Key Points When Reviewing a Network 
-### 1. Review Existing Documentation 
-Start by checking any available documentation, handover notes, or network records. 
-Documentation provides a useful starting point, but it doesn't always reflect the current environment. It's important to compare the documents with the actual infrastructure. 
+## Key Points When Reviewing a Network
+### 1. Review Existing Documentation
+Start by checking any available documentation, handover notes, or network records.
+Documentation provides a useful starting point, but it doesn't always reflect the current environment. It's important to compare the documents with the actual infrastructure.
 
-### 2. Verify the Physical Network Devices 
-Next, inspect the network devices themselves. 
+### 2. Verify the Physical Network Devices
+Next, inspect the network devices themselves.
 Understanding the purpose of each component—such as the firewall, switches, and servers—helps build a clearer picture of how the network is designed.
 
-Reviewing the management interface also helped confirm that: 
-* The office was currently using a PPPoE Internet connection. 
-* VPN services were being provided through the firewall. 
+Reviewing the management interface also helped confirm that:
+* The office was currently using a PPPoE Internet connection.
+* VPN services were being provided through the firewall.
 
-At this stage, it became clear that changing the Internet connection could also affect VPN connectivity and the static IP configuration. 
+At this stage, it became clear that changing the Internet connection could also affect VPN connectivity and the static IP configuration.
 
-### 3. Focus on Both Roles and Relationships 
-One of the biggest lessons I learned was that a single infrastructure change can have a wider impact than expected. 
-At first glance, switching from PPPoE to IPoE seems like an Internet connectivity upgrade. 
-In reality, however, related services such as VPN access, static IP addresses, and firewall settings may also need to be reviewed. 
-Rather than looking at the Internet connection, firewall, VPN, and servers individually, it's far more useful to understand how they work together as one network. 
+### 3. Focus on Both Roles and Relationships
+One of the biggest lessons I learned was that a single infrastructure change can have a wider impact than expected.
+At first glance, switching from PPPoE to IPoE seems like an Internet connectivity upgrade.
+In reality, however, related services such as VPN access, static IP addresses, and firewall settings may also need to be reviewed.
+Rather than looking at the Internet connection, firewall, VPN, and servers individually, it's far more useful to understand how they work together as one network.
 
-### 4. Create a Simple Network Diagram 
+### 4. Create a Simple Network Diagram
 <figure class="flex flex-col justify-start items-left">
   <img alt="Screenshot of a network diagram sample" src="/uploads/202603f-small-office-infra-diagram.png" width="700px" transform-images="avif webp png jpeg 700@2">
 </figure>
 
-Even if no official network diagram exists, creating a simple sketch can be extremely helpful. 
-A basic diagram showing device connections and responsibilities makes it much easier to understand: 
-* Where the Internet connection terminates 
-* Which device controls network traffic 
-* Which systems provide authentication or network services 
+Even if no official network diagram exists, creating a simple sketch can be extremely helpful.
+A basic diagram showing device connections and responsibilities makes it much easier to understand:
+* Where the Internet connection terminates
+* Which device controls network traffic
+* Which systems provide authentication or network services
 
-It also becomes valuable documentation for future troubleshooting, maintenance, and infrastructure upgrades. 
+It also becomes valuable documentation for future troubleshooting, maintenance, and infrastructure upgrades.
 
-## Conclusion 
-Understanding a network isn't simply about memorizing technical terms. 
-More importantly, it's about understanding what each device is responsible for and how everything connects together. 
-Even without a complete network diagram, reviewing existing documentation alongside the actual devices can gradually reveal the overall network architecture. 
-Whenever changes such as Internet upgrades or hardware replacements are planned, having that understanding allows you to assess the impact more confidently and reduce the risk of unexpected issues. 
+## Conclusion
+Understanding a network isn't simply about memorizing technical terms.
+More importantly, it's about understanding what each device is responsible for and how everything connects together.
+Even without a complete network diagram, reviewing existing documentation alongside the actual devices can gradually reveal the overall network architecture.
+Whenever changes such as Internet upgrades or hardware replacements are planned, having that understanding allows you to assess the impact more confidently and reduce the risk of unexpected issues.
 Taking the time to visualize and document your network today can save significant time and effort when changes are needed in the future.

--- a/src/posts/20260707-pdfs-with-adobe-scan-en.md
+++ b/src/posts/20260707-pdfs-with-adobe-scan-en.md
@@ -11,7 +11,7 @@ title: 'Quickly turn your documents into clean, high-quality PDFs with Adobe Sca
 description: >-
   An introduction about “Adobe Scan”, a mobile application that enables you to
   scan and convert documents into PDFs without the need for a multifunction
-  printer. 
+  printer.
 image: /uploads/202603c-adobe-scan-en.png
 image_top: /uploads/202603c-adobe-scan.png
 author: YM
@@ -25,37 +25,37 @@ tags:
   - WorkSmarter
 comments: {}
 ---
-Have you ever wanted to quickly convert documents into PDFs when you don’t have access to a multifunction printer, or when you can’t use one right away? Of course, taking a photo of the document with your smartphone is one option, but shadows, camera shake, and uneven image quality can often make the result less than ideal. I’ve experienced that myself. 
-That’s where the app [Adobe Scan](https://www.adobe.com/jp/acrobat/mobile/scanner-app.html){target="_blank" rel="noopener"} comes in handy for easily creating PDFs. 
-I personally use it privately when I find it a bit inconvenient to start up a PC and scan documents. I also use it at work in situations where I can’t access a multifunction printer or when I want to save time by avoiding a trip to the copier. 
+Have you ever wanted to quickly convert documents into PDFs when you don’t have access to a multifunction printer, or when you can’t use one right away? Of course, taking a photo of the document with your smartphone is one option, but shadows, camera shake, and uneven image quality can often make the result less than ideal. I’ve experienced that myself.
+That’s where the app [Adobe Scan](https://www.adobe.com/jp/acrobat/mobile/scanner-app.html){target="_blank" rel="noopener"} comes in handy for easily creating PDFs.
+I personally use it privately when I find it a bit inconvenient to start up a PC and scan documents. I also use it at work in situations where I can’t access a multifunction printer or when I want to save time by avoiding a trip to the copier.
 
 <!--more-->
 
-## Features of Adobe Scan 
-Adobe Scan is an application that uses your smartphone’s camera to read documents, automatically correct them, and convert them into PDF files. It is not merely an app for taking photos; it is designed with document management in mind, which is one of its key features. 
+## Features of Adobe Scan
+Adobe Scan is an application that uses your smartphone’s camera to read documents, automatically correct them, and convert them into PDF files. It is not merely an app for taking photos; it is designed with document management in mind, which is one of its key features.
 
 The main functions include:
-* Automatic document detection and correction 
-* Saving documents in PDF format 
-* OCR (optical character recognition) 
+* Automatic document detection and correction
+* Saving documents in PDF format
+* OCR (optical character recognition)
 * Integration with Adobe Acrobat
-  
+
 > [!CAUTION]
 > Basic scanning, OCR, and PDF conversion are available for free. However, functions such as merging PDFs, password protection, and exporting files (for example, converting to Word or Excel formats) require an Adobe Acrobat subscription.
 
-## Difference from taking a photo 
+## Difference from taking a photo
 1. **Stable readability**
-* Photos: The readability of a document depends on shooting conditions. Depending on the angle or lighting, text may become difficult to read or shadows may appear. 
+* Photos: The readability of a document depends on shooting conditions. Depending on the angle or lighting, text may become difficult to read or shadows may appear.
 * Adobe Scan: The app automatically detects document edges and corrects skew and distortion. It also cleans up the background, enabling document data with consistent readability regardless of who scans it.
 
 2. **Differences in searchability**
-* Photos: Images are treated as picture data, so you cannot search for text later. You must rely on file names or storage locations to find documents. 
+* Photos: Images are treated as picture data, so you cannot search for text later. You must rely on file names or storage locations to find documents.
 * Adobe Scan: PDFs created with Adobe Scan support OCR (optical character recognition), allowing text within the document to be recognized and searched. This makes it possible to search for words and numbers inside the file.
 
-## How to use Adobe Scan 
-The basic usage of Adobe Scan is very simple. 
-1. Install Adobe Scan on your smartphone and launch the app. 
-2. Use the camera to scan the document. You can select the shooting mode from the bottom of the capture screen according to the item you want to scan. 
+## How to use Adobe Scan
+The basic usage of Adobe Scan is very simple.
+1. Install Adobe Scan on your smartphone and launch the app.
+2. Use the camera to scan the document. You can select the shooting mode from the bottom of the capture screen according to the item you want to scan.
 
 For example, in “Book” mode, the app automatically detects the center binding (gutter) of a book and splits a two-page spread into separate pages when converting it into a PDF.
 
@@ -86,7 +86,7 @@ For example, in “Book” mode, the app automatically detects the center bindin
 > [!CAUTION]
 > The features marked with a ★ are premium features available in the paid version.
 
-## Conclusion 
-If your only goal is simply to “keep a record” or “send it to someone”, taking a photo may be sufficient. However, if you want to organize it later, convert it into a clean PDF, or avoid issues such as shadows in the image, using a PDF scanning app is more suitable. 
+## Conclusion
+If your only goal is simply to “keep a record” or “send it to someone”, taking a photo may be sufficient. However, if you want to organize it later, convert it into a clean PDF, or avoid issues such as shadows in the image, using a PDF scanning app is more suitable.
 
-The PDF-specialized app Adobe Scan is free to use and requires no special setup. If you haven’t tried If you haven't used it yet, I highly recommend giving it a try.
+The PDF-specialized app Adobe Scan is free to use and requires no special setup. If you haven't used it yet, I highly recommend giving it a try.

--- a/src/posts/2026406-using-onedrive-en.md
+++ b/src/posts/2026406-using-onedrive-en.md
@@ -23,8 +23,8 @@ tags:
   - DigitalTools
 comments: {}
 ---
-Many people use Microsoft's cloud storage service "**OneDrive**". It's convenient not only as a backup storage for your data, but also as a function for sharing data with others using. In this article, we'll show you how to share data with OneDrive. 
-*Some companies have rules that prohibit sharing with external parties. Please check beforehand. 
+Many people use Microsoft's cloud storage service "**OneDrive**". It's convenient not only as a backup storage for your data, but also as a function for sharing data with others. In this article, we'll show you how to share data with OneDrive.
+*Some companies have rules that prohibit sharing with external parties. Please check beforehand.
 
 <!--more-->
 
@@ -59,17 +59,17 @@ Microsoft will send you a verification code via email to your address. Check you
 
 Once you enter the correct verification code, you will be able to access and view the shared data.
 
-## Advantages of OneDrive 
+## Advantages of OneDrive
 * **You can send large data**
   OneDrive supports up to 250GB. (As of 2025)
-* **You can set permissions** 
+* **You can set permissions**
   You can select how you want others to handle the shared data such as view-only or editable.
-* **No risk of data loss or stolen** 
-  Since it does not use physical media such as USB sticks, there is no risk of physical leakage. It is sent as electronic data to only to the recipient over the Internet, so the data cannot be physically stolen by others.
+* **No risk of data loss or theft**
+  Since it does not use physical media such as USB sticks, there is no risk of physical leakage. It is sent as electronic data only to the recipient over the Internet, so the data cannot be physically stolen by others.
 
 ## Disadvantages of OneDrive
 - **Internet connection required**
-  Unlike sharing data via USB, both ends need the Internet connection.
+  Unlike sharing data via USB, both ends need an Internet connection.
 - **Both require a Microsoft account**
   In order to use OneDrive, both ends must have a Microsoft account.
 


### PR DESCRIPTION
A light-touch copyedit across the **40 English blog posts** (written by Japanese authors, often AI-translated). Deliberately conservative — spelling, grammar, obvious awkward phrasing, and formatting only. **No restructuring, no meaning or voice changes, no frontmatter values touched, Japanese posts untouched.**

### What changed
- **Spelling/typos:** writhing→writing, operation system→operating system, Chrom→Chrome, Uses→Users, massage→message, Shit→Shift, foldfers→folders, custum→custom, colum→column, pearson→person, of date→of data, and similar.
- **Grammar:** missing articles (a/an/the), subject–verb agreement, prepositions ("in this site"→"on this site"), plurals, verb tense, a few missing terminal periods.
- **Clear content bugs:** duplicated "Acrobat Pro and Acrobat Pro" → "Acrobat Standard and Acrobat Pro"; duplicated fragment "If you haven't tried If you haven't used it"; a shortcut cell "Win + Win + S" → "Win + Shift + S"; closed dangling quotes; removed a stray 1×1 transparent placeholder image (alt text "図形").
- **Formatting:** trailing-whitespace cleanup (this addresses the "too many page breaks" note — stray Markdown hard breaks).

### Process
Reviewed via 6 parallel copyeditors with strict light-touch rules, then the **full prose diff was vetted by hand** (whitespace-ignored) to confirm no over-editing, plus a consolidation pass for reader-visible typos the editors correctly left inside table/kbd markup.

Frontmatter values, HTML/table structure, links, code, `<kbd>`, and image references are untouched (only trailing spaces on a couple of `tags:`/`oldUrl:` keys were normalized — YAML-equivalent).

Quality: readability/spelling per writing standards; no functional change.